### PR TITLE
improved callgraph

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -578,8 +578,7 @@ function getContractsToAnalyze(
     // A contract is a proxy if proxyType is not "immutable" and not "EOA"
     const isProxy =
       proxyType !== undefined &&
-      proxyType !== 'immutable' &&
-      proxyType !== 'EOA'
+      proxyType !== 'immutable'
 
     if (isProxy) {
       // Get implementation address from values.$implementation

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -568,12 +568,8 @@ function getContractsToAnalyze(
     if (externalAddresses.has(normalizedAddress)) continue
 
     const displayName = entry.name || 'Unknown'
-    const implNames = (
-      'implementationNames' in entry ? entry.implementationNames : undefined
-    ) as Record<string, string> | undefined
-    const proxyType = ('proxyType' in entry ? entry.proxyType : undefined) as
-      | string
-      | undefined
+    const implNames = entry.implementationNames
+    const proxyType = entry.proxyType
 
     // A contract is a proxy if proxyType is not "immutable" and not "EOA"
     const isProxy =
@@ -582,14 +578,12 @@ function getContractsToAnalyze(
 
     if (isProxy) {
       // Get implementation address from values.$implementation
-      const implValue =
-        'values' in entry && entry.values
-          ? (entry.values as Record<string, unknown>).$implementation
-          : undefined
+      const implValue = entry.values?.$implementation
 
       if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
         // Proxy contract — analyze the implementation
-        const implName = implNames?.[implValue] ?? displayName
+        const implAddress = implValue as typeof entry.address
+        const implName = implNames?.[implAddress] ?? displayName
         contracts.push({
           entryAddress: entry.address,
           slitherAddress: implValue,

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -572,9 +572,7 @@ function getContractsToAnalyze(
     const proxyType = entry.proxyType
 
     // A contract is a proxy if proxyType is not "immutable" and not "EOA"
-    const isProxy =
-      proxyType !== undefined &&
-      proxyType !== 'immutable'
+    const isProxy = proxyType !== undefined && proxyType !== 'immutable'
 
     if (isProxy) {
       // Get implementation address from values.$implementation

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -150,7 +150,12 @@ export async function generateCallGraph(
   const discovered = configReader.readDiscovery(project)
 
   // Get contracts to analyze (non-external only)
-  const contracts = getContractsToAnalyze(paths, discovered, project)
+  const contracts = getContractsToAnalyze(
+    paths,
+    discovered,
+    project,
+    onProgress,
+  )
 
   onProgress?.(`Found ${contracts.length} non-external contracts to analyze`)
 
@@ -177,10 +182,11 @@ export async function generateCallGraph(
 
     // Check cache first
     // Cache key uses slitherAddress (implementation for proxies) since that's what Slither runs on
-    // Source hash uses entryAddress (proxy) since sourceHashes covers both proxy + implementation
+    // Source hash uses slitherAddress to avoid cache thrashing when two proxies share an implementation
     const currentSourceHash = getContractSourceHash(
       discovered,
       contract.entryAddress,
+      contract.slitherAddress,
     )
     const cachedEntry = getSlithirCache(paths, project, contract.slitherAddress)
 
@@ -509,23 +515,26 @@ function saveSlithirCache(
 
 function getContractSourceHash(
   discovered: DiscoveryOutput,
-  address: string,
+  entryAddress: string,
+  slitherAddress: string,
 ): string | undefined {
   const entry = discovered.entries.find(
-    (e) => e.address.toLowerCase() === address.toLowerCase(),
+    (e) => e.address.toLowerCase() === entryAddress.toLowerCase(),
   )
 
-  if (!entry || !('sourceHashes' in entry)) {
+  if (!entry?.sourceHashes || entry.sourceHashes.length === 0) {
     return undefined
   }
 
-  const sourceHashes = (entry as { sourceHashes?: string[] }).sourceHashes
-  if (!sourceHashes || sourceHashes.length === 0) {
-    return undefined
+  // For proxies (entryAddress !== slitherAddress), use only the implementation hash
+  // to avoid cache thrashing when two proxies share one implementation.
+  // sourceHashes order: [proxy, implementation] — last element is the implementation.
+  if (entryAddress.toLowerCase() !== slitherAddress.toLowerCase()) {
+    return entry.sourceHashes[entry.sourceHashes.length - 1]
   }
 
-  // Combine all source hashes into one (handles proxy + implementation)
-  return sourceHashes.join(':')
+  // Regular contract — single source hash
+  return entry.sourceHashes[0]
 }
 
 // =============================================================================
@@ -549,6 +558,7 @@ function getContractsToAnalyze(
   paths: DiscoveryPaths,
   discovered: DiscoveryOutput,
   project: string,
+  onProgress?: (message: string) => void,
 ): ContractToAnalyze[] {
   // Load contract tags to identify external contracts
   const tags = getContractTags(paths, project)
@@ -571,7 +581,7 @@ function getContractsToAnalyze(
     const implNames = entry.implementationNames
     const proxyType = entry.proxyType
 
-    // A contract is a proxy if proxyType is not "immutable" and not "EOA"
+    // A contract is a proxy if proxyType is not "immutable"
     const isProxy = proxyType !== undefined && proxyType !== 'immutable'
 
     if (isProxy) {
@@ -590,7 +600,10 @@ function getContractsToAnalyze(
           displayName,
         })
       } else {
-        // Proxy but no valid $implementation — log warning and skip
+        // Proxy but no valid $implementation — fall back to proxy address
+        onProgress?.(
+          `  Warning: proxy ${displayName} has no $implementation — running Slither on proxy bytecode, results may be empty`,
+        )
         contracts.push({
           entryAddress: entry.address,
           slitherAddress: entry.address,

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -175,12 +175,14 @@ export async function generateCallGraph(
       `[${i + 1}/${contracts.length}] Analyzing ${contract.displayName} (${contract.entryAddress})...`,
     )
 
-    // Check cache first (keyed by entry address, sourceHash covers proxy + implementation)
+    // Check cache first
+    // Cache key uses slitherAddress (implementation for proxies) since that's what Slither runs on
+    // Source hash uses entryAddress (proxy) since sourceHashes covers both proxy + implementation
     const currentSourceHash = getContractSourceHash(
       discovered,
       contract.entryAddress,
     )
-    const cachedEntry = getSlithirCache(paths, project, contract.entryAddress)
+    const cachedEntry = getSlithirCache(paths, project, contract.slitherAddress)
 
     let slithirOutput: string | null = null
 
@@ -237,7 +239,7 @@ export async function generateCallGraph(
 
       // Save to cache if we have a source hash
       if (currentSourceHash && slithirOutput) {
-        saveSlithirCache(paths, project, contract.entryAddress, {
+        saveSlithirCache(paths, project, contract.slitherAddress, {
           version: '1.0',
           sourceHash: currentSourceHash,
           generatedAt: new Date().toISOString(),

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -172,15 +172,15 @@ export async function generateCallGraph(
   for (let i = 0; i < contracts.length; i++) {
     const contract = contracts[i]!
     onProgress?.(
-      `[${i + 1}/${contracts.length}] Analyzing ${contract.name} (${contract.address})...`,
+      `[${i + 1}/${contracts.length}] Analyzing ${contract.displayName} (${contract.entryAddress})...`,
     )
 
-    // Check cache first
+    // Check cache first (keyed by entry address, sourceHash covers proxy + implementation)
     const currentSourceHash = getContractSourceHash(
       discovered,
-      contract.address,
+      contract.entryAddress,
     )
-    const cachedEntry = getSlithirCache(paths, project, contract.address)
+    const cachedEntry = getSlithirCache(paths, project, contract.entryAddress)
 
     let slithirOutput: string | null = null
 
@@ -198,8 +198,9 @@ export async function generateCallGraph(
       const reason = cachedEntry ? 'source changed' : 'no cache'
       onProgress?.(`  Running Slither (${reason})...`)
 
+      // runs on implementation address for proxies (since interested in business logic of the contract, not proxy logic)
       const slitherResult = await runSlitherOnContract(
-        contract.address,
+        contract.slitherAddress,
         etherscanApiKey,
         onProgress,
       )
@@ -208,9 +209,9 @@ export async function generateCallGraph(
         onProgress?.(
           '  Skipping: Source code not available (unverified contract)',
         )
-        result[contract.address] = {
-          address: contract.address,
-          name: contract.name,
+        result[contract.entryAddress] = {
+          address: contract.entryAddress,
+          name: contract.displayName,
           externalCalls: [],
           generatedAt: new Date().toISOString(),
           skipped: true,
@@ -221,9 +222,9 @@ export async function generateCallGraph(
 
       if (slitherResult.error) {
         onProgress?.(`  Error: ${slitherResult.error}`)
-        result[contract.address] = {
-          address: contract.address,
-          name: contract.name,
+        result[contract.entryAddress] = {
+          address: contract.entryAddress,
+          name: contract.displayName,
           externalCalls: [],
           generatedAt: new Date().toISOString(),
           error: slitherResult.error,
@@ -236,7 +237,7 @@ export async function generateCallGraph(
 
       // Save to cache if we have a source hash
       if (currentSourceHash && slithirOutput) {
-        saveSlithirCache(paths, project, contract.address, {
+        saveSlithirCache(paths, project, contract.entryAddress, {
           version: '1.0',
           sourceHash: currentSourceHash,
           generatedAt: new Date().toISOString(),
@@ -245,16 +246,17 @@ export async function generateCallGraph(
       }
     }
 
-    // Get ABI function names for this contract
+    // Get ABI function names (use implementation ABI for proxies)
     const abiFunctionNames = getAbiFunctionNames(
       discovered.abis,
-      contract.address,
+      contract.abiAddress,
     )
 
     // Parse the slithir output using ABI-driven approach
+    // Uses code-derived name (from implementationNames) for SlithIR section lookup
     const externalCalls = parseSlithirForContract(
       slithirOutput!,
-      contract.name,
+      contract.slitherContractName,
       abiFunctionNames,
       onProgress,
     )
@@ -290,9 +292,10 @@ export async function generateCallGraph(
     // Resolve addresses and classify calls for each external call
     for (const call of externalCalls) {
       // Try deterministic resolution first (direct state variable lookup)
+      // Use entryAddress — values (state variables) are stored on the proxy entry
       const resolved = resolveStorageVariable(
         discovered,
-        contract.address,
+        contract.entryAddress,
         call.storageVariable,
       )
 
@@ -306,7 +309,7 @@ export async function generateCallGraph(
         // Try optimistic resolution using heuristics
         const heuristicContext: HeuristicContext = {
           call,
-          callerContractAddress: contract.address,
+          callerContractAddress: contract.entryAddress,
           discovered,
           variableAssignments,
         }
@@ -351,10 +354,11 @@ export async function generateCallGraph(
 
       // If we couldn't determine from target ABI, check if the caller function is view/pure
       // (view/pure functions can only call other view/pure functions)
+      // Use abiAddress — caller ABI is on the implementation for proxies
       if (call.isViewCall === undefined) {
         const callerAbiLookup = findFunctionInAbi(
           discovered.abis,
-          contract.address,
+          contract.abiAddress,
           call.callerFunction,
         )
         if (callerAbiLookup.found && callerAbiLookup.isView) {
@@ -374,9 +378,9 @@ export async function generateCallGraph(
     )
     onProgress?.(`  Read/Write: ${viewCount} reads, ${writeCount} writes`)
 
-    result[contract.address] = {
-      address: contract.address,
-      name: contract.name,
+    result[contract.entryAddress] = {
+      address: contract.entryAddress,
+      name: contract.displayName,
       externalCalls,
       generatedAt: new Date().toISOString(),
     }
@@ -526,14 +530,24 @@ function getContractSourceHash(
 // Private Helpers - Contract Analysis
 // =============================================================================
 
+interface ContractToAnalyze {
+  entryAddress: string // proxy address — used for storing results (UI shows proxy)
+  slitherAddress: string // address to run Slither on (impl for proxies, self otherwise)
+  slitherContractName: string // code-derived name for SlithIR section lookup
+  abiAddress: string // address to get ABI from (impl for proxies, self otherwise)
+  displayName: string // entry.name for display/logging
+}
+
 /**
- * Get list of non-external contracts to analyze
+ * Get list of non-external contracts to analyze.
+ * For proxy contracts, returns the implementation address for Slither/ABI analysis
+ * while keeping the proxy address for result storage.
  */
 function getContractsToAnalyze(
   paths: DiscoveryPaths,
   discovered: DiscoveryOutput,
   project: string,
-): { address: string; name: string }[] {
+): ContractToAnalyze[] {
   // Load contract tags to identify external contracts
   const tags = getContractTags(paths, project)
   const externalAddresses = new Set(
@@ -542,7 +556,7 @@ function getContractsToAnalyze(
       .map((tag) => tag.contractAddress.toLowerCase()),
   )
 
-  const contracts: { address: string; name: string }[] = []
+  const contracts: ContractToAnalyze[] = []
 
   for (const entry of discovered.entries) {
     if (entry.type !== 'Contract') continue
@@ -551,10 +565,59 @@ function getContractsToAnalyze(
     const normalizedAddress = entry.address.toLowerCase()
     if (externalAddresses.has(normalizedAddress)) continue
 
-    contracts.push({
-      address: entry.address,
-      name: entry.name || 'Unknown',
-    })
+    const displayName = entry.name || 'Unknown'
+    const implNames = (
+      'implementationNames' in entry ? entry.implementationNames : undefined
+    ) as Record<string, string> | undefined
+    const proxyType = ('proxyType' in entry ? entry.proxyType : undefined) as
+      | string
+      | undefined
+
+    // A contract is a proxy if proxyType is not "immutable" and not "EOA"
+    const isProxy =
+      proxyType !== undefined &&
+      proxyType !== 'immutable' &&
+      proxyType !== 'EOA'
+
+    if (isProxy) {
+      // Get implementation address from values.$implementation
+      const implValue =
+        'values' in entry && entry.values
+          ? (entry.values as Record<string, unknown>).$implementation
+          : undefined
+
+      if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
+        // Proxy contract — analyze the implementation
+        const implName = implNames?.[implValue] ?? displayName
+        contracts.push({
+          entryAddress: entry.address,
+          slitherAddress: implValue,
+          slitherContractName: implName,
+          abiAddress: implValue,
+          displayName,
+        })
+      } else {
+        // Proxy but no valid $implementation — log warning and skip
+        contracts.push({
+          entryAddress: entry.address,
+          slitherAddress: entry.address,
+          slitherContractName: displayName,
+          abiAddress: entry.address,
+          displayName,
+        })
+      }
+    } else {
+      // Regular contract — use implementationNames for code-derived name
+      // prevent taking the alias given by config.jsonc (field "name")
+      const codeName = implNames?.[entry.address] ?? displayName
+      contracts.push({
+        entryAddress: entry.address,
+        slitherAddress: entry.address,
+        slitherContractName: codeName,
+        abiAddress: entry.address,
+        displayName,
+      })
+    }
   }
 
   return contracts
@@ -959,10 +1022,33 @@ function parseSlithirForContract(
     // Skip constructor
     if (funcName === 'constructor') continue
 
+    // Determine which SlithIR contract section contains this function
+    let targetContractName = contractName
+    const mainContract = parsedSlithir.contracts.get(contractName)
+
+    if (!mainContract?.functions.has(funcName)) {
+      // Inheritance fallback: search other sections within slithir output for this function
+      // Skip interfaces (empty function bodies — no call instructions)
+      for (const [name, contract] of parsedSlithir.contracts) {
+        if (name === contractName) continue
+        const func = contract.functions.get(funcName)
+        if (!func) continue
+        // Skip interfaces: they have declarations but no call instructions
+        if (
+          func.internalCalls.length === 0 &&
+          func.highLevelCalls.length === 0 &&
+          func.libraryCalls.length === 0
+        )
+          continue
+        targetContractName = name
+        break
+      }
+    }
+
     const visited = new Set<string>()
     const hlcs = collectHighLevelCalls(
       parsedSlithir,
-      contractName,
+      targetContractName,
       funcName,
       visited,
       new Map(), // No type substitutions for top-level public functions

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -235,15 +235,30 @@ class FunctionSignatureHeuristic implements ResolutionHeuristic {
     for (const entry of discovered.entries) {
       if (entry.type !== 'Contract') continue
 
-      const abi = discovered.abis[entry.address]
-      if (!abi) continue
+      // Collect ABI addresses: entry address + implementation address for proxies
+      const abiAddresses = [entry.address]
+      const implValue =
+        'values' in entry && entry.values
+          ? (entry.values as Record<string, unknown>).$implementation
+          : undefined
+      if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
+        abiAddresses.push(implValue as typeof entry.address)
+      }
 
-      // Check if this contract has the function
-      const hasFunction = abi.some((abiEntry) => {
-        if (!abiEntry.startsWith('function ')) return false
-        const match = abiEntry.match(/^function\s+(\w+)\(/)
-        return match && match[1] === functionName
-      })
+      // Check if any of the contract's ABIs have the function
+      let hasFunction = false
+      for (const abiAddress of abiAddresses) {
+        const abi = discovered.abis[abiAddress]
+        if (!abi) continue
+
+        hasFunction = abi.some((abiEntry) => {
+          if (!abiEntry.startsWith('function ')) return false
+          const match = abiEntry.match(/^function\s+(\w+)\(/)
+          return match && match[1] === functionName
+        })
+
+        if (hasFunction) break
+      }
 
       if (hasFunction) {
         matches.push({

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -177,8 +177,8 @@ class InterfaceNameHeuristic implements ResolutionHeuristic {
       }
 
       // Check implementationNames values (code-derived names from Etherscan source)
-      if ('implementationNames' in entry && entry.implementationNames) {
-        const implNames = entry.implementationNames as Record<string, string>
+      if (entry.implementationNames) {
+        const implNames = entry.implementationNames
         let matched = false
         for (const implName of Object.values(implNames)) {
           if (implName.toLowerCase() === expectedLower) {
@@ -237,10 +237,7 @@ class FunctionSignatureHeuristic implements ResolutionHeuristic {
 
       // Collect ABI addresses: entry address + implementation address for proxies
       const abiAddresses = [entry.address]
-      const implValue =
-        'values' in entry && entry.values
-          ? (entry.values as Record<string, unknown>).$implementation
-          : undefined
+      const implValue = entry.values?.$implementation
       if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
         abiAddresses.push(implValue as typeof entry.address)
       }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -158,17 +158,39 @@ class InterfaceNameHeuristic implements ResolutionHeuristic {
     const expectedContractName = interfaceName.slice(1) // Remove 'I' prefix
 
     // Find all contracts with matching name (case-insensitive)
+    // Checks both entry.name and implementationNames values to handle:
+    // - Aliases: entry.name is the alias, but implementationNames has the code-derived name
+    // - Proxies: entry.name is the proxy name, but implementationNames has the implementation name
     const matches: HeuristicMatch[] = []
+    const expectedLower = expectedContractName.toLowerCase()
 
     for (const entry of discovered.entries) {
       if (entry.type !== 'Contract') continue
 
       const contractName = entry.name || ''
-      if (contractName.toLowerCase() === expectedContractName.toLowerCase()) {
+      if (contractName.toLowerCase() === expectedLower) {
         matches.push({
           address: entry.address,
           contractName: entry.name,
         })
+        continue // Don't double-match same entry
+      }
+
+      // Check implementationNames values (code-derived names from Etherscan source)
+      if ('implementationNames' in entry && entry.implementationNames) {
+        const implNames = entry.implementationNames as Record<string, string>
+        let matched = false
+        for (const implName of Object.values(implNames)) {
+          if (implName.toLowerCase() === expectedLower) {
+            matches.push({
+              address: entry.address,
+              contractName: entry.name,
+            })
+            matched = true
+            break // One match per entry is enough
+          }
+        }
+        if (matched) continue
       }
     }
 


### PR DESCRIPTION
  Fix 1+2: Proxy Support & Name Resolution

  The call graph analysis now correctly handles proxy contracts by running Slither on the implementation address instead of the proxy address, which only contains delegatecall forwarding code. A new ContractToAnalyze
  interface enriches each contract with separate addresses for Slither execution, ABI lookup, and result storage. Name resolution uses implementationNames (code-derived names from Etherscan source) instead of entry.name
  for SlithIR section lookup, fixing silent failures when config.jsonc aliases don't match the actual contract name in Slither output. Proxy detection uses proxyType (not "immutable" and not "EOA"), and the implementation
   address is extracted from values.$implementation.

  Fix 3: Inheritance Fallback

  When a public ABI function is inherited but not overridden, Slither attributes it to the parent contract's section in SlithIR output, causing the analysis to silently skip it. The parser now falls back to searching
  other contract sections when a function isn't found in the main section. Interface sections are excluded from the fallback by checking for empty function bodies (no internal calls, high-level calls, or library calls),
  preventing false positives from interface declarations like IERC20.transfer().

  Fix 4: Interface-Name Heuristic Enhancement

  The interface-name heuristic (e.g., matching ITroveManager → TroveManager) previously only checked entry.name, which fails for aliased or proxy contracts where the display name differs from the code-derived name. The
  heuristic now also checks all values in entry.implementationNames, which preserves the original contract names from Etherscan source code regardless of config aliases. This fixes resolution for both aliased contracts
  (where entry.name is the alias) and proxy contracts (where entry.name is the proxy name but implementationNames has the implementation name).

Not handling yet
- DiamondProxy