### PR TITLE
Callgraph improvements

### DIFF
--- a/.claude/skills/generate-review/SKILL.md
+++ b/.claude/skills/generate-review/SKILL.md
@@ -12,9 +12,26 @@ You are a DeFi protocol security review writer. Your task is to generate a profe
 
 This skill **always replaces** the entire existing review. Every run produces a fresh review from scratch.
 
+**CRITICAL: Do NOT read, reference, or be influenced by any existing `review-config.json` for this project.** Your output must be generated entirely from the API data fetched below. If the file exists, it will be moved aside before generation begins.
+
 ## Prerequisites
 
 The l2b UI server must be running at `http://localhost:2021`. If not, tell the user to start it with `cd packages/config && l2b ui`.
+
+---
+
+## Step 0: Remove Existing Review
+
+Move the existing review-config.json out of the way so it cannot influence generation:
+
+```bash
+if [ -f "packages/config/src/projects/$0/review-config.json" ]; then
+  mv "packages/config/src/projects/$0/review-config.json" "/tmp/review-config-backup-$0.json"
+  echo "Moved existing review-config.json to /tmp/review-config-backup-$0.json"
+else
+  echo "No existing review-config.json found"
+fi
+```
 
 ---
 
@@ -61,6 +78,7 @@ INTERESTING_FIELDS = {'multisigThreshold','\$members','\$threshold','delay','MIN
 for entry in d.get('entries', []):
     for c in entry.get('initialContracts',[]) + entry.get('discoveredContracts',[]):
         summary = {'name': c.get('name',''), 'address': c['address'], 'type': c.get('type',''), 'proxyType': c.get('proxyType','')}
+        if c.get('description'): summary['description'] = c['description']
         if c.get('template'): summary['template'] = c['template'].get('id','')
         key_fields = {}
         for field in c.get('fields', []):
@@ -128,6 +146,7 @@ If any core file (v2-score, project, tags, funds, functions) is empty or contain
 
 ### From project (contract details)
 - `contracts[]`: Each has `name`, `address`, `type`, `proxyType`, `template`
+- `description`: Human-written contract description from config (if present). Use these descriptions as context when writing about dependencies or funds — they capture the researcher's understanding of what the contract does
 - `keyFields`: Only present for contracts with interesting fields:
   - `multisigThreshold`: e.g. "3 of 5 (60%)" — for naming multisigs
   - `$members`: array of signer addresses — for multisig member count
@@ -281,7 +300,7 @@ packages/config/src/projects/$0/review-config.json
 Then clean up all temporary files:
 
 ```bash
-rm -f /tmp/review-project-raw.json /tmp/review-v2score-raw.json /tmp/review-traversal-raw.json /tmp/review-project.json /tmp/review-v2score.json /tmp/review-tags.json /tmp/review-funds.json /tmp/review-functions.json /tmp/review-traversal.json
+rm -f /tmp/review-project-raw.json /tmp/review-v2score-raw.json /tmp/review-traversal-raw.json /tmp/review-project.json /tmp/review-v2score.json /tmp/review-tags.json /tmp/review-funds.json /tmp/review-functions.json /tmp/review-traversal.json /tmp/review-config-backup-$0.json
 ```
 
 Report what was generated:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,7 +334,7 @@ When `ETHEREUM_RPC_URL_FOR_DISCOVERY` is set, defiscan-endpoints detects Morpho 
 3. **InterfaceNameHeuristic** (confidence: 90/60/40%) — strips `I` prefix from interface name and matches contract names
 4. **FunctionSignatureHeuristic** (confidence: 99/50/30%) — finds all contracts with the called function in their ABI
 
-Shared helper: `contractHasFunction(discovered, entry, functionName)` — checks if a contract (including proxy implementations) has a function in its ABI.
+Internal helper: `contractHasFunction(discovered, entry, functionName)` — checks if a contract (including proxy implementations) has a function in its ABI. Module-private to `callGraphHeuristics.ts` (not exported).
 
 **Data Structure** (`call-graph-data.json`):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,7 +299,7 @@ When `ETHEREUM_RPC_URL_FOR_DISCOVERY` is set, defiscan-endpoints detects Morpho 
 
 **External Call Detection**: Uses Slither to analyze which external contracts each function calls
 
-- **Backend**: `packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts`
+- **Backend**: `packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts` (Slither runner + parser), `callGraphHeuristics.ts` (resolution heuristic engine)
 - **Storage**: `call-graph-data.json` per project
 - **Tool**: Slither's `--print slithir` command
 - **Configuration**:
@@ -323,6 +323,18 @@ When `ETHEREUM_RPC_URL_FOR_DISCOVERY` is set, defiscan-endpoints detects Morpho 
 - **View inference**: If caller is view/pure, external call must also be view
 - **Contract name matching**: Slithir uses `INFO:Printers:Contract X` or alternatives such as `Contract X` format for main contract
 - **Deduplication**: Removes duplicate calls per caller function
+- **Nested object resolution**: `resolveStorageVariable` extracts addresses from struct-like objects (e.g., `{ aggregator: "eth:0x...", decimals: 8 }`) and resolves when exactly one address is found
+- **REF_ propagation**: Parent type substitutions propagate through synthetic Slither `REF_`/`TMP_` references, so the same internal function called with different arguments (e.g., `_getPrice(ethUsdOracle)` vs `_getPrice(rEthEthOracle)`) produces separate call entries
+- **Context-aware deduplication**: Visited-set key includes type substitutions to prevent merging calls with different argument contexts
+
+**Heuristic Resolution Engine** (`callGraphHeuristics.ts`): Resolves storage variables to contract addresses when direct `discovered.json` lookup fails. Runs all heuristics and picks the highest-confidence result:
+
+1. **VariableChainHeuristic** (confidence: 100%) — follows Slither variable assignment chains to find state variables, handles nested struct fields
+2. **DiscoveredValuesScanHeuristic** (confidence: 95/70/50%) — scans caller contract's discovered values for `eth:` addresses, matches against contracts that have the called function in their ABI
+3. **InterfaceNameHeuristic** (confidence: 90/60/40%) — strips `I` prefix from interface name and matches contract names
+4. **FunctionSignatureHeuristic** (confidence: 99/50/30%) — finds all contracts with the called function in their ABI
+
+Shared helper: `contractHasFunction(discovered, entry, functionName)` — checks if a contract (including proxy implementations) has a function in its ABI.
 
 **Data Structure** (`call-graph-data.json`):
 
@@ -354,6 +366,7 @@ When `ETHEREUM_RPC_URL_FOR_DISCOVERY` is set, defiscan-endpoints detects Morpho 
 - `buildExternalAddressSet(tags)` / `buildTagsByAddress(tags)` — build lookup structures from contract tags
 - `isExternalAddress(address, externalAddresses)` / `findTag(tagsByAddress, address)` — address matching with `eth:` prefix normalization
 - `getCallGraphContractName(callGraphData, address)` — resolve contract name from call graph data
+- `extractEthAddresses(value)` — extract all `eth:` addresses from a value (handles flat strings and one-level-deep object fields)
 
 ### Enhanced Traversal & Function Analysis ✅
 
@@ -497,10 +510,11 @@ When `ETHEREUM_RPC_URL_FOR_DISCOVERY` is set, defiscan-endpoints detects Morpho 
 - **File**: `.claude/skills/generate-review/SKILL.md`
 - **Prerequisites**: l2b UI server running at `localhost:2021` (`cd packages/config && l2b ui`)
 - **Behavior**: Always replaces the entire review — every run generates fresh content
+- **Isolation**: Moves existing `review-config.json` aside before generation to prevent bias from prior output
 
 **How It Works**:
 1. Fetches pre-processed data from l2b API endpoints (v2-score, enhanced-traversal, funds-data, contract-tags, functions, project data)
-2. Preprocesses large responses into compact summaries (python3 scripts)
+2. Preprocesses large responses into compact summaries (python3 scripts); includes contract `description` fields from config for context
 3. Analyzes protocol structure, admin hierarchy, dependencies, and fund distribution
 4. Generates professional descriptions following built-in writing guidelines (neutral tone, data-driven, no marketing copy, no hardcoded USD values)
 5. Writes result directly to `packages/config/src/projects/{project}/review-config.json`
@@ -674,6 +688,8 @@ packages/
 │   ├── reviewConfig.ts              # Review config CRUD
 │   ├── reviewCompiler.ts            # Compiled review builder (shared with monitor)
 │   ├── generatePermissionsReport.ts
+│   ├── callGraph.ts                  # Slither-based external call detection
+│   ├── callGraphHeuristics.ts        # Heuristic engine for variable-to-address resolution
 │   ├── enhancedTraversal.ts          # Backward BFS governance chains
 │   └── functionAnalysis.ts           # Forward BFS impact & dependencies
 ├── defiscan-frontend/                # Standalone public review website

--- a/packages/config/src/projects/_templates/liquity-v2/ActivePool/template.jsonc
+++ b/packages/config/src/projects/_templates/liquity-v2/ActivePool/template.jsonc
@@ -10,7 +10,8 @@
     "getBoldDebt",
     "getCollBalance",
     "lastAggBatchManagementFeesUpdateTime",
-    "lastAggUpdateTime"
+    "lastAggUpdateTime",
+    "aggWeightedBatchManagementFeeSum"
   ],
   "ignoreRelatives": ["collToken"]
 }

--- a/packages/config/src/projects/liquity-v2/call-graph-data.json
+++ b/packages/config/src/projects/liquity-v2/call-graph-data.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "lastModified": "2026-03-04T13:46:44.004Z",
+  "lastModified": "2026-03-06T08:20:14.530Z",
   "contracts": {
     "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386": {
       "address": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -21,25 +21,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -47,25 +33,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -73,25 +45,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -99,25 +57,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -125,25 +69,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -157,7 +87,7 @@
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:02.214Z"
+      "generatedAt": "2026-03-06T08:20:06.410Z"
     },
     "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013": {
       "address": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
@@ -165,13 +95,13 @@
       "externalCalls": [
         {
           "callerFunction": "safeTransferFrom",
-          "storageVariable": "TMP_1099",
+          "storageVariable": "from",
           "interfaceType": "IERC721Receiver",
           "calledFunction": "onERC721Received"
         },
         {
           "callerFunction": "safeTransferFrom",
-          "storageVariable": "TMP_1099",
+          "storageVariable": "from",
           "interfaceType": "IERC721Receiver",
           "calledFunction": "onERC721Received"
         },
@@ -206,7 +136,7 @@
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:02.439Z"
+      "generatedAt": "2026-03-06T08:20:06.427Z"
     },
     "eth:0x3400874305E1547020fb8e80eAF1308B757171Af": {
       "address": "eth:0x3400874305E1547020fb8e80eAF1308B757171Af",
@@ -259,25 +189,11 @@
           "storageVariable": "_assetReader",
           "interfaceType": "FixedAssetReader",
           "calledFunction": "readAsset",
-          "resolvedAddress": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
+          "resolvedAddress": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
           "resolvedContractName": "FixedAssetReader",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
-              "contractName": "FixedAssetReader"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -366,49 +282,7 @@
         },
         {
           "callerFunction": "uri",
-          "storageVariable": "TMP_1004",
-          "interfaceType": "IERC20Metadata",
-          "calledFunction": "symbol",
-          "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-          "resolvedContractName": "TroveNFT",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-              "contractName": "BoldToken"
-            },
-            {
-              "address": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-              "contractName": "WstETH"
-            },
-            {
-              "address": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-              "contractName": "RocketTokenRETH"
-            },
-            {
-              "address": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-              "contractName": "Wrapped Ether Token"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "uri",
-          "storageVariable": "TMP_1023",
+          "storageVariable": "_troveData",
           "interfaceType": "IERC20Metadata",
           "calledFunction": "symbol",
           "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
@@ -453,29 +327,15 @@
           "storageVariable": "_assetReader",
           "interfaceType": "FixedAssetReader",
           "calledFunction": "readAsset",
-          "resolvedAddress": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
+          "resolvedAddress": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
           "resolvedContractName": "FixedAssetReader",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
-              "contractName": "FixedAssetReader"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:03.161Z"
+      "generatedAt": "2026-03-06T08:20:06.456Z"
     },
     "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B": {
       "address": "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B",
@@ -483,33 +343,27 @@
       "externalCalls": [
         {
           "callerFunction": "fetchPrice",
-          "storageVariable": "REF_1343",
+          "storageVariable": "ethUsdOracle",
           "interfaceType": "AggregatorV3Interface",
           "calledFunction": "latestRoundData",
-          "resolvedAddress": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+          "resolvedAddress": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
           "resolvedContractName": "EACAggregatorProxy",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-              "contractName": "EACAggregatorProxy"
-            }
-          ],
+          "resolutionType": "deterministic",
           "isViewCall": true
         },
         {
           "callerFunction": "fetchPrice",
-          "storageVariable": "TMP_2522",
+          "storageVariable": "rEthEthOracle",
+          "interfaceType": "AggregatorV3Interface",
+          "calledFunction": "latestRoundData",
+          "resolvedAddress": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+          "resolvedContractName": "EACAggregatorProxy",
+          "resolutionType": "deterministic",
+          "isViewCall": true
+        },
+        {
+          "callerFunction": "fetchPrice",
+          "storageVariable": "False",
           "interfaceType": "IRETHToken",
           "calledFunction": "getExchangeRate",
           "resolvedAddress": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
@@ -547,33 +401,27 @@
         },
         {
           "callerFunction": "fetchRedemptionPrice",
-          "storageVariable": "REF_1343",
+          "storageVariable": "ethUsdOracle",
           "interfaceType": "AggregatorV3Interface",
           "calledFunction": "latestRoundData",
-          "resolvedAddress": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+          "resolvedAddress": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
           "resolvedContractName": "EACAggregatorProxy",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-              "contractName": "EACAggregatorProxy"
-            }
-          ],
+          "resolutionType": "deterministic",
           "isViewCall": true
         },
         {
           "callerFunction": "fetchRedemptionPrice",
-          "storageVariable": "TMP_2522",
+          "storageVariable": "rEthEthOracle",
+          "interfaceType": "AggregatorV3Interface",
+          "calledFunction": "latestRoundData",
+          "resolvedAddress": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+          "resolvedContractName": "EACAggregatorProxy",
+          "resolutionType": "deterministic",
+          "isViewCall": true
+        },
+        {
+          "callerFunction": "fetchRedemptionPrice",
+          "storageVariable": "True",
           "interfaceType": "IRETHToken",
           "calledFunction": "getExchangeRate",
           "resolvedAddress": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
@@ -610,7 +458,7 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:03.797Z"
+      "generatedAt": "2026-03-06T08:20:06.508Z"
     },
     "eth:0x362f822dF79790C8077e61110484Fffa48F682A1": {
       "address": "eth:0x362f822dF79790C8077e61110484Fffa48F682A1",
@@ -663,25 +511,11 @@
           "storageVariable": "_assetReader",
           "interfaceType": "FixedAssetReader",
           "calledFunction": "readAsset",
-          "resolvedAddress": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
+          "resolvedAddress": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
           "resolvedContractName": "FixedAssetReader",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
-              "contractName": "FixedAssetReader"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -770,49 +604,7 @@
         },
         {
           "callerFunction": "uri",
-          "storageVariable": "TMP_1004",
-          "interfaceType": "IERC20Metadata",
-          "calledFunction": "symbol",
-          "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-          "resolvedContractName": "TroveNFT",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-              "contractName": "BoldToken"
-            },
-            {
-              "address": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-              "contractName": "WstETH"
-            },
-            {
-              "address": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-              "contractName": "RocketTokenRETH"
-            },
-            {
-              "address": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-              "contractName": "Wrapped Ether Token"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "uri",
-          "storageVariable": "TMP_1023",
+          "storageVariable": "_troveData",
           "interfaceType": "IERC20Metadata",
           "calledFunction": "symbol",
           "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
@@ -857,29 +649,15 @@
           "storageVariable": "_assetReader",
           "interfaceType": "FixedAssetReader",
           "calledFunction": "readAsset",
-          "resolvedAddress": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
+          "resolvedAddress": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
           "resolvedContractName": "FixedAssetReader",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
-              "contractName": "FixedAssetReader"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:04.519Z"
+      "generatedAt": "2026-03-06T08:20:06.537Z"
     },
     "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65": {
       "address": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
@@ -949,15 +727,14 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "addColl",
@@ -985,15 +762,14 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "addColl",
@@ -1053,96 +829,64 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "addColl",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "mint",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "addColl",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "addColl",
-          "storageVariable": "REF_323",
-          "interfaceType": "IActivePool",
-          "calledFunction": "sendColl",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "addColl",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "mint",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "addColl",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "burn",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "addColl",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IActivePool",
+          "calledFunction": "sendColl",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "addColl",
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -1209,15 +953,14 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "adjustTrove",
@@ -1245,15 +988,14 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "adjustTrove",
@@ -1313,96 +1055,64 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "adjustTrove",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "mint",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "adjustTrove",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "adjustTrove",
-          "storageVariable": "REF_323",
-          "interfaceType": "IActivePool",
-          "calledFunction": "sendColl",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "adjustTrove",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "mint",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "adjustTrove",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "burn",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "adjustTrove",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IActivePool",
+          "calledFunction": "sendColl",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "adjustTrove",
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -1607,22 +1317,8 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -1665,15 +1361,14 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "adjustZombieTrove",
@@ -1701,15 +1396,14 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "adjustZombieTrove",
@@ -1763,76 +1457,58 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "mint",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_323",
-          "interfaceType": "IActivePool",
-          "calledFunction": "sendColl",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "adjustZombieTrove",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "mint",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "adjustZombieTrove",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "burn",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "adjustZombieTrove",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IActivePool",
+          "calledFunction": "sendColl",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "adjustZombieTrove",
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -2271,31 +1947,31 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -2321,7 +1997,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -2357,38 +2033,26 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_534",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_535",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -2415,18 +2079,6 @@
               "contractName": "TroveNFT"
             }
           ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
           "isViewCall": true
         },
         {
@@ -2561,31 +2213,31 @@
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_159",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_186",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_189",
+          "storageVariable": "_owner",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -2649,14 +2301,14 @@
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_152",
+          "storageVariable": "_owner",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -2701,14 +2353,14 @@
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_188",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
           "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -2763,31 +2415,31 @@
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_159",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_186",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_189",
+          "storageVariable": "REF_109",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -2851,14 +2503,14 @@
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_152",
+          "storageVariable": "REF_109",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -2903,14 +2555,14 @@
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_188",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
           "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -2925,31 +2577,31 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -2975,7 +2627,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -3011,38 +2663,26 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_534",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_535",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -3069,18 +2709,6 @@
               "contractName": "TroveNFT"
             }
           ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
           "isViewCall": true
         },
         {
@@ -3233,15 +2861,14 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "repayBold",
@@ -3269,15 +2896,14 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "repayBold",
@@ -3337,96 +2963,64 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "repayBold",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "mint",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "repayBold",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "repayBold",
-          "storageVariable": "REF_323",
-          "interfaceType": "IActivePool",
-          "calledFunction": "sendColl",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "repayBold",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "mint",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "repayBold",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "burn",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "repayBold",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IActivePool",
+          "calledFunction": "sendColl",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "repayBold",
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -3841,31 +3435,31 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -3891,7 +3485,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -3927,38 +3521,26 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_534",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -4175,31 +3757,31 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -4225,7 +3807,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -4261,38 +3843,26 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_534",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_535",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -4319,18 +3889,6 @@
               "contractName": "TroveNFT"
             }
           ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
           "isViewCall": true
         },
         {
@@ -4395,55 +3953,31 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_464",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getLatestTroveData",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_467",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getLatestBatchData",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_513",
+          "storageVariable": "_troveId",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_515",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onSetInterestBatchManager",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_526",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "remove",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -4469,7 +4003,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_528",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insertIntoBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -4557,15 +4091,14 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "withdrawBold",
@@ -4593,15 +4126,14 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "withdrawBold",
@@ -4661,96 +4193,64 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "withdrawBold",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "mint",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "withdrawBold",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "withdrawBold",
-          "storageVariable": "REF_323",
-          "interfaceType": "IActivePool",
-          "calledFunction": "sendColl",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "withdrawBold",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "mint",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "withdrawBold",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "burn",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "withdrawBold",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IActivePool",
+          "calledFunction": "sendColl",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "withdrawBold",
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -4817,15 +4317,14 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": true
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "withdrawColl",
@@ -4853,15 +4352,14 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "withdrawColl",
@@ -4921,100 +4419,68 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "withdrawColl",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "mint",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "withdrawColl",
-          "storageVariable": "REF_322",
-          "interfaceType": "IBoldToken",
-          "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
-          "isViewCall": false
-        },
-        {
-          "callerFunction": "withdrawColl",
-          "storageVariable": "REF_323",
-          "interfaceType": "IActivePool",
-          "calledFunction": "sendColl",
-          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-          "resolvedContractName": "ActivePool",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
           "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
-          "isViewCall": false
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "withdrawColl",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "mint",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "withdrawColl",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IBoldToken",
+          "calledFunction": "burn",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
+        },
+        {
+          "callerFunction": "withdrawColl",
+          "storageVariable": "troveManagerCached",
+          "interfaceType": "IActivePool",
+          "calledFunction": "sendColl",
+          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedContractName": "TroveManager",
+          "resolutionType": "optimistic",
+          "resolutionHeuristic": "variable-chain",
+          "resolutionConfidence": 100
         },
         {
           "callerFunction": "withdrawColl",
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:24.962Z"
+      "generatedAt": "2026-03-06T08:20:06.605Z"
     },
     "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0": {
       "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
@@ -5075,29 +4541,15 @@
           "storageVariable": "TMP_1278",
           "interfaceType": "IDefaultPool",
           "calledFunction": "receiveColl",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
+          "resolvedAddress": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
           "resolvedContractName": "DefaultPool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:25.078Z"
+      "generatedAt": "2026-03-06T08:20:06.616Z"
     },
     "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF": {
       "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
@@ -5138,25 +4590,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -5174,25 +4612,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -5266,7 +4690,7 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:25.288Z"
+      "generatedAt": "2026-03-06T08:20:06.627Z"
     },
     "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b": {
       "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
@@ -5277,35 +4701,21 @@
           "storageVariable": "TMP_1087",
           "interfaceType": "IActivePool",
           "calledFunction": "receiveColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:25.395Z"
+      "generatedAt": "2026-03-06T08:20:06.638Z"
     },
     "eth:0x5CcA549ca706C39D68156e5E0a72CcBC95f563d0": {
       "address": "eth:0x5CcA549ca706C39D68156e5E0a72CcBC95f563d0",
       "name": "Unknown",
       "externalCalls": [],
-      "generatedAt": "2026-03-04T13:45:27.892Z",
+      "generatedAt": "2026-03-06T08:20:09.030Z",
       "skipped": true,
       "skipReason": "Unverified contract"
     },
@@ -5313,7 +4723,7 @@
       "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
       "name": "BoldToken",
       "externalCalls": [],
-      "generatedAt": "2026-03-04T13:45:27.895Z"
+      "generatedAt": "2026-03-06T08:20:09.037Z"
     },
     "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873": {
       "address": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
@@ -5321,13 +4731,13 @@
       "externalCalls": [
         {
           "callerFunction": "safeTransferFrom",
-          "storageVariable": "TMP_1099",
+          "storageVariable": "from",
           "interfaceType": "IERC721Receiver",
           "calledFunction": "onERC721Received"
         },
         {
           "callerFunction": "safeTransferFrom",
-          "storageVariable": "TMP_1099",
+          "storageVariable": "from",
           "interfaceType": "IERC721Receiver",
           "calledFunction": "onERC721Received"
         },
@@ -5362,7 +4772,7 @@
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:28.105Z"
+      "generatedAt": "2026-03-06T08:20:09.053Z"
     },
     "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A": {
       "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -5615,23 +5025,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+          "resolvedContractName": "StabilityPool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "contractName": "StabilityPool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "contractName": "ActivePool"
             }
           ],
           "isViewCall": true
@@ -5644,38 +5050,8 @@
           "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
           "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-              "contractName": "BoldToken"
-            },
-            {
-              "address": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-              "contractName": "WstETH"
-            },
-            {
-              "address": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-              "contractName": "RocketTokenRETH"
-            },
-            {
-              "address": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-              "contractName": "Wrapped Ether Token"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -5693,23 +5069,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+          "resolvedContractName": "StabilityPool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "contractName": "StabilityPool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "contractName": "ActivePool"
             }
           ],
           "isViewCall": true
@@ -5729,25 +5101,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -5801,25 +5159,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -5837,23 +5181,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+          "resolvedContractName": "StabilityPool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "contractName": "StabilityPool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "contractName": "ActivePool"
             }
           ],
           "isViewCall": true
@@ -6493,11 +5833,11 @@
           "storageVariable": "boldToken",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
+          "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
+          "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -6505,11 +5845,11 @@
           "storageVariable": "boldToken",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
+          "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
+          "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -6575,7 +5915,7 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:35.745Z"
+      "generatedAt": "2026-03-06T08:20:09.082Z"
     },
     "eth:0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1": {
       "address": "eth:0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1",
@@ -6758,13 +6098,13 @@
           "calledFunction": "unstake"
         }
       ],
-      "generatedAt": "2026-03-04T13:45:36.455Z"
+      "generatedAt": "2026-03-06T08:20:09.089Z"
     },
     "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258": {
       "address": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
       "name": "FixedAssetReader",
       "externalCalls": [],
-      "generatedAt": "2026-03-04T13:45:36.456Z"
+      "generatedAt": "2026-03-06T08:20:09.090Z"
     },
     "eth:0x84eb85a8C25049255614F0536Bea8F31682e86F1": {
       "address": "eth:0x84eb85a8C25049255614F0536Bea8F31682e86F1",
@@ -6785,25 +6125,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -6811,25 +6137,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -6837,25 +6149,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -6863,25 +6161,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -6889,25 +6173,11 @@
           "storageVariable": "_troveManager",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveAnnualInterestRate",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "resolvedAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -6921,7 +6191,7 @@
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:36.963Z"
+      "generatedAt": "2026-03-06T08:20:09.101Z"
     },
     "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04": {
       "address": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
@@ -6929,13 +6199,13 @@
       "externalCalls": [
         {
           "callerFunction": "safeTransferFrom",
-          "storageVariable": "TMP_1099",
+          "storageVariable": "from",
           "interfaceType": "IERC721Receiver",
           "calledFunction": "onERC721Received"
         },
         {
           "callerFunction": "safeTransferFrom",
-          "storageVariable": "TMP_1099",
+          "storageVariable": "from",
           "interfaceType": "IERC721Receiver",
           "calledFunction": "onERC721Received"
         },
@@ -6970,13 +6240,13 @@
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:37.174Z"
+      "generatedAt": "2026-03-06T08:20:09.110Z"
     },
     "eth:0x884Acfa4593a6FdbA0a9373007E48Ea9AF881C42": {
       "address": "eth:0x884Acfa4593a6FdbA0a9373007E48Ea9AF881C42",
       "name": "Unknown",
       "externalCalls": [],
-      "generatedAt": "2026-03-04T13:45:38.629Z",
+      "generatedAt": "2026-03-06T08:20:12.447Z",
       "skipped": true,
       "skipReason": "Unverified contract"
     },
@@ -7042,26 +6312,12 @@
           "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
           "resolvedContractName": "DefaultPool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:38.736Z"
+      "generatedAt": "2026-03-06T08:20:12.467Z"
     },
     "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B": {
       "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
@@ -7102,25 +6358,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -7138,25 +6380,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -7230,7 +6458,7 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:38.942Z"
+      "generatedAt": "2026-03-06T08:20:12.485Z"
     },
     "eth:0x9B36C3B16299D68c79F174df7e728E35b6AF4A12": {
       "address": "eth:0x9B36C3B16299D68c79F174df7e728E35b6AF4A12",
@@ -7286,22 +6514,8 @@
           "resolvedAddress": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
           "resolvedContractName": "FixedAssetReader",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
-              "contractName": "FixedAssetReader"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -7390,49 +6604,7 @@
         },
         {
           "callerFunction": "uri",
-          "storageVariable": "TMP_1004",
-          "interfaceType": "IERC20Metadata",
-          "calledFunction": "symbol",
-          "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-          "resolvedContractName": "TroveNFT",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-              "contractName": "BoldToken"
-            },
-            {
-              "address": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-              "contractName": "WstETH"
-            },
-            {
-              "address": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-              "contractName": "RocketTokenRETH"
-            },
-            {
-              "address": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-              "contractName": "Wrapped Ether Token"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "uri",
-          "storageVariable": "TMP_1023",
+          "storageVariable": "_troveData",
           "interfaceType": "IERC20Metadata",
           "calledFunction": "symbol",
           "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
@@ -7480,26 +6652,12 @@
           "resolvedAddress": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
           "resolvedContractName": "FixedAssetReader",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
-              "contractName": "FixedAssetReader"
-            },
-            {
-              "address": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
-              "contractName": "FixedAssetReader"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:39.655Z"
+      "generatedAt": "2026-03-06T08:20:12.497Z"
     },
     "eth:0xA25269E41BD072513849F2E64Ad221e84f3063F4": {
       "address": "eth:0xA25269E41BD072513849F2E64Ad221e84f3063F4",
@@ -7523,22 +6681,8 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -7549,22 +6693,8 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -7575,22 +6705,8 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -7601,22 +6717,8 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -7627,22 +6729,8 @@
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
           "resolvedContractName": "TroveManager",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -7656,7 +6744,7 @@
           "isViewCall": true
         }
       ],
-      "generatedAt": "2026-03-04T13:45:40.164Z"
+      "generatedAt": "2026-03-06T08:20:12.507Z"
     },
     "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22": {
       "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
@@ -7909,23 +6997,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "contractName": "ActivePool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "contractName": "StabilityPool"
             }
           ],
           "isViewCall": true
@@ -7935,41 +7019,11 @@
           "storageVariable": "WETH",
           "interfaceType": "IWETH",
           "calledFunction": "transferFrom",
-          "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
+          "resolvedAddress": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
           "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-              "contractName": "BoldToken"
-            },
-            {
-              "address": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-              "contractName": "WstETH"
-            },
-            {
-              "address": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-              "contractName": "RocketTokenRETH"
-            },
-            {
-              "address": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-              "contractName": "Wrapped Ether Token"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -7987,23 +7041,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "contractName": "ActivePool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "contractName": "StabilityPool"
             }
           ],
           "isViewCall": true
@@ -8023,25 +7073,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -8095,25 +7131,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -8131,23 +7153,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "contractName": "ActivePool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "contractName": "StabilityPool"
             }
           ],
           "isViewCall": true
@@ -8787,11 +7805,11 @@
           "storageVariable": "boldToken",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
+          "resolvedAddress": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
+          "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -8799,11 +7817,11 @@
           "storageVariable": "boldToken",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
+          "resolvedAddress": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
+          "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -8869,13 +7887,13 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:45:44.815Z"
+      "generatedAt": "2026-03-06T08:20:12.534Z"
     },
     "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237": {
       "address": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
       "name": "FixedAssetReader",
       "externalCalls": [],
-      "generatedAt": "2026-03-04T13:45:44.817Z"
+      "generatedAt": "2026-03-06T08:20:12.535Z"
     },
     "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3": {
       "address": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
@@ -8987,14 +8005,14 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -9051,14 +8069,14 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -9086,25 +8104,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -9122,25 +8126,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -9171,7 +8161,7 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -9183,7 +8173,7 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -9195,7 +8185,7 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -9207,14 +8197,14 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -9225,22 +8215,8 @@
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -9349,14 +8325,14 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -9413,14 +8389,14 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -9448,25 +8424,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -9484,25 +8446,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -9533,7 +8481,7 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -9545,7 +8493,7 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -9557,7 +8505,7 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -9569,14 +8517,14 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -9587,22 +8535,8 @@
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -9780,25 +8714,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -9816,25 +8736,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -9995,14 +8901,14 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -10059,14 +8965,14 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -10094,25 +9000,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -10130,30 +9022,16 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -10165,7 +9043,7 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -10177,7 +9055,7 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -10189,14 +9067,14 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -10207,22 +9085,8 @@
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -10720,25 +9584,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -10756,25 +9606,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -10792,25 +9628,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -10828,30 +9650,16 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -10877,7 +9685,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -10903,7 +9711,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -10929,7 +9737,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -10965,7 +9773,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -10991,33 +9799,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_534",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_535",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -11069,32 +9851,6 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "kickFromBatch",
           "storageVariable": "activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
@@ -11128,25 +9884,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -11164,25 +9906,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -11301,31 +10029,31 @@
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_159",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_186",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_189",
+          "storageVariable": "_owner",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -11389,7 +10117,7 @@
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_152",
+          "storageVariable": "_owner",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -11428,25 +10156,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -11464,37 +10178,23 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_188",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -11577,31 +10277,31 @@
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_159",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_186",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_189",
+          "storageVariable": "REF_109",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -11665,7 +10365,7 @@
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_152",
+          "storageVariable": "REF_109",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -11704,25 +10404,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -11740,37 +10426,23 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_188",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -11801,7 +10473,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -11827,7 +10499,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -11853,7 +10525,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -11879,7 +10551,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -11915,7 +10587,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -11941,33 +10613,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_534",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_535",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -12019,32 +10665,6 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "removeFromBatch",
           "storageVariable": "activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
@@ -12078,25 +10698,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -12114,25 +10720,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -12267,14 +10859,14 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -12331,14 +10923,14 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -12366,25 +10958,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -12402,25 +10980,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -12451,7 +11015,7 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -12463,7 +11027,7 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -12475,7 +11039,7 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -12487,14 +11051,14 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -12505,22 +11069,8 @@
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -12702,25 +11252,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -12738,25 +11274,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -12988,25 +11510,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -13024,25 +11532,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -13099,7 +11593,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -13125,7 +11619,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -13151,7 +11645,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -13177,7 +11671,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -13213,7 +11707,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -13239,33 +11733,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_534",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_551",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -13324,25 +11792,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -13360,25 +11814,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -13458,25 +11898,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -13494,25 +11920,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -13615,7 +12027,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -13641,7 +12053,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -13667,7 +12079,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -13693,7 +12105,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -13729,7 +12141,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -13755,33 +12167,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_534",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_535",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -13833,32 +12219,6 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
           "storageVariable": "activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
@@ -13892,25 +12252,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -13928,94 +12274,28 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_464",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getLatestTroveData",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_467",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getLatestBatchData",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_513",
+          "storageVariable": "_troveId",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_515",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onSetInterestBatchManager",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -14041,7 +12321,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_526",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "remove",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -14067,7 +12347,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_528",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insertIntoBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -14197,14 +12477,14 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -14261,14 +12541,14 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -14296,25 +12576,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -14332,25 +12598,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -14381,7 +12633,7 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -14393,7 +12645,7 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -14405,7 +12657,7 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -14417,14 +12669,14 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -14435,22 +12687,8 @@
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -14559,14 +12797,14 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -14623,14 +12861,14 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -14658,25 +12896,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -14694,25 +12918,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -14743,7 +12953,7 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -14755,7 +12965,7 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -14767,7 +12977,7 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -14779,14 +12989,14 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -14797,26 +13007,12 @@
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:10.933Z"
+      "generatedAt": "2026-03-06T08:20:12.598Z"
     },
     "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e": {
       "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
@@ -15069,23 +13265,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "contractName": "ActivePool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "contractName": "StabilityPool"
             }
           ],
           "isViewCall": true
@@ -15095,41 +13287,11 @@
           "storageVariable": "WETH",
           "interfaceType": "IWETH",
           "calledFunction": "transferFrom",
-          "resolvedAddress": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
+          "resolvedAddress": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
           "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-              "contractName": "BoldToken"
-            },
-            {
-              "address": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-              "contractName": "WstETH"
-            },
-            {
-              "address": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
-              "contractName": "TroveNFT"
-            },
-            {
-              "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-              "contractName": "RocketTokenRETH"
-            },
-            {
-              "address": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-              "contractName": "Wrapped Ether Token"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -15147,23 +13309,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "contractName": "ActivePool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "contractName": "StabilityPool"
             }
           ],
           "isViewCall": true
@@ -15183,25 +13341,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -15255,25 +13399,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -15291,23 +13421,19 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 70,
           "resolutionCandidates": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "contractName": "ActivePool"
             },
             {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "contractName": "StabilityPool"
             }
           ],
           "isViewCall": true
@@ -15947,11 +14073,11 @@
           "storageVariable": "boldToken",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
+          "resolvedAddress": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
+          "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -15959,11 +14085,11 @@
           "storageVariable": "boldToken",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
-          "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-          "resolvedContractName": "BoldToken",
+          "resolvedAddress": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
+          "resolvedContractName": "TroveNFT",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 90,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -16029,13 +14155,13 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:15.593Z"
+      "generatedAt": "2026-03-06T08:20:12.618Z"
     },
     "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
       "address": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       "name": "Wrapped Ether Token",
       "externalCalls": [],
-      "generatedAt": "2026-03-04T13:46:15.594Z"
+      "generatedAt": "2026-03-06T08:20:12.620Z"
     },
     "eth:0xCC5F8102eb670c89a4a3c567C13851260303c24F": {
       "address": "eth:0xCC5F8102eb670c89a4a3c567C13851260303c24F",
@@ -16043,28 +14169,12 @@
       "externalCalls": [
         {
           "callerFunction": "fetchPrice",
-          "storageVariable": "REF_1313",
+          "storageVariable": "ethUsdOracle",
           "interfaceType": "AggregatorV3Interface",
           "calledFunction": "latestRoundData",
-          "resolvedAddress": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+          "resolvedAddress": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
           "resolvedContractName": "EACAggregatorProxy",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-              "contractName": "EACAggregatorProxy"
-            }
-          ],
+          "resolutionType": "deterministic",
           "isViewCall": true
         },
         {
@@ -16095,28 +14205,12 @@
         },
         {
           "callerFunction": "fetchRedemptionPrice",
-          "storageVariable": "REF_1313",
+          "storageVariable": "ethUsdOracle",
           "interfaceType": "AggregatorV3Interface",
           "calledFunction": "latestRoundData",
-          "resolvedAddress": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+          "resolvedAddress": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
           "resolvedContractName": "EACAggregatorProxy",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-              "contractName": "EACAggregatorProxy"
-            }
-          ],
+          "resolutionType": "deterministic",
           "isViewCall": true
         },
         {
@@ -16146,13 +14240,13 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:16.007Z"
+      "generatedAt": "2026-03-06T08:20:12.633Z"
     },
     "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e": {
       "address": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
       "name": "FixedAssetReader",
       "externalCalls": [],
-      "generatedAt": "2026-03-04T13:46:16.008Z"
+      "generatedAt": "2026-03-06T08:20:12.634Z"
     },
     "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695": {
       "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
@@ -16193,25 +14287,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -16229,25 +14309,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -16321,7 +14387,7 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:16.217Z"
+      "generatedAt": "2026-03-06T08:20:12.647Z"
     },
     "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0": {
       "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
@@ -16332,29 +14398,15 @@
           "storageVariable": "TMP_1087",
           "interfaceType": "IActivePool",
           "calledFunction": "receiveColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:16.321Z"
+      "generatedAt": "2026-03-06T08:20:12.654Z"
     },
     "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1": {
       "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
@@ -16368,26 +14420,12 @@
           "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:16.429Z"
+      "generatedAt": "2026-03-06T08:20:12.665Z"
     },
     "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E": {
       "address": "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E",
@@ -16395,33 +14433,17 @@
       "externalCalls": [
         {
           "callerFunction": "fetchPrice",
-          "storageVariable": "REF_1343",
+          "storageVariable": "stEthUsdOracle",
           "interfaceType": "AggregatorV3Interface",
           "calledFunction": "latestRoundData",
-          "resolvedAddress": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+          "resolvedAddress": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
           "resolvedContractName": "EACAggregatorProxy",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-              "contractName": "EACAggregatorProxy"
-            }
-          ],
+          "resolutionType": "deterministic",
           "isViewCall": true
         },
         {
           "callerFunction": "fetchPrice",
-          "storageVariable": "TMP_2521",
+          "storageVariable": "False",
           "interfaceType": "IWSTETH",
           "calledFunction": "stEthPerToken",
           "resolvedAddress": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
@@ -16429,6 +14451,16 @@
           "resolutionType": "optimistic",
           "resolutionHeuristic": "function-signature",
           "resolutionConfidence": 99,
+          "isViewCall": true
+        },
+        {
+          "callerFunction": "fetchPrice",
+          "storageVariable": "ethUsdOracle",
+          "interfaceType": "AggregatorV3Interface",
+          "calledFunction": "latestRoundData",
+          "resolvedAddress": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+          "resolvedContractName": "EACAggregatorProxy",
+          "resolutionType": "deterministic",
           "isViewCall": true
         },
         {
@@ -16459,33 +14491,17 @@
         },
         {
           "callerFunction": "fetchRedemptionPrice",
-          "storageVariable": "REF_1343",
+          "storageVariable": "stEthUsdOracle",
           "interfaceType": "AggregatorV3Interface",
           "calledFunction": "latestRoundData",
-          "resolvedAddress": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+          "resolvedAddress": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
           "resolvedContractName": "EACAggregatorProxy",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "function-signature",
-          "resolutionConfidence": 30,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
-              "contractName": "EACAggregatorProxy"
-            },
-            {
-              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-              "contractName": "EACAggregatorProxy"
-            }
-          ],
+          "resolutionType": "deterministic",
           "isViewCall": true
         },
         {
           "callerFunction": "fetchRedemptionPrice",
-          "storageVariable": "TMP_2521",
+          "storageVariable": "True",
           "interfaceType": "IWSTETH",
           "calledFunction": "stEthPerToken",
           "resolvedAddress": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
@@ -16493,6 +14509,16 @@
           "resolutionType": "optimistic",
           "resolutionHeuristic": "function-signature",
           "resolutionConfidence": 99,
+          "isViewCall": true
+        },
+        {
+          "callerFunction": "fetchRedemptionPrice",
+          "storageVariable": "ethUsdOracle",
+          "interfaceType": "AggregatorV3Interface",
+          "calledFunction": "latestRoundData",
+          "resolvedAddress": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+          "resolvedContractName": "EACAggregatorProxy",
+          "resolutionType": "deterministic",
           "isViewCall": true
         },
         {
@@ -16522,7 +14548,7 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:17.052Z"
+      "generatedAt": "2026-03-06T08:20:12.675Z"
     },
     "eth:0xe8119fC02953B27a1b48D2573855738485A17329": {
       "address": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
@@ -16634,14 +14660,14 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -16698,14 +14724,14 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -16733,25 +14759,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -16769,25 +14781,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -16818,7 +14816,7 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -16830,7 +14828,7 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -16842,7 +14840,7 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -16854,14 +14852,14 @@
         },
         {
           "callerFunction": "addColl",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -16869,25 +14867,11 @@
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -16996,14 +14980,14 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -17060,14 +15044,14 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -17095,25 +15079,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -17131,25 +15101,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -17180,7 +15136,7 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -17192,7 +15148,7 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -17204,7 +15160,7 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -17216,14 +15172,14 @@
         },
         {
           "callerFunction": "adjustTrove",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -17231,25 +15187,11 @@
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -17427,25 +15369,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -17463,25 +15391,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -17642,14 +15556,14 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -17706,14 +15620,14 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -17741,25 +15655,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -17777,30 +15677,16 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -17812,7 +15698,7 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -17824,7 +15710,7 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -17836,14 +15722,14 @@
         },
         {
           "callerFunction": "adjustZombieTrove",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -17851,25 +15737,11 @@
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -18367,25 +16239,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -18403,25 +16261,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -18439,25 +16283,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -18475,30 +16305,16 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -18524,7 +16340,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -18550,7 +16366,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -18576,7 +16392,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -18612,7 +16428,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -18638,33 +16454,7 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_534",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_535",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -18716,32 +16506,6 @@
         },
         {
           "callerFunction": "kickFromBatch",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "kickFromBatch",
           "storageVariable": "activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
@@ -18775,25 +16539,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -18811,25 +16561,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -18948,31 +16684,31 @@
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_159",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_186",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_189",
+          "storageVariable": "_owner",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -19036,7 +16772,7 @@
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_152",
+          "storageVariable": "_owner",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -19075,25 +16811,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -19111,37 +16833,23 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTrove",
-          "storageVariable": "REF_188",
+          "storageVariable": "_owner",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -19224,31 +16932,31 @@
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_159",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_186",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_189",
+          "storageVariable": "REF_109",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -19312,7 +17020,7 @@
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_152",
+          "storageVariable": "REF_109",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -19351,25 +17059,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -19387,37 +17081,23 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "openTroveAndJoinInterestBatchManager",
-          "storageVariable": "REF_188",
+          "storageVariable": "REF_109",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -19448,7 +17128,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -19474,7 +17154,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -19500,7 +17180,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -19526,7 +17206,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -19562,7 +17242,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -19588,33 +17268,7 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_534",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_535",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -19666,32 +17320,6 @@
         },
         {
           "callerFunction": "removeFromBatch",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "removeFromBatch",
           "storageVariable": "activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
@@ -19725,25 +17353,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -19761,25 +17375,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -19914,14 +17514,14 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -19978,14 +17578,14 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -20013,25 +17613,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -20049,25 +17635,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -20098,7 +17670,7 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -20110,7 +17682,7 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -20122,7 +17694,7 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -20134,14 +17706,14 @@
         },
         {
           "callerFunction": "repayBold",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -20149,25 +17721,11 @@
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -20349,25 +17907,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -20385,25 +17929,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -20635,25 +18165,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -20671,25 +18187,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -20746,7 +18248,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -20772,7 +18274,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -20798,7 +18300,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -20824,7 +18326,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -20860,7 +18362,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -20886,33 +18388,7 @@
         },
         {
           "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_534",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "setInterestIndividualDelegate",
-          "storageVariable": "REF_551",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -20971,25 +18447,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -21007,25 +18469,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -21105,25 +18553,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -21141,25 +18575,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -21262,7 +18682,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_538",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestTroveData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -21288,7 +18708,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_541",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getLatestBatchData",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -21314,7 +18734,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_552",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "removeFromBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -21340,7 +18760,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_554",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insert",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -21376,7 +18796,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_616",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onRemoveFromBatch",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -21402,33 +18822,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_534",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_535",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "getTroveStatus",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -21480,32 +18874,6 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_551",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getTroveStatus",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
           "storageVariable": "activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
@@ -21539,25 +18907,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -21575,94 +18929,28 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_464",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getLatestTroveData",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_467",
-          "interfaceType": "ITroveManager",
-          "calledFunction": "getLatestBatchData",
-          "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-          "resolvedContractName": "TroveManager",
-          "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-              "contractName": "TroveManager"
-            },
-            {
-              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-              "contractName": "TroveManager"
-            }
-          ],
-          "isViewCall": true
-        },
-        {
-          "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_513",
+          "storageVariable": "_troveId",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_515",
+          "storageVariable": "_troveId",
           "interfaceType": "ITroveManager",
           "calledFunction": "onSetInterestBatchManager",
           "resolvedAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -21688,7 +18976,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_526",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "remove",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -21714,7 +19002,7 @@
         },
         {
           "callerFunction": "switchBatchManager",
-          "storageVariable": "REF_528",
+          "storageVariable": "_troveId",
           "interfaceType": "ISortedTroves",
           "calledFunction": "insertIntoBatch",
           "resolvedAddress": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
@@ -21844,14 +19132,14 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -21908,14 +19196,14 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -21943,25 +19231,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -21979,25 +19253,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -22028,7 +19288,7 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -22040,7 +19300,7 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -22052,7 +19312,7 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -22064,14 +19324,14 @@
         },
         {
           "callerFunction": "withdrawBold",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -22079,25 +19339,11 @@
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -22206,14 +19452,14 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_290",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "getNewApproxAvgInterestRateFromTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -22270,14 +19516,14 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_320",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "mintAggInterestAndAccountForTroveChange",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -22305,25 +19551,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getCollBalance",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -22341,25 +19573,11 @@
           "storageVariable": "defaultPool",
           "interfaceType": "IDefaultPool",
           "calledFunction": "getBoldDebt",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-          "resolvedContractName": "DefaultPool",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+          "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": true
         },
         {
@@ -22390,7 +19608,7 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_237",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "balanceOf",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -22402,7 +19620,7 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "mint",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -22414,7 +19632,7 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_322",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IBoldToken",
           "calledFunction": "burn",
           "resolvedAddress": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -22426,14 +19644,14 @@
         },
         {
           "callerFunction": "withdrawColl",
-          "storageVariable": "REF_323",
+          "storageVariable": "troveManagerCached",
           "interfaceType": "IActivePool",
           "calledFunction": "sendColl",
           "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "variable-chain",
-          "resolutionConfidence": 100,
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         },
         {
@@ -22441,29 +19659,15 @@
           "storageVariable": "_activePool",
           "interfaceType": "IActivePool",
           "calledFunction": "accountForReceivedColl",
-          "resolvedAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+          "resolvedAddress": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
           "resolvedContractName": "ActivePool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-              "contractName": "ActivePool"
-            },
-            {
-              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-              "contractName": "ActivePool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:41.675Z"
+      "generatedAt": "2026-03-06T08:20:12.723Z"
     },
     "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE": {
       "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
@@ -22524,35 +19728,21 @@
           "storageVariable": "TMP_1278",
           "interfaceType": "IDefaultPool",
           "calledFunction": "receiveColl",
-          "resolvedAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
+          "resolvedAddress": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
           "resolvedContractName": "DefaultPool",
           "resolutionType": "optimistic",
-          "resolutionHeuristic": "interface-name",
-          "resolutionConfidence": 40,
-          "resolutionCandidates": [
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-              "contractName": "DefaultPool"
-            },
-            {
-              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-              "contractName": "DefaultPool"
-            }
-          ],
+          "resolutionHeuristic": "discovered-values-scan",
+          "resolutionConfidence": 95,
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:41.781Z"
+      "generatedAt": "2026-03-06T08:20:12.732Z"
     },
     "eth:0xf4a3fE99227F6060e4C1c62b557EEE050B6483E4": {
       "address": "eth:0xf4a3fE99227F6060e4C1c62b557EEE050B6483E4",
       "name": "Unknown",
       "externalCalls": [],
-      "generatedAt": "2026-03-04T13:46:43.594Z",
+      "generatedAt": "2026-03-06T08:20:14.526Z",
       "skipped": true,
       "skipReason": "Unverified contract"
     },
@@ -22705,7 +19895,7 @@
           "isViewCall": false
         }
       ],
-      "generatedAt": "2026-03-04T13:46:44.001Z"
+      "generatedAt": "2026-03-06T08:20:14.529Z"
     }
   }
 }

--- a/packages/config/src/projects/liquity-v2/config.jsonc
+++ b/packages/config/src/projects/liquity-v2/config.jsonc
@@ -106,6 +106,21 @@
     },
     "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1": {
       "ignoreRelatives": ["collToken"]
+    },
+    "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0": {
+      "description": "rETH/ETH Chainlink Price Feed"
+    },
+    "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8": {
+      "description": "stETH/USD Price Feed"
+    },
+    "eth:0xae78736Cd615f374D3085123A210448E74Fc6393": {
+      "ignoreInWatchMode": [
+        "getCollateralRate",
+        "getExchangeRate",
+        "getTotalCollateral",
+        "totalSupply"
+      ],
+      "ignoreMethods": ["getEthValue", "getRethValue"]
     }
   }
 }

--- a/packages/config/src/projects/liquity-v2/diffHistory.md
+++ b/packages/config/src/projects/liquity-v2/diffHistory.md
@@ -1,3 +1,75 @@
+Generated with discovered.json: 0x9fcc5159a31b84da9d6d988627b80a2f25d80dc3
+
+# Diff at Fri, 06 Mar 2026 08:47:37 GMT:
+
+- author: emduc (<emilien.duc@gmail.com>)
+- comparing to: main@98630e5ebe9adefa807d3e71ec36dab2eb8594e0 block: 1772629150
+- current timestamp: 1772786748
+
+## Description
+
+Provide description of changes. This section will be preserved.
+
+## Watched changes
+
+```diff
+    contract ActivePool (eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0) {
+    +++ description: None
+      values.aggWeightedBatchManagementFeeSum:
+-        "15224465054459121365746676000000000000000"
++        "26069934540966459620744293000000000000000"
+    }
+```
+
+```diff
+    contract RocketTokenRETH (eth:0xae78736Cd615f374D3085123A210448E74Fc6393) {
+    +++ description: None
+      values.getCollateralRate:
+-        "9684838227955654"
++        "9939385896594708"
+      values.getExchangeRate:
+-        "1158735463711660524"
++        "1158872140378225549"
+      values.getTotalCollateral:
+-        "3865027871669339910088"
++        "3965862867625100873492"
+      values.totalSupply:
+-        "344410164552332742285096"
++        "344304436006420139696216"
+    }
+```
+
+```diff
+    contract ActivePool (eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE) {
+    +++ description: None
+      values.aggWeightedBatchManagementFeeSum:
+-        "eth:0x4671404119147669602431827500000000000000"
++        "eth:0x6048896546837818165748415000000000000000"
+    }
+```
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1772629150 (main branch discovery), not current.
+
+```diff
+    contract EACAggregatorProxy (eth:0x536218f9E9Eb48863970252233c8F271f554C2d0) {
+    +++ description: rETH/ETH Chainlink Price Feed
+      description:
++        "rETH/ETH Chainlink Price Feed"
+    }
+```
+
+```diff
+    contract EACAggregatorProxy (eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8) {
+    +++ description: stETH/USD Price Feed
+      description:
++        "stETH/USD Price Feed"
+    }
+```
+
 Generated with discovered.json: 0xc33e4c7f516c90272a2614b2984ed136b051228f
 
 # Diff at Wed, 04 Mar 2026 13:43:35 GMT:

--- a/packages/config/src/projects/liquity-v2/discovered.json
+++ b/packages/config/src/projects/liquity-v2/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "liquity-v2",
-  "timestamp": 1772629150,
-  "configHash": "0x29b808bd7959f3488a762005ee7649112546eaf8ccb165caa4576335366bd541",
+  "timestamp": 1772786748,
+  "configHash": "0x4be18784a415a8f8ddc930ea959c286fa976c7d5e8e5ae18314ece95f4a72f7e",
   "entries": [
     {
       "address": "eth:0x05724B9C8C1dDE1b2f659d7c0676ff63f6d5E781",
@@ -23,11 +23,11 @@
       "values": {
         "$immutable": true,
         "borrowerOperationsAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-        "getSize": 22,
+        "getSize": 23,
         "isBatchedNode": [false, false, false, false, false],
         "isEmpty": false,
         "NAME": "SortedTroves",
-        "size": 22,
+        "size": 23,
         "troveManager": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e"
       },
       "errors": { "isBatchedNode": "Processing error occurred." },
@@ -94,7 +94,7 @@
         ],
         "multisigThreshold": "4 of 9 (44%)",
         "NAME": "Gnosis Safe",
-        "nonce": 2068,
+        "nonce": 2069,
         "VERSION": "1.1.1"
       },
       "implementationNames": {
@@ -166,7 +166,7 @@
           "stalenessThreshold": 86400,
           "decimals": 8
         },
-        "lastGoodPrice": "2311246032176026938457",
+        "lastGoodPrice": "2409417200087017365389",
         "priceSource": 0,
         "rateProviderAddress": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
         "RETH_ETH_DEVIATION_THRESHOLD": "20000000000000000",
@@ -272,11 +272,6 @@
       "proxyType": "EOA"
     },
     {
-      "address": "eth:0x4671404119147669602431827500000000000000",
-      "type": "EOA",
-      "proxyType": "EOA"
-    },
-    {
       "address": "eth:0x47A1dD4E277530fffb5B5f70A43CCbD542F54e17",
       "type": "EOA",
       "proxyType": "EOA"
@@ -311,23 +306,23 @@
       "sinceBlock": 22516101,
       "values": {
         "$immutable": true,
-        "aggBatchManagementFees": "158940431303364915436",
-        "aggRecordedDebt": "18441681556409172293999092",
-        "aggWeightedBatchManagementFeeSum": "15224465054459121365746676000000000000000",
-        "aggWeightedDebtSum": "280558495348003237072220921108847364452521",
+        "aggBatchManagementFees": "24253833102072888802",
+        "aggRecordedDebt": "18474501476166729192885145",
+        "aggWeightedBatchManagementFeeSum": "26069934540966459620744293000000000000000",
+        "aggWeightedDebtSum": "266772518519245198810723062320085414452521",
         "boldToken": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
         "borrowerOperationsAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
-        "calcPendingAggBatchManagementFee": "163877346826689355097",
-        "calcPendingAggInterest": "128108901985389605970",
-        "calcPendingSPYield": "96081676489042204477",
+        "calcPendingAggBatchManagementFee": "36317363148583793255",
+        "calcPendingAggInterest": "50552783189719980597",
+        "calcPendingSPYield": "37914587392289985447",
         "collToken": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
         "defaultPoolAddress": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-        "getBoldDebt": "18442132483089287737875595",
+        "getBoldDebt": "18474612600146169569547799",
         "getCollBalance": "25100737265460317881161",
         "hasBeenShutDown": false,
         "interestRouter": "eth:0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1",
-        "lastAggBatchManagementFeesUpdateTime": 1772289683,
-        "lastAggUpdateTime": 1772614739,
+        "lastAggBatchManagementFeesUpdateTime": 1772742815,
+        "lastAggUpdateTime": 1772780771,
         "NAME": "ActivePool",
         "shutdownTime": 0,
         "stabilityPool": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
@@ -346,6 +341,7 @@
         "0x056d4c6b4a8b2539822536f963ddff40d7327819b0a088b558d678ba5f38e984"
       ],
       "proxyType": "immutable",
+      "description": "rETH/ETH Chainlink Price Feed",
       "sinceTimestamp": 1677265283,
       "sinceBlock": 16700133,
       "values": {
@@ -391,11 +387,11 @@
         "boldToken": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
         "collToken": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
         "currentScale": 0,
-        "getCollBalance": "64236772726256188432",
-        "getEntireBranchColl": "6006781966669596358390",
-        "getEntireBranchDebt": "6512662800217855475304864",
-        "getTotalBoldDeposits": "7355117164721913533017801",
-        "getYieldGainsOwed": "14146333959475574612099",
+        "getCollBalance": "52704556170177767198",
+        "getEntireBranchColl": "6212245851859853689032",
+        "getEntireBranchDebt": "6992802499919784223778118",
+        "getTotalBoldDeposits": "7408486261720896441453107",
+        "getYieldGainsOwed": "11974102731339046895298",
         "getYieldGainsPending": 0,
         "MAX_SCALE_FACTOR_EXPONENT": 8,
         "NAME": "StabilityPool",
@@ -403,7 +399,7 @@
         "P_PRECISION": "1000000000000000000000000000000000000",
         "SCALE_FACTOR": 1000000000,
         "SCALE_SPAN": 2,
-        "scaleToB": ["93594784897010159892645574907477928", 0, 0, 0, 0],
+        "scaleToB": ["93786945549998462058463459151241629", 0, 0, 0, 0],
         "scaleToS": ["91973646659030210071285211989882", 0, 0, 0, 0],
         "troveManager": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A"
       },
@@ -478,6 +474,11 @@
       }
     },
     {
+      "address": "eth:0x6048896546837818165748415000000000000000",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
       "name": "BoldToken",
       "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
       "type": "Contract",
@@ -506,7 +507,7 @@
         "name": "BOLD Stablecoin",
         "owner": "eth:0x0000000000000000000000000000000000000000",
         "symbol": "BOLD",
-        "totalSupply": "30721468893452507387071518"
+        "totalSupply": "31238266985194192048139156"
       },
       "implementationNames": {
         "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D": "BoldToken"
@@ -564,8 +565,8 @@
         "activePool": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
         "borrowerOperations": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
         "CCR": "1500000000000000000",
-        "getEntireBranchColl": "6006781966669596358390",
-        "getEntireBranchDebt": "6512662800217855475304864",
+        "getEntireBranchColl": "6212245851859853689032",
+        "getEntireBranchDebt": "6992802499919784223778118",
         "getTroveIdsCount": 88,
         "lastZombieTroveId": 0,
         "rewardSnapshots": [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]],
@@ -597,10 +598,10 @@
         "DOMAIN_SEPARATOR": "0xd4a8ff90a402dc7d4fcbf60f5488291263c743ccff180e139f47d139cedfd5fe",
         "name": "Wrapped liquid staked Ether 2.0",
         "stETH": "eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
-        "stEthPerToken": "1228451344976762689",
+        "stEthPerToken": "1228533376527798730",
         "symbol": "wstETH",
-        "tokensPerStEth": "814033053965939480",
-        "totalSupply": "3469329530474778546795132"
+        "tokensPerStEth": "813978699403591193",
+        "totalSupply": "3461763505250939835037862"
       },
       "implementationNames": {
         "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "WstETH"
@@ -630,28 +631,28 @@
       "values": {
         "$immutable": true,
         "bold": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-        "boldAccrued": "10073616005787689554315",
+        "boldAccrued": "9286590099167867732202",
         "calculateVotingThreshold": [0, 0, 0, 0, 0],
-        "epoch": 43,
+        "epoch": 44,
         "EPOCH_DURATION": 604800,
         "EPOCH_START": 1746662400,
         "EPOCH_VOTING_CUTOFF": 518400,
-        "epochStart": 1772064000,
-        "getLatestVotingThreshold": "16708123830712930280513486364216",
+        "epochStart": 1772668800,
+        "getLatestVotingThreshold": "17214917283135436445657314880628",
         "getTotalVotesAndState": {
           "snapshot": {
-            "votes": "835406191535646514025674318210826",
-            "forEpoch": 42
+            "votes": "860745864156771822282865744031448",
+            "forEpoch": 43
           },
           "state": {
-            "countedVoteLQTY": "41896987981287496170658864",
-            "countedVoteOffset": "73408737544246556469563577912211752"
+            "countedVoteLQTY": "41587282472838629175170778",
+            "countedVoteOffset": "72867646787014609855669519958518390"
           },
           "shouldUpdate": false
         },
         "globalState": {
-          "countedVoteLQTY": "41896987981287496170658864",
-          "countedVoteOffset": "73408737544246556469563577912211752"
+          "countedVoteLQTY": "41587282472838629175170778",
+          "countedVoteOffset": "72867646787014609855669519958518390"
         },
         "isOwner": false,
         "lqty": "eth:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
@@ -660,14 +661,14 @@
         "owner": "eth:0x0000000000000000000000000000000000000000",
         "REGISTRATION_FEE": "100000000000000000000",
         "REGISTRATION_THRESHOLD_FACTOR": 100000000000000,
-        "secondsWithinEpoch": 565139,
+        "secondsWithinEpoch": 117947,
         "stakingV1": "eth:0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d",
         "UNREGISTRATION_AFTER_EPOCHS": 4,
         "UNREGISTRATION_THRESHOLD_FACTOR": "1000000000000000001",
         "userProxyImplementation": "eth:0x65f9A98009Aecaa3fc8A3A83FEF44e2b6931A7b2",
         "votesSnapshot": {
-          "votes": "835406191535646514025674318210826",
-          "forEpoch": 42
+          "votes": "860745864156771822282865744031448",
+          "forEpoch": 43
         },
         "VOTING_THRESHOLD_FACTOR": "20000000000000000"
       },
@@ -789,22 +790,22 @@
       "values": {
         "$immutable": true,
         "aggBatchManagementFees": "1845131107383543399",
-        "aggRecordedDebt": "5767298649060496203540977",
+        "aggRecordedDebt": "5770993138442973672728473",
         "aggWeightedBatchManagementFeeSum": "14593442887722890197289245500000000000000",
-        "aggWeightedDebtSum": "168192813986637143079648389598797812681070",
+        "aggWeightedDebtSum": "168274893802236284983416790922635973339750",
         "boldToken": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
         "borrowerOperationsAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-        "calcPendingAggBatchManagementFee": "67419707039514311220",
-        "calcPendingAggInterest": "127360616374964959943",
-        "calcPendingSPYield": "95520462281223719957",
+        "calcPendingAggBatchManagementFee": "140353603115371404010",
+        "calcPendingAggInterest": "13702750104139484394",
+        "calcPendingSPYield": "10277062578104613295",
         "collToken": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
         "defaultPoolAddress": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-        "getBoldDebt": "5767495274515018066355539",
-        "getCollBalance": "5918346373805473016365",
+        "getBoldDebt": "5771149039927300567160276",
+        "getCollBalance": "5919560390951283046710",
         "hasBeenShutDown": false,
         "interestRouter": "eth:0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1",
         "lastAggBatchManagementFeesUpdateTime": 1772483447,
-        "lastAggUpdateTime": 1772605259,
+        "lastAggUpdateTime": 1772784179,
         "NAME": "ActivePool",
         "shutdownTime": 0,
         "stabilityPool": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
@@ -844,9 +845,9 @@
         "currentScale": 0,
         "getCollBalance": "48191851423121521984",
         "getEntireBranchColl": "25100737265460317881161",
-        "getEntireBranchDebt": "18442132483089287737875595",
-        "getTotalBoldDeposits": "10952225283585746611124676",
-        "getYieldGainsOwed": "37362631082360009012748",
+        "getEntireBranchDebt": "18474612600146169569547799",
+        "getTotalBoldDeposits": "10944740651721227009711474",
+        "getYieldGainsOwed": "37680381801852388133684",
         "getYieldGainsPending": 0,
         "MAX_SCALE_FACTOR_EXPONENT": 8,
         "NAME": "StabilityPool",
@@ -854,7 +855,7 @@
         "P_PRECISION": "1000000000000000000000000000000000000",
         "SCALE_FACTOR": 1000000000,
         "SCALE_SPAN": 2,
-        "scaleToB": ["56719197418129694937721751635607054", 0, 0, 0, 0],
+        "scaleToB": ["56856726112554625802798778600040816", 0, 0, 0, 0],
         "scaleToS": ["49484103944342211213589019074888", 0, 0, 0, 0],
         "troveManager": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22"
       },
@@ -935,7 +936,7 @@
         "borrowerOperations": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
         "CCR": "1600000000000000000",
         "getEntireBranchColl": "25100737265460317881161",
-        "getEntireBranchDebt": "18442132483089287737875595",
+        "getEntireBranchDebt": "18474612600146169569547799",
         "getTroveIdsCount": 55,
         "lastZombieTroveId": 0,
         "rewardSnapshots": [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]],
@@ -1046,14 +1047,14 @@
       "values": {
         "$immutable": true,
         "decimals": 18,
-        "getCollateralRate": "9684838227955654",
+        "getCollateralRate": "9939385896594708",
         "getEthValue": [0, 1, 2, 3, 4],
-        "getExchangeRate": "1158735463711660524",
+        "getExchangeRate": "1158872140378225549",
         "getRethValue": [0, 0, 1, 2, 3],
-        "getTotalCollateral": "3865027871669339910088",
+        "getTotalCollateral": "3965862867625100873492",
         "name": "Rocket Pool ETH",
         "symbol": "rETH",
-        "totalSupply": "344410164552332742285096",
+        "totalSupply": "344304436006420139696216",
         "version": 1
       },
       "errors": {
@@ -1087,9 +1088,9 @@
         "activePool": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
         "borrowerOperations": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
         "CCR": "1600000000000000000",
-        "getEntireBranchColl": "5918346373805473016365",
-        "getEntireBranchDebt": "5767495274515018066355539",
-        "getTroveIdsCount": 29,
+        "getEntireBranchColl": "5919560390951283046710",
+        "getEntireBranchDebt": "5771149039927300567160276",
+        "getTroveIdsCount": 30,
         "lastZombieTroveId": 0,
         "rewardSnapshots": [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]],
         "shutdownTime": 0,
@@ -1129,7 +1130,7 @@
         "decimals": 18,
         "name": "Wrapped Ether",
         "symbol": "WETH",
-        "totalSupply": "2058508786538273965537231"
+        "totalSupply": "2116061842208129355384840"
       },
       "implementationNames": {
         "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "WETH9"
@@ -1153,7 +1154,7 @@
           "stalenessThreshold": 86400,
           "decimals": 8
         },
-        "lastGoodPrice": "1978306700000000000000",
+        "lastGoodPrice": "2082886854000000000000",
         "priceSource": 0
       },
       "implementationNames": {
@@ -1187,6 +1188,7 @@
         "0x056d4c6b4a8b2539822536f963ddff40d7327819b0a088b558d678ba5f38e984"
       ],
       "proxyType": "immutable",
+      "description": "stETH/USD Price Feed",
       "sinceTimestamp": 1629828389,
       "sinceBlock": 13089591,
       "values": {
@@ -1232,11 +1234,11 @@
         "boldToken": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
         "collToken": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
         "currentScale": 0,
-        "getCollBalance": "3190945782731810634",
-        "getEntireBranchColl": "5918346373805473016365",
-        "getEntireBranchDebt": "5767495274515018066355539",
-        "getTotalBoldDeposits": "3296741469491296221975431",
-        "getYieldGainsOwed": "5514323585312133931866",
+        "getCollBalance": "3184537313472652318",
+        "getEntireBranchColl": "5919560390951283046710",
+        "getEntireBranchDebt": "5771149039927300567160276",
+        "getTotalBoldDeposits": "3296211240685394240086670",
+        "getYieldGainsOwed": "5325632969745577877651",
         "getYieldGainsPending": 0,
         "MAX_SCALE_FACTOR_EXPONENT": 8,
         "NAME": "StabilityPool",
@@ -1244,7 +1246,7 @@
         "P_PRECISION": "1000000000000000000000000000000000000",
         "SCALE_FACTOR": 1000000000,
         "SCALE_SPAN": 2,
-        "scaleToB": ["49994529099937625523749905685565757", 0, 0, 0, 0],
+        "scaleToB": ["50205788324454708718139191588247662", 0, 0, 0, 0],
         "scaleToS": ["12516419898161033555263713090285", 0, 0, 0, 0],
         "troveManager": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e"
       },
@@ -1321,7 +1323,7 @@
           "stalenessThreshold": 86400,
           "decimals": 8
         },
-        "lastGoodPrice": "2533143181884415775864",
+        "lastGoodPrice": "2562352745395192455507",
         "priceSource": 0,
         "rateProviderAddress": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
         "STETH_USD_DEVIATION_THRESHOLD": "10000000000000000",
@@ -1426,23 +1428,23 @@
       "sinceBlock": 22516081,
       "values": {
         "$immutable": true,
-        "aggBatchManagementFees": "7981236384910263552",
-        "aggRecordedDebt": "6512488687982838889531449",
-        "aggWeightedBatchManagementFeeSum": "eth:0x4671404119147669602431827500000000000000",
-        "aggWeightedDebtSum": "242689652200423571144275731394626738392901",
+        "aggBatchManagementFees": "5152662918575522649",
+        "aggRecordedDebt": "6992772370584489182525538",
+        "aggWeightedBatchManagementFeeSum": "eth:0x6048896546837818165748415000000000000000",
+        "aggWeightedDebtSum": "255405310261666711002283629277339542928893",
         "boldToken": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
         "borrowerOperationsAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
-        "calcPendingAggBatchManagementFee": "3137377576215995757",
-        "calcPendingAggInterest": "162993621055459514106",
-        "calcPendingSPYield": "122245215791594635579",
+        "calcPendingAggBatchManagementFee": "6122551299310729194",
+        "calcPendingAggInterest": "18854121077155000737",
+        "calcPendingSPYield": "14140590807866250552",
         "collToken": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
         "defaultPoolAddress": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
-        "getBoldDebt": "6512662800217855475304864",
-        "getCollBalance": "6006781966669596358390",
+        "getBoldDebt": "6992802499919784223778118",
+        "getCollBalance": "6212245851859853689032",
         "hasBeenShutDown": false,
         "interestRouter": "eth:0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1",
-        "lastAggBatchManagementFeesUpdateTime": 1772607959,
-        "lastAggUpdateTime": 1772607959,
+        "lastAggBatchManagementFeesUpdateTime": 1772754827,
+        "lastAggUpdateTime": 1772784419,
         "NAME": "ActivePool",
         "shutdownTime": 0,
         "stabilityPool": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
@@ -1490,10 +1492,10 @@
         "getRedemptionFeeWithDecay": [0, 0, 0, 0, 0],
         "getRedemptionRate": 5663826765213462,
         "getRedemptionRateForRedeemedAmount": [
-          5059930501641867, 5059930501641867, 5059930501641867,
-          5059930501641867, 5059930501641867
+          5000381769591669, 5000381769591669, 5000381769591669,
+          5000381769591669, 5000381769591669
         ],
-        "getRedemptionRateWithDecay": 5059930501641867,
+        "getRedemptionRateWithDecay": 5000381769591669,
         "getToken": [
           "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
           "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
@@ -2932,6 +2934,6 @@
     "tokens": "0x9cb0edfecd174d91d81f651ad52d7c288ec44b877a0e2f8ad0ff293a553bfe30",
     "tokens/Lido/wstETH": "0xd55ccc93c3f52e654ebbffee9194b0b8a0d974753091db2a43a185679e002e88"
   },
-  "usedBlockNumbers": { "ethereum": 24584247 },
-  "permissionsConfigHash": "0x83530d6e768eda479127bb594b9dd501ffdf1061db58893cf9a7e7112a6250a1"
+  "usedBlockNumbers": { "ethereum": 24597312 },
+  "permissionsConfigHash": "0xacb02b43eacc3e10beb9ee7992bb299fdeed53f1e6fe03b0cd1254a44b513445"
 }

--- a/packages/config/src/projects/liquity-v2/funds-data.json
+++ b/packages/config/src/projects/liquity-v2/funds-data.json
@@ -1,44 +1,44 @@
 {
   "version": "1.0",
-  "lastModified": "2026-03-04T07:52:28.134Z",
+  "lastModified": "2026-03-06T08:48:17.647Z",
   "contracts": {
     "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF": {
-      "lastFetched": "2026-03-04T07:52:21.835Z",
+      "lastFetched": "2026-03-06T08:48:11.326Z",
       "balances": {
         "tokens": [
           {
             "assetAddress": "0x6440f144b7e50d6a8439336510312d2f54beb01d",
             "symbol": "BOLD",
             "name": "BOLD Stablecoin",
-            "balance": "7.369263498681389e+24",
+            "balance": "7.420460364452236e+24",
             "decimals": 18,
-            "usdValue": 7397287.909149106
+            "usdValue": 7441154.779319736
           },
           {
             "assetAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
             "symbol": "WETH",
             "name": "Wrapped Ether",
-            "balance": "64236772726256190000",
+            "balance": "52704556170177765000",
             "decimals": 18,
-            "usdValue": 128751.0483106898
+            "usdValue": 109754.07595102499
           }
         ],
-        "totalUsdValue": 7526038.957459795,
-        "timestamp": "2026-03-04T07:52:22.138Z",
+        "totalUsdValue": 7550908.855270761,
+        "timestamp": "2026-03-06T08:48:12.332Z",
         "source": "debank"
       }
     },
     "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B": {
-      "lastFetched": "2026-03-04T07:52:22.140Z",
+      "lastFetched": "2026-03-06T08:48:12.378Z",
       "balances": {
         "tokens": [
           {
             "assetAddress": "0x6440f144b7e50d6a8439336510312d2f54beb01d",
             "symbol": "BOLD",
             "name": "BOLD Stablecoin",
-            "balance": "1.098953518432676e+25",
+            "balance": "1.0982421033523079e+25",
             "decimals": 18,
-            "usdValue": 11031327.046554254
+            "usdValue": 11013049.157110404
           },
           {
             "assetAddress": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
@@ -46,69 +46,69 @@
             "name": "Wrapped liquid staked Ether 2.0",
             "balance": "48191851423121520000",
             "decimals": 18,
-            "usdValue": 118716.03369697681
+            "usdValue": 123150.97849819224
           }
         ],
-        "totalUsdValue": 11150043.080251232,
-        "timestamp": "2026-03-04T07:52:23.027Z",
+        "totalUsdValue": 11136200.135608597,
+        "timestamp": "2026-03-06T08:48:12.923Z",
         "source": "debank"
       }
     },
     "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695": {
-      "lastFetched": "2026-03-04T07:52:23.028Z",
+      "lastFetched": "2026-03-06T08:48:12.928Z",
       "balances": {
         "tokens": [
           {
             "assetAddress": "0x6440f144b7e50d6a8439336510312d2f54beb01d",
             "symbol": "BOLD",
             "name": "BOLD Stablecoin",
-            "balance": "3.302255793076608e+24",
+            "balance": "3.3015368736551397e+24",
             "decimals": 18,
-            "usdValue": 3314813.8691762257
+            "usdValue": 3310744.304246788
           },
           {
             "assetAddress": "0xae78736cd615f374d3085123a210448e74fc6393",
             "symbol": "rETH",
             "name": "Rocket Pool ETH",
-            "balance": "3190945782731811000",
+            "balance": "3184537313472652300",
             "decimals": 18,
-            "usdValue": 7414.1508850794335
+            "usdValue": 7679.391581231168
           }
         ],
-        "totalUsdValue": 3322228.0200613053,
-        "timestamp": "2026-03-04T07:52:24.024Z",
+        "totalUsdValue": 3318423.695828019,
+        "timestamp": "2026-03-06T08:48:13.716Z",
         "source": "debank"
       }
     },
     "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE": {
-      "lastFetched": "2026-03-04T07:52:24.025Z",
+      "lastFetched": "2026-03-06T08:48:13.719Z",
       "balances": {
         "tokens": [
           {
             "assetAddress": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
             "symbol": "WETH",
             "name": "Wrapped Ether",
-            "balance": "6.006781966669596e+21",
+            "balance": "6.212245851859854e+21",
             "decimals": 18,
-            "usdValue": 12039453.163615538
+            "usdValue": 12936629.251747033
           }
         ],
-        "totalUsdValue": 12039453.163615538,
-        "timestamp": "2026-03-04T07:52:25.153Z",
+        "totalUsdValue": 12936629.251747033,
+        "timestamp": "2026-03-06T08:48:14.926Z",
         "source": "debank"
       }
     },
     "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0": {
-      "lastFetched": "2026-03-04T07:52:25.154Z",
+      "lastFetched": "2026-03-06T08:48:14.930Z",
       "balances": {
         "tokens": [
           {
             "assetAddress": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
             "symbol": "wstETH",
             "name": "Wrapped liquid staked Ether 2.0",
-            "balance": "2.508269191661454e+22",
+            "balance": "2.5100737265460316e+22",
             "decimals": 18,
-            "usdValue": 61788821.364000306
+            "usdValue": 64143216.414889336
           },
           {
             "assetAddress": "0xa27493b888d123482853912e705c796d83faa1a4",
@@ -119,22 +119,22 @@
             "usdValue": 0
           }
         ],
-        "totalUsdValue": 61788821.364000306,
-        "timestamp": "2026-03-04T07:52:26.166Z",
+        "totalUsdValue": 64143216.414889336,
+        "timestamp": "2026-03-06T08:48:15.889Z",
         "source": "debank"
       }
     },
     "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F": {
-      "lastFetched": "2026-03-04T07:52:26.167Z",
+      "lastFetched": "2026-03-06T08:48:15.892Z",
       "balances": {
         "tokens": [
           {
             "assetAddress": "0xae78736cd615f374d3085123a210448e74fc6393",
             "symbol": "rETH",
             "name": "Rocket Pool ETH",
-            "balance": "5.918346373805473e+21",
+            "balance": "5.919560390951283e+21",
             "decimals": 18,
-            "usdValue": 13751256.20843068
+            "usdValue": 14274796.542198261
           },
           {
             "assetAddress": "0xbaa70614c7aafb568a93e62a98d55696bcc85dfe",
@@ -145,21 +145,21 @@
             "usdValue": 0
           }
         ],
-        "totalUsdValue": 13751256.20843068,
-        "timestamp": "2026-03-04T07:52:27.155Z",
+        "totalUsdValue": 14274796.542198261,
+        "timestamp": "2026-03-06T08:48:16.923Z",
         "source": "debank"
       }
     },
     "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D": {
-      "lastFetched": "2026-03-04T07:52:27.156Z",
+      "lastFetched": "2026-03-06T08:48:16.926Z",
       "tokenInfo": {
         "symbol": "BOLD",
         "name": "BOLD Stablecoin",
         "decimals": 18,
-        "price": 1.0038028780586732,
-        "totalSupply": "30728770193970129332264404",
-        "tokenValue": 30845627.959910788,
-        "timestamp": "2026-03-04T07:52:28.134Z",
+        "price": 1.002788831669614,
+        "totalSupply": "31238266985194192048139156",
+        "tokenValue": 31325385.25346636,
+        "timestamp": "2026-03-06T08:48:17.646Z",
         "source": "debank"
       }
     }

--- a/packages/config/src/projects/liquity-v2/review-config.json
+++ b/packages/config/src/projects/liquity-v2/review-config.json
@@ -1,92 +1,92 @@
 {
   "version": "1.0",
-  "lastModified": "2026-03-04T14:06:02.873Z",
+  "lastModified": "2026-03-06T12:00:00.000Z",
   "protocolSlug": "liquity-v2",
   "protocolName": "Liquity V2",
   "tokenName": "BOLD",
   "chain": "Ethereum",
   "projectType": "cdp",
-  "description": "Liquity V2 is a multi-collateral CDP protocol that issues BOLD, a USD-soft-pegged stablecoin, against WETH, wstETH, and rETH collateral across three independent branches, with {{totalCapitalAtRisk}} held across the protocol's collateral and stability pools. Borrowers open Troves — each represented as a transferable NFT — and pay market-determined interest rates set individually or delegated to batch managers, replacing the fixed-fee model of Liquity V1. All 44 contracts are immutable with no upgradeable proxies, ownership was renounced to the zero address after initialization, and no administrative keys exist post-deployment. The protocol relies on Chainlink price feeds (ETH/USD, stETH/USD, rETH/ETH) as the primary price source, with on-chain exchange rate queries from the wstETH and rETH token contracts as secondary inputs; oracle failure beyond the fallback timeout triggers branch-level shutdown.",
+  "description": "Liquity V2 is a multi-collateral borrowing protocol that lets users deposit WETH, wstETH, or rETH as collateral to mint BOLD, a USD-pegged stablecoin. All 44 contracts are immutable with no admin keys, timelocks, or governance — every permissioned function is restricted to internal contract-to-contract calls, making the protocol fully autonomous once deployed. The system relies on three Chainlink price feeds for collateral valuation and on Lido's wstETH and RocketPool's rETH exchange rate contracts for LST pricing, with {{totalCapitalAtRisk}} in total capital across its collateral pools.",
   "admins": {
     "eth:0xa741a32f9dcfe6adba088fd0f97e90742d7d5da3": {
-      "name": "wstETH Branch BorrowerOperations",
-      "description": "Internal protocol contract — not a human-controlled admin. BorrowerOperations is the exclusive caller permitted to execute sendColl, receiveColl, accountForReceivedColl, and mintAggInterest functions on the wstETH branch collateral pools, and is the entry point for all Trove operations. All ownership chain terminals resolve to immutable Liquity V2 contracts with no external keyholder. Authorized access spans {{borrowerOpsDirectCapital}} in direct capital across 21 contracts."
+      "name": "BorrowerOperations (wstETH branch)",
+      "description": "Internal protocol contract that gates user-facing operations for the wstETH collateral branch. Controls 37 permissioned functions across 24 contracts including collateral transfers in ActivePool, interest minting, trove management in SortedTroves, and branch shutdown. This is not a human admin — it enforces protocol logic for opening, adjusting, and closing troves."
     },
     "eth:0xa2895d6a3bf110561dfe4b71ca539d84e1928b22": {
-      "name": "wstETH Branch TroveManager",
-      "description": "Internal protocol contract. TroveManager is authorized to call sendCollToDefaultPool, mintAggInterestAndAccountForTroveChange, mintBatchManagementFeeAndAccountForChange, and setShutdownFlag on the wstETH ActivePool, and drives SortedTroves remove and removeFromBatch operations during liquidations. Authorized access spans {{wstethTroveManagerDirectCapital}} in direct capital across 10 contracts."
+      "name": "TroveManager (wstETH branch)",
+      "description": "Internal protocol contract that manages trove lifecycle for the wstETH branch. Controls 24 permissioned functions across 10 contracts including collateral redistribution to DefaultPool, batch management fee minting, branch shutdown flag, and StabilityPool offset (liquidation debt cancellation). All calls are protocol-internal with no external admin."
     },
     "eth:0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b": {
-      "name": "wstETH Branch StabilityPool",
-      "description": "Internal protocol contract. The wstETH StabilityPool is authorized to call sendColl and mintAggInterest on the wstETH ActivePool, enabling BOLD liquidation offsets and interest distribution to stability depositors. Holds {{wstethStabilityPoolBalance}} in BOLD deposits and wstETH liquidation proceeds."
+      "name": "StabilityPool (wstETH branch)",
+      "description": "Internal protocol contract that manages the wstETH Stability Pool. Controls 6 permissioned functions across 7 contracts, primarily collateral transfers from ActivePool and interest minting. Acts as a caller for ActivePool.sendColl and ActivePool.mintAggInterest during liquidation processing."
     },
     "eth:0xd796e1648526400386cc4d12fa05e5f11e6a22a1": {
-      "name": "wstETH Branch DefaultPool",
-      "description": "Internal protocol contract. DefaultPool is authorized to call receiveColl and accountForReceivedColl on the wstETH ActivePool, handling collateral accounting during redistribution liquidations where bad debt and collateral are socialized across surviving trove holders. Authorized access spans {{defaultPoolDirectCapital}} in direct capital."
+      "name": "DefaultPool (rETH branch)",
+      "description": "Internal protocol contract that holds redistributed collateral for the rETH branch. Controls 6 permissioned functions across 3 contracts, primarily receiving collateral from ActivePool during redistributions and sending it back. All calls are protocol-internal."
     },
     "eth:0x9074d72cc82dad1e13e454755aa8f144c479532f": {
-      "name": "rETH Branch ActivePool",
-      "description": "Internal protocol contract. The rETH ActivePool is authorized to call receiveColl on its DefaultPool and triggerBoldRewards on the rETH StabilityPool, coordinating redistribution accounting and interest distribution to depositors. Holds {{rethActivePoolBalance}} in rETH collateral, and its authorized-caller set is fixed at deployment."
+      "name": "ActivePool (rETH branch)",
+      "description": "Internal protocol contract that holds rETH collateral. Controls 5 permissioned functions across 5 contracts, gating collateral receipt from DefaultPool and BorrowerOperations. Holds {{rethActivePoolBalance}} in rETH collateral."
     },
     "eth:0xe8119fc02953b27a1b48d2573855738485a17329": {
-      "name": "rETH Branch BorrowerOperations",
-      "description": "Internal protocol contract. The rETH branch BorrowerOperations is authorized to call insert, remove, reInsert, insertIntoBatch, removeFromBatch, and reInsertBatch on the rETH SortedTroves, maintaining the sorted-by-interest-rate linked list used for batch management and redemptions. SortedTroves holds no collateral, so direct capital exposure is zero."
+      "name": "BorrowerOperations (rETH branch)",
+      "description": "Internal protocol contract that gates user-facing operations for the rETH collateral branch. Controls 18 permissioned functions across 6 contracts, mirroring the wstETH BorrowerOperations for rETH-collateralized troves. No capital directly at risk in this branch's pools as measured."
     },
     "eth:0xb2b2abeb5c357a234363ff5d180912d319e3e19e": {
-      "name": "rETH Branch TroveManager",
-      "description": "Internal protocol contract. The rETH TroveManager is authorized to call remove and removeFromBatch on its SortedTroves, collateral accounting functions on its DefaultPool, and offset on the rETH StabilityPool during liquidations. Authorized access spans {{rethTroveManagerDirectCapital}} in direct capital across 8 contracts."
+      "name": "TroveManager (rETH branch)",
+      "description": "Internal protocol contract that manages trove lifecycle for the rETH branch. Controls 8 permissioned functions across 8 contracts including collateral redistribution, shutdown flags, and StabilityPool offsets."
     }
   },
   "dependencies": {
     "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419": {
       "name": "Chainlink ETH/USD Price Feed",
-      "description": "Chainlink EACAggregatorProxy supplying the ETH/USD spot price used by WETHPriceFeed for WETH collateral valuation. An oracle outage lasting beyond the fallback timeout causes the WETH branch to enter shutdown mode, halting new borrows and redemptions. The aggregator address can be updated by a Chainlink-operated 4/9 multisig."
-    },
-    "eth:0x536218f9e9eb48863970252233c8f271f554c2d0": {
-      "name": "Chainlink stETH/USD Price Feed",
-      "description": "Chainlink EACAggregatorProxy used by WSTETHPriceFeed as a price input for wstETH collateral valuation, combined with the on-chain stETH/wstETH exchange rate from the Lido contract. 29 borrowing and interest rate management functions in the wstETH branch depend on this feed being live and accurate."
+      "description": "Chainlink EACAggregatorProxy providing the ETH/USD price. Used by all three collateral branches via their respective PriceFeed contracts — impacts 30 functions including openTrove, adjustTroveInterestRate, shutdown, and liquidation operations across BorrowerOperations and TroveManager contracts. Owned by a Chainlink 4/9 multisig."
     },
     "eth:0xcfe54b5cd566ab89272946f602d76ea879cab4a8": {
+      "name": "Chainlink stETH/USD Price Feed",
+      "description": "Chainlink EACAggregatorProxy providing the stETH/USD price, used by the WSTETHPriceFeed contract to value wstETH collateral. Impacts 10 functions in the wstETH BorrowerOperations branch."
+    },
+    "eth:0x536218f9e9eb48863970252233c8f271f554c2d0": {
       "name": "Chainlink rETH/ETH Price Feed",
-      "description": "Chainlink EACAggregatorProxy providing rETH/ETH price data used by RETHPriceFeed alongside the Rocket Pool on-chain exchange rate to compute rETH collateral value. Failure of this feed triggers rETH branch shutdown after the fallback timeout."
+      "description": "Chainlink EACAggregatorProxy providing the rETH/ETH exchange rate, used by the RETHPriceFeed contract to value rETH collateral. Impacts 9 functions in the rETH BorrowerOperations branch."
     },
     "eth:0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0": {
-      "name": "Lido wstETH",
-      "description": "Lido's wrapped staked ETH token, queried by WSTETHPriceFeed for the current stETH/wstETH exchange rate as a component in collateral pricing. A sustained stETH depeg or Lido systemic failure would directly affect collateral ratios in the wstETH branch and could trigger mass liquidations."
+      "name": "Lido wstETH Token",
+      "description": "Lido's wrapped staked ETH token contract, used by the WSTETHPriceFeed for the wstETH/stETH exchange rate via stEthPerToken(). Impacts 10 functions in the wstETH collateral branch. The largest collateral pool holds {{wstethActivePoolBalance}} in wstETH."
     },
     "eth:0xae78736cd615f374d3085123a210448e74fc6393": {
-      "name": "Rocket Pool rETH",
-      "description": "Rocket Pool's liquid staking token, queried by RETHPriceFeed for the rETH/ETH exchange rate as a component in collateral pricing. A depeg or liquidity disruption in the rETH market would affect collateral valuations in the rETH branch."
+      "name": "RocketPool rETH Token",
+      "description": "RocketPool's liquid staking token contract, used by the RETHPriceFeed for the rETH/ETH exchange rate via getExchangeRate(). Impacts 9 functions in the rETH collateral branch."
     }
   },
   "funds": {
     "eth:0x531a8f99c70d6a56a7cee02d6b4281650d7919a0": {
-      "name": "ActivePool (wstETH branch)",
-      "description": "Holds {{wstethActivePoolBalance}} in wstETH collateral deposited by wstETH-branch borrowers as backing for their BOLD debt. The largest collateral pool in the protocol; collateral moves to DefaultPool during redistribution liquidations and returns to borrowers on full repayment."
-    },
-    "eth:0xeb5a8c825582965f1d84606e078620a84ab16afe": {
-      "name": "ActivePool (WETH branch)",
-      "description": "Holds {{wethActivePoolBalance}} in WETH collateral deposited by WETH-branch borrowers. Collateral is transferred to BorrowerOperations on withdrawals, to DefaultPool during redistributions, and to the StabilityPool during offset liquidations."
+      "name": "ActivePool (wstETH)",
+      "description": "Main collateral pool for the wstETH branch, holding {{wstethActivePoolBalance}} in wstETH deposited by borrowers. The largest single pool in the protocol."
     },
     "eth:0x9074d72cc82dad1e13e454755aa8f144c479532f": {
-      "name": "ActivePool (rETH branch)",
-      "description": "Holds {{rethActivePoolBalance}} in rETH collateral deposited by rETH-branch borrowers. rETH accrues ETH staking rewards over time, so the collateral value changes independently of ETH spot price movements."
+      "name": "ActivePool (rETH)",
+      "description": "Main collateral pool for the rETH branch, holding {{rethActivePoolBalance}} in rETH deposited by borrowers."
+    },
+    "eth:0xeb5a8c825582965f1d84606e078620a84ab16afe": {
+      "name": "ActivePool (WETH)",
+      "description": "Main collateral pool for the WETH branch, holding {{wethActivePoolBalance}} in wrapped Ether deposited by borrowers."
     },
     "eth:0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b": {
-      "name": "StabilityPool (wstETH branch)",
-      "description": "Holds {{wstethStabilityPoolBalance}} in BOLD deposits and wstETH liquidation proceeds. Depositors absorb liquidated wstETH-branch troves by canceling BOLD against bad debt and receive the liquidated wstETH collateral at a discount."
+      "name": "StabilityPool (wstETH)",
+      "description": "Stability pool for the wstETH branch, holding {{wstethStabilityPoolBalance}} in BOLD deposits and wstETH liquidation gains from borrowers."
     },
     "eth:0x5721cbbd64fc7ae3ef44a0a3f9a790a9264cf9bf": {
-      "name": "StabilityPool (WETH branch)",
-      "description": "Holds {{wethStabilityPoolBalance}} in BOLD deposits and WETH liquidation proceeds. Provides the primary liquidation backstop for the WETH branch; depositors earn liquidated WETH collateral and BOLD rewards from branch interest accrual."
+      "name": "StabilityPool (WETH)",
+      "description": "Stability pool for the WETH branch, holding {{wethStabilityPoolBalance}} in BOLD deposits and WETH liquidation gains."
     },
     "eth:0xd442e41019b7f5c4dd78f50dc03726c446148695": {
-      "name": "StabilityPool (rETH branch)",
-      "description": "Holds {{rethStabilityPoolBalance}} in BOLD deposits and rETH liquidation proceeds. Provides the primary liquidation backstop for the rETH branch; depositors earn liquidated rETH collateral and BOLD rewards from branch interest accrual."
+      "name": "StabilityPool (rETH)",
+      "description": "Stability pool for the rETH branch, holding {{rethStabilityPoolBalance}} in BOLD deposits and rETH liquidation gains."
     },
     "eth:0x6440f144b7e50d6a8439336510312d2f54beb01d": {
       "name": "BOLD Stablecoin",
-      "description": "Protocol-native stablecoin with a circulating market cap of {{boldMarketCap}}. Minted when borrowers open Troves and burned on repayment or redemption. Token ownership was renounced to the zero address after the CollateralRegistry address was set; all subsequent minting and burning is exclusively controlled by the immutable branch contracts."
+      "description": "The protocol's native stablecoin token contract with a market cap of {{boldMarketCap}}. Ownership was renounced to the zero address after initialization — setBranchAddresses and setCollateralRegistry can no longer be called."
     }
   },
   "sections": {
@@ -101,34 +101,18 @@
               "type": "dataTable",
               "dataSource": "project.contracts",
               "columns": [
-                {
-                  "field": "name",
-                  "header": "Name"
-                },
-                {
-                  "field": "address",
-                  "header": "Address",
-                  "format": "address"
-                },
-                {
-                  "field": "proxyType",
-                  "header": "Proxy Type",
-                  "format": "badge"
-                }
+                { "field": "name", "header": "Name" },
+                { "field": "address", "header": "Address", "format": "address" },
+                { "field": "proxyType", "header": "Proxy Type", "format": "badge" }
               ],
-              "filters": {
-                "excludeExternal": true
-              }
+              "filters": { "excludeExternal": true }
             }
           ]
         },
         {
           "title": "Audits",
           "content": [
-            {
-              "type": "text",
-              "content": ""
-            }
+            { "type": "text", "content": "" }
           ]
         }
       ]
@@ -136,16 +120,12 @@
   },
   "dataKeys": {
     "totalCapitalAtRisk": "v2score.inventory.admins.totalCapitalAtRisk",
-    "borrowerOpsDirectCapital": "v2score.inventory.admins.breakdown[\"eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3\"].totalDirectCapital",
-    "wstethTroveManagerDirectCapital": "v2score.inventory.admins.breakdown[\"eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22\"].totalDirectCapital",
-    "defaultPoolDirectCapital": "v2score.inventory.admins.breakdown[\"eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1\"].totalDirectCapital",
-    "rethTroveManagerDirectCapital": "v2score.inventory.admins.breakdown[\"eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e\"].totalDirectCapital",
-    "wstethActivePoolBalance": "fundsdata.contracts[\"eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0\"].balances.totalUsdValue",
-    "wethActivePoolBalance": "fundsdata.contracts[\"eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE\"].balances.totalUsdValue",
-    "rethActivePoolBalance": "fundsdata.contracts[\"eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F\"].balances.totalUsdValue",
-    "wstethStabilityPoolBalance": "fundsdata.contracts[\"eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B\"].balances.totalUsdValue",
-    "wethStabilityPoolBalance": "fundsdata.contracts[\"eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF\"].balances.totalUsdValue",
-    "rethStabilityPoolBalance": "fundsdata.contracts[\"eth:0xd442E41019B7F5C4dD78F50dc03726C446148695\"].balances.totalUsdValue",
-    "boldMarketCap": "fundsdata.contracts[\"eth:0x6440f144b7e50D6a8439336510312d2F54beB01D\"].tokenInfo.tokenValue"
+    "wstethActivePoolBalance": "fundsdata.contracts[\"eth:0x531a8f99c70d6a56a7cee02d6b4281650d7919a0\"].balances.totalUsdValue",
+    "rethActivePoolBalance": "fundsdata.contracts[\"eth:0x9074d72cc82dad1e13e454755aa8f144c479532f\"].balances.totalUsdValue",
+    "wethActivePoolBalance": "fundsdata.contracts[\"eth:0xeb5a8c825582965f1d84606e078620a84ab16afe\"].balances.totalUsdValue",
+    "wstethStabilityPoolBalance": "fundsdata.contracts[\"eth:0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b\"].balances.totalUsdValue",
+    "wethStabilityPoolBalance": "fundsdata.contracts[\"eth:0x5721cbbd64fc7ae3ef44a0a3f9a790a9264cf9bf\"].balances.totalUsdValue",
+    "rethStabilityPoolBalance": "fundsdata.contracts[\"eth:0xd442e41019b7f5c4dd78f50dc03726c446148695\"].balances.totalUsdValue",
+    "boldMarketCap": "fundsdata.contracts[\"eth:0x6440f144b7e50d6a8439336510312d2f54beb01d\"].tokenInfo.tokenValue"
   }
 }

--- a/packages/config/src/projects/liquity-v2/review-config.json
+++ b/packages/config/src/projects/liquity-v2/review-config.json
@@ -21,8 +21,8 @@
       "description": "Internal protocol contract that manages the wstETH Stability Pool. Controls 6 permissioned functions across 7 contracts, primarily collateral transfers from ActivePool and interest minting. Acts as a caller for ActivePool.sendColl and ActivePool.mintAggInterest during liquidation processing."
     },
     "eth:0xd796e1648526400386cc4d12fa05e5f11e6a22a1": {
-      "name": "DefaultPool (rETH branch)",
-      "description": "Internal protocol contract that holds redistributed collateral for the rETH branch. Controls 6 permissioned functions across 3 contracts, primarily receiving collateral from ActivePool during redistributions and sending it back. All calls are protocol-internal."
+      "name": "DefaultPool (wstETH branch)",
+      "description": "Internal protocol contract that holds redistributed collateral for the wstETH branch. Controls 6 permissioned functions across 3 contracts, primarily receiving collateral from ActivePool during redistributions and sending it back. All calls are protocol-internal."
     },
     "eth:0x9074d72cc82dad1e13e454755aa8f144c479532f": {
       "name": "ActivePool (rETH branch)",

--- a/packages/defiscan-frontend/public/data/index.json
+++ b/packages/defiscan-frontend/public/data/index.json
@@ -53,8 +53,20 @@
       ]
     },
     {
-      "address": "eth:0x536218f9e9eb48863970252233c8f271f554c2d0",
-      "name": "Chainlink stETH/USD Price Feed",
+      "address": "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+      "name": "Chainlink ETH/USD Price Feed",
+      "entity": "Chainlink",
+      "totalFundsAtRisk": 87579530.73604652,
+      "protocols": [
+        {
+          "slug": "liquity-v2",
+          "name": "Liquity V2"
+        }
+      ]
+    },
+    {
+      "address": "eth:0xcfe54b5cd566ab89272946f602d76ea879cab4a8",
+      "name": "Chainlink rETH/ETH Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 87579530.73604652,
       "protocols": [
@@ -68,6 +80,18 @@
       "address": "eth:0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
       "name": "Lido wstETH",
       "entity": "Lido",
+      "totalFundsAtRisk": 87579530.73604652,
+      "protocols": [
+        {
+          "slug": "liquity-v2",
+          "name": "Liquity V2"
+        }
+      ]
+    },
+    {
+      "address": "eth:0x536218f9e9eb48863970252233c8f271f554c2d0",
+      "name": "Chainlink stETH/USD Price Feed",
+      "entity": "Chainlink",
       "totalFundsAtRisk": 87579530.73604652,
       "protocols": [
         {
@@ -169,18 +193,6 @@
         {
           "slug": "Steakhouse-USDC",
           "name": "Steakhouse USDC"
-        }
-      ]
-    },
-    {
-      "address": "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
-      "name": "Chainlink ETH/USD Price Feed",
-      "entity": "Chainlink",
-      "totalFundsAtRisk": 0,
-      "protocols": [
-        {
-          "slug": "liquity-v2",
-          "name": "Liquity V2"
         }
       ]
     }

--- a/packages/defiscan-frontend/public/data/liquity-v2/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/liquity-v2/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-04T16:25:41.869Z",
+  "compiledAt": "2026-03-06T08:48:19.890Z",
   "project": "liquity-v2",
   "metadata": {
     "protocolName": "Liquity V2",
@@ -8,22 +8,22 @@
     "chain": "Ethereum",
     "projectType": "cdp",
     "tokenName": "BOLD",
-    "description": "Liquity V2 is a multi-collateral CDP protocol that issues BOLD, a USD-soft-pegged stablecoin, against WETH, wstETH, and rETH collateral across three independent branches, with $102.05M held across the protocol's collateral and stability pools. Borrowers open Troves — each represented as a transferable NFT — and pay market-determined interest rates set individually or delegated to batch managers, replacing the fixed-fee model of Liquity V1. All 44 contracts are immutable with no upgradeable proxies, ownership was renounced to the zero address after initialization, and no administrative keys exist post-deployment. The protocol relies on Chainlink price feeds (ETH/USD, stETH/USD, rETH/ETH) as the primary price source, with on-chain exchange rate queries from the wstETH and rETH token contracts as secondary inputs; oracle failure beyond the fallback timeout triggers branch-level shutdown."
+    "description": "Liquity V2 is a multi-collateral borrowing protocol that lets users deposit WETH, wstETH, or rETH as collateral to mint BOLD, a USD-pegged stablecoin. All 44 contracts are immutable with no admin keys, timelocks, or governance — every permissioned function is restricted to internal contract-to-contract calls, making the protocol fully autonomous once deployed. The system relies on three Chainlink price feeds for collateral valuation and on Lido's wstETH and RocketPool's rETH exchange rate contracts for LST pricing, with $105.81M in total capital across its collateral pools."
   },
   "totals": {
     "contractCount": 44,
     "permissionedFunctionCount": 115,
     "scoredFunctionCount": 17,
     "adminCount": 7,
-    "dependencyCount": 4,
-    "totalCapitalAtRisk": 102051801.83635905,
+    "dependencyCount": 5,
+    "totalCapitalAtRisk": 105809266.04027124,
     "totalTokenValueAtRisk": 0
   },
   "admins": [
     {
       "address": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
-      "name": "wstETH Branch BorrowerOperations",
-      "description": "Internal protocol contract — not a human-controlled admin. BorrowerOperations is the exclusive caller permitted to execute sendColl, receiveColl, accountForReceivedColl, and mintAggInterest functions on the wstETH branch collateral pools, and is the entry point for all Trove operations. All ownership chain terminals resolve to immutable Liquity V2 contracts with no external keyholder. Authorized access spans $87.58M in direct capital across 21 contracts.",
+      "name": "BorrowerOperations (wstETH branch)",
+      "description": "Internal protocol contract that gates user-facing operations for the wstETH collateral branch. Controls 37 permissioned functions across 24 contracts including collateral transfers in ActivePool, interest minting, trove management in SortedTroves, and branch shutdown. This is not a human admin — it enforces protocol logic for opening, adjusting, and closing troves.",
       "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
@@ -32,7 +32,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -41,7 +41,7 @@
           "contractName": "ActivePool",
           "functionName": "receiveColl",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -50,7 +50,7 @@
           "contractName": "ActivePool",
           "functionName": "accountForReceivedColl",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -59,7 +59,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterestAndAccountForTroveChange",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -70,7 +70,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -80,7 +80,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -91,7 +91,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterest",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -102,7 +102,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -112,7 +112,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -123,7 +123,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -132,7 +132,7 @@
           "contractName": "ActivePool",
           "functionName": "receiveColl",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -141,7 +141,7 @@
           "contractName": "ActivePool",
           "functionName": "accountForReceivedColl",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -150,7 +150,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterestAndAccountForTroveChange",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -161,7 +161,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -171,7 +171,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 3322228.0200613053,
+              "fundsUsd": 3318423.695828019,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -182,7 +182,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterest",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -193,7 +193,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -203,7 +203,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 3322228.0200613053,
+              "fundsUsd": 3318423.695828019,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -214,7 +214,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -223,7 +223,7 @@
           "contractName": "ActivePool",
           "functionName": "receiveColl",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -232,7 +232,7 @@
           "contractName": "ActivePool",
           "functionName": "accountForReceivedColl",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -241,7 +241,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterestAndAccountForTroveChange",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -252,7 +252,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -262,7 +262,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -273,7 +273,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterest",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -284,7 +284,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -294,7 +294,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -315,7 +315,6 @@
               "calledFunctions": [
                 "onOpenTrove",
                 "getTroveStatus",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -344,7 +343,7 @@
                 "getBoldDebt",
                 "accountForReceivedColl"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -356,7 +355,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -383,12 +382,11 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "name": "DefaultPool",
-              "viewOnlyPath": true,
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
               "calledFunctions": [
-                "getCollBalance",
-                "getBoldDebt"
+                "getTroveAnnualInterestRate"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -401,12 +399,12 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -422,6 +420,17 @@
               "viewOnlyPath": false,
               "calledFunctions": [
                 "stEthPerToken"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              "name": "EACAggregatorProxy",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "latestRoundData"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -446,7 +455,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -457,7 +466,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -479,7 +488,6 @@
                 "getLatestBatchData",
                 "onOpenTroveAndJoinBatch",
                 "getTroveStatus",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -508,7 +516,7 @@
                 "getBoldDebt",
                 "accountForReceivedColl"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -520,7 +528,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -547,12 +555,11 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "name": "DefaultPool",
-              "viewOnlyPath": true,
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
               "calledFunctions": [
-                "getCollBalance",
-                "getBoldDebt"
+                "getTroveAnnualInterestRate"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -565,12 +572,12 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -586,6 +593,17 @@
               "viewOnlyPath": false,
               "calledFunctions": [
                 "stEthPerToken"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              "name": "EACAggregatorProxy",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "latestRoundData"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -610,7 +628,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -621,7 +639,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -675,7 +693,7 @@
               "calledFunctions": [
                 "mintAggInterestAndAccountForTroveChange"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -687,7 +705,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -697,7 +715,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -718,7 +736,6 @@
               "calledFunctions": [
                 "getLatestBatchData",
                 "onSetBatchManagerAnnualInterestRate",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -735,7 +752,7 @@
                 "getCollBalance",
                 "getBoldDebt"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -763,18 +780,6 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "name": "DefaultPool",
-              "viewOnlyPath": true,
-              "calledFunctions": [
-                "getCollBalance",
-                "getBoldDebt"
-              ],
-              "fundsUsd": 0,
-              "tokenValueUsd": 0,
-              "fundsAtRisk": false
-            },
-            {
               "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
               "name": "BoldToken",
               "viewOnlyPath": false,
@@ -782,7 +787,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -792,12 +797,23 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTroveAnnualInterestRate"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -813,6 +829,17 @@
               "viewOnlyPath": false,
               "calledFunctions": [
                 "stEthPerToken"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              "name": "EACAggregatorProxy",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "latestRoundData"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -837,7 +864,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -848,7 +875,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -871,7 +898,6 @@
                 "getLatestBatchData",
                 "onRemoveFromBatch",
                 "getTroveStatus",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -898,10 +924,9 @@
                 "mintAggInterestAndAccountForTroveChange",
                 "getNewApproxAvgInterestRateFromTroveChange",
                 "getCollBalance",
-                "getBoldDebt",
-                "receiveColl"
+                "getBoldDebt"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -928,14 +953,11 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "name": "DefaultPool",
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
               "viewOnlyPath": false,
               "calledFunctions": [
-                "getCollBalance",
-                "getBoldDebt",
-                "decreaseBoldDebt",
-                "sendCollToActivePool"
+                "getTroveAnnualInterestRate"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -949,7 +971,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -959,12 +981,24 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
+              "name": "DefaultPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "decreaseBoldDebt",
+                "sendCollToActivePool"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -986,6 +1020,17 @@
               "fundsAtRisk": false
             },
             {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              "name": "EACAggregatorProxy",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "latestRoundData"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
               "address": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
               "name": "BorrowerOperations",
               "viewOnlyPath": false,
@@ -997,6 +1042,17 @@
               "fundsAtRisk": false
             },
             {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
               "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
               "name": "ActivePool",
               "viewOnlyPath": false,
@@ -1004,7 +1060,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1015,7 +1071,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -1039,7 +1095,6 @@
                 "onRemoveFromBatch",
                 "getTroveStatus",
                 "onSetInterestBatchManager",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -1068,10 +1123,9 @@
                 "mintAggInterestAndAccountForTroveChange",
                 "getNewApproxAvgInterestRateFromTroveChange",
                 "getCollBalance",
-                "getBoldDebt",
-                "receiveColl"
+                "getBoldDebt"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -1098,14 +1152,11 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "name": "DefaultPool",
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
               "viewOnlyPath": false,
               "calledFunctions": [
-                "getCollBalance",
-                "getBoldDebt",
-                "decreaseBoldDebt",
-                "sendCollToActivePool"
+                "getTroveAnnualInterestRate"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -1119,7 +1170,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -1129,12 +1180,24 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
+              "name": "DefaultPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "decreaseBoldDebt",
+                "sendCollToActivePool"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -1156,6 +1219,17 @@
               "fundsAtRisk": false
             },
             {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              "name": "EACAggregatorProxy",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "latestRoundData"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
               "address": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
               "name": "BorrowerOperations",
               "viewOnlyPath": false,
@@ -1167,6 +1241,17 @@
               "fundsAtRisk": false
             },
             {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
               "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
               "name": "ActivePool",
               "viewOnlyPath": false,
@@ -1174,7 +1259,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1185,7 +1270,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -1219,21 +1304,9 @@
                 "getBoldDebt",
                 "mintAggInterest"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
-            },
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "name": "DefaultPool",
-              "viewOnlyPath": true,
-              "calledFunctions": [
-                "getCollBalance",
-                "getBoldDebt"
-              ],
-              "fundsUsd": 0,
-              "tokenValueUsd": 0,
-              "fundsAtRisk": false
             },
             {
               "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
@@ -1247,7 +1320,7 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -1263,6 +1336,17 @@
               "viewOnlyPath": false,
               "calledFunctions": [
                 "stEthPerToken"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              "name": "EACAggregatorProxy",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "latestRoundData"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -1287,7 +1371,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -1297,7 +1381,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -1309,7 +1393,7 @@
                 "setShutdownFlag",
                 "mintAggInterest"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1320,7 +1404,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -1341,7 +1425,7 @@
               "calledFunctions": [
                 "mintAggInterest"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -1364,7 +1448,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -1374,7 +1458,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -1385,7 +1469,7 @@
               "calledFunctions": [
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -1439,7 +1523,7 @@
               "calledFunctions": [
                 "mintAggInterestAndAccountForTroveChange"
               ],
-              "fundsUsd": 13751256.20843068,
+              "fundsUsd": 14274796.542198261,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1451,7 +1535,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -1461,7 +1545,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 3322228.0200613053,
+              "fundsUsd": 3318423.695828019,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -1482,7 +1566,6 @@
               "calledFunctions": [
                 "getLatestBatchData",
                 "onSetBatchManagerAnnualInterestRate",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -1499,7 +1582,7 @@
                 "getCollBalance",
                 "getBoldDebt"
               ],
-              "fundsUsd": 13751256.20843068,
+              "fundsUsd": 14274796.542198261,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1527,18 +1610,6 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "name": "DefaultPool",
-              "viewOnlyPath": true,
-              "calledFunctions": [
-                "getCollBalance",
-                "getBoldDebt"
-              ],
-              "fundsUsd": 0,
-              "tokenValueUsd": 0,
-              "fundsAtRisk": false
-            },
-            {
               "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
               "name": "BoldToken",
               "viewOnlyPath": false,
@@ -1546,7 +1617,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -1556,9 +1627,31 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 3322228.0200613053,
+              "fundsUsd": 3318423.695828019,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTroveAnnualInterestRate"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              "name": "EACAggregatorProxy",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "latestRoundData"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
             },
             {
               "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
@@ -1601,7 +1694,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1612,7 +1705,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -1646,19 +1739,7 @@
                 "getBoldDebt",
                 "mintAggInterest"
               ],
-              "fundsUsd": 13751256.20843068,
-              "tokenValueUsd": 0,
-              "fundsAtRisk": false
-            },
-            {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
-              "name": "DefaultPool",
-              "viewOnlyPath": true,
-              "calledFunctions": [
-                "getCollBalance",
-                "getBoldDebt"
-              ],
-              "fundsUsd": 0,
+              "fundsUsd": 14274796.542198261,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1668,6 +1749,17 @@
               "viewOnlyPath": false,
               "calledFunctions": [
                 "shutdown"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+              "name": "EACAggregatorProxy",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "latestRoundData"
               ],
               "fundsUsd": 0,
               "tokenValueUsd": 0,
@@ -1714,7 +1806,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -1724,7 +1816,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 3322228.0200613053,
+              "fundsUsd": 3318423.695828019,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             },
@@ -1736,7 +1828,7 @@
                 "setShutdownFlag",
                 "mintAggInterest"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1747,7 +1839,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -1768,7 +1860,6 @@
               "calledFunctions": [
                 "onOpenTrove",
                 "getTroveStatus",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -1799,7 +1890,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1811,7 +1902,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -1850,18 +1941,29 @@
               "fundsAtRisk": false
             },
             {
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTroveAnnualInterestRate"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
               "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
               "name": "StabilityPool",
               "viewOnlyPath": false,
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -1889,7 +1991,6 @@
                 "getLatestBatchData",
                 "onOpenTroveAndJoinBatch",
                 "getTroveStatus",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -1920,7 +2021,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -1932,7 +2033,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -1971,18 +2072,29 @@
               "fundsAtRisk": false
             },
             {
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTroveAnnualInterestRate"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
               "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
               "name": "StabilityPool",
               "viewOnlyPath": false,
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -2042,7 +2154,7 @@
               "calledFunctions": [
                 "mintAggInterestAndAccountForTroveChange"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -2054,7 +2166,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2064,7 +2176,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -2085,7 +2197,6 @@
               "calledFunctions": [
                 "getLatestBatchData",
                 "onSetBatchManagerAnnualInterestRate",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -2104,7 +2215,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -2151,7 +2262,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2161,12 +2272,23 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTroveAnnualInterestRate"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -2195,7 +2317,6 @@
                 "getLatestBatchData",
                 "onRemoveFromBatch",
                 "getTroveStatus",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -2226,7 +2347,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -2265,6 +2386,17 @@
               "fundsAtRisk": false
             },
             {
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTroveAnnualInterestRate"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
               "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
               "name": "BoldToken",
               "viewOnlyPath": false,
@@ -2272,7 +2404,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2282,7 +2414,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -2299,7 +2431,7 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -2310,13 +2442,13 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
               "name": "ActivePool",
               "viewOnlyPath": false,
               "calledFunctions": [
                 "receiveColl"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 14274796.542198261,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -2340,7 +2472,6 @@
                 "onRemoveFromBatch",
                 "getTroveStatus",
                 "onSetInterestBatchManager",
-                "getTroveAnnualInterestRate",
                 "shutdown"
               ],
               "fundsUsd": 0,
@@ -2373,7 +2504,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -2412,6 +2543,17 @@
               "fundsAtRisk": false
             },
             {
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+              "name": "TroveManager",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTroveAnnualInterestRate"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": false
+            },
+            {
               "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
               "name": "BoldToken",
               "viewOnlyPath": false,
@@ -2419,7 +2561,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2429,7 +2571,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -2446,7 +2588,7 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -2457,13 +2599,13 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
               "name": "ActivePool",
               "viewOnlyPath": false,
               "calledFunctions": [
                 "receiveColl"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 14274796.542198261,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -2498,7 +2640,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -2526,7 +2668,7 @@
               "fundsAtRisk": false
             },
             {
-              "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+              "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
               "name": "EACAggregatorProxy",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -2544,7 +2686,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2554,7 +2696,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -2576,7 +2718,7 @@
                 "mintAggInterest",
                 "setShutdownFlag"
               ],
-              "fundsUsd": 12039453.163615538,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             },
@@ -2599,7 +2741,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2609,22 +2751,22 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
           ]
         }
       ],
-      "totalDirectCapital": 87579530.73604652,
+      "totalDirectCapital": 91354642.20883462,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 102051801.83635905,
+      "totalReachableCapital": 105809266.04027124,
       "totalReachableTokenValue": 0
     },
     {
       "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-      "name": "wstETH Branch TroveManager",
-      "description": "Internal protocol contract. TroveManager is authorized to call sendCollToDefaultPool, mintAggInterestAndAccountForTroveChange, mintBatchManagementFeeAndAccountForChange, and setShutdownFlag on the wstETH ActivePool, and drives SortedTroves remove and removeFromBatch operations during liquidations. Authorized access spans $87.58M in direct capital across 10 contracts.",
+      "name": "TroveManager (wstETH branch)",
+      "description": "Internal protocol contract that manages trove lifecycle for the wstETH branch. Controls 24 permissioned functions across 10 contracts including collateral redistribution to DefaultPool, batch management fee minting, branch shutdown flag, and StabilityPool offset (liquidation debt cancellation). All calls are protocol-internal with no external admin.",
       "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
@@ -2633,7 +2775,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -2642,11 +2784,11 @@
           "contractName": "ActivePool",
           "functionName": "sendCollToDefaultPool",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
+              "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
               "name": "DefaultPool",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -2663,7 +2805,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterestAndAccountForTroveChange",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -2674,7 +2816,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2684,7 +2826,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -2695,7 +2837,7 @@
           "contractName": "ActivePool",
           "functionName": "mintBatchManagementFeeAndAccountForChange",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -2706,7 +2848,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             }
           ]
@@ -2716,7 +2858,7 @@
           "contractName": "ActivePool",
           "functionName": "setShutdownFlag",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -2725,7 +2867,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -2734,7 +2876,7 @@
           "contractName": "ActivePool",
           "functionName": "sendCollToDefaultPool",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -2755,7 +2897,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterestAndAccountForTroveChange",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -2766,7 +2908,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2776,7 +2918,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 3322228.0200613053,
+              "fundsUsd": 3318423.695828019,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -2787,7 +2929,7 @@
           "contractName": "ActivePool",
           "functionName": "mintBatchManagementFeeAndAccountForChange",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -2798,7 +2940,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             }
           ]
@@ -2808,7 +2950,7 @@
           "contractName": "ActivePool",
           "functionName": "setShutdownFlag",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -2817,7 +2959,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -2826,11 +2968,11 @@
           "contractName": "ActivePool",
           "functionName": "sendCollToDefaultPool",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
+              "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
               "name": "DefaultPool",
               "viewOnlyPath": false,
               "calledFunctions": [
@@ -2847,7 +2989,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterestAndAccountForTroveChange",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -2858,7 +3000,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -2868,7 +3010,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -2879,7 +3021,7 @@
           "contractName": "ActivePool",
           "functionName": "mintBatchManagementFeeAndAccountForChange",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -2890,7 +3032,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             }
           ]
@@ -2900,7 +3042,7 @@
           "contractName": "ActivePool",
           "functionName": "setShutdownFlag",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -2913,13 +3055,13 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
               "name": "ActivePool",
               "viewOnlyPath": false,
               "calledFunctions": [
                 "receiveColl"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 14274796.542198261,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -2952,13 +3094,13 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
               "name": "ActivePool",
               "viewOnlyPath": false,
               "calledFunctions": [
                 "receiveColl"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 12936629.251747033,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -2997,7 +3139,7 @@
               "calledFunctions": [
                 "receiveColl"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -3022,15 +3164,15 @@
           "reachableContracts": []
         }
       ],
-      "totalDirectCapital": 87579530.73604652,
+      "totalDirectCapital": 91354642.20883462,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 102051801.83635905,
+      "totalReachableCapital": 105809266.04027124,
       "totalReachableTokenValue": 0
     },
     {
       "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
-      "name": "wstETH Branch StabilityPool",
-      "description": "Internal protocol contract. The wstETH StabilityPool is authorized to call sendColl and mintAggInterest on the wstETH ActivePool, enabling BOLD liquidation offsets and interest distribution to stability depositors. Holds $11.15M in BOLD deposits and wstETH liquidation proceeds.",
+      "name": "StabilityPool (wstETH branch)",
+      "description": "Internal protocol contract that manages the wstETH Stability Pool. Controls 6 permissioned functions across 7 contracts, primarily collateral transfers from ActivePool and interest minting. Acts as a caller for ActivePool.sendColl and ActivePool.mintAggInterest during liquidation processing.",
       "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
@@ -3039,7 +3181,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3048,7 +3190,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterest",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -3059,7 +3201,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -3069,7 +3211,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 11150043.080251232,
+              "fundsUsd": 11136200.135608597,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -3080,7 +3222,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3089,7 +3231,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterest",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -3100,7 +3242,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -3110,7 +3252,7 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 3322228.0200613053,
+              "fundsUsd": 3318423.695828019,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
@@ -3121,7 +3263,7 @@
           "contractName": "ActivePool",
           "functionName": "sendColl",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3130,7 +3272,7 @@
           "contractName": "ActivePool",
           "functionName": "mintAggInterest",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -3141,7 +3283,7 @@
                 "mint"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -3151,22 +3293,22 @@
               "calledFunctions": [
                 "triggerBoldRewards"
               ],
-              "fundsUsd": 7526038.957459795,
+              "fundsUsd": 7550908.855270761,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
           ]
         }
       ],
-      "totalDirectCapital": 87579530.73604652,
+      "totalDirectCapital": 91354642.20883462,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 102051801.83635905,
+      "totalReachableCapital": 105809266.04027124,
       "totalReachableTokenValue": 0
     },
     {
       "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-      "name": "wstETH Branch DefaultPool",
-      "description": "Internal protocol contract. DefaultPool is authorized to call receiveColl and accountForReceivedColl on the wstETH ActivePool, handling collateral accounting during redistribution liquidations where bad debt and collateral are socialized across surviving trove holders. Authorized access spans $87.58M in direct capital.",
+      "name": "DefaultPool (rETH branch)",
+      "description": "Internal protocol contract that holds redistributed collateral for the rETH branch. Controls 6 permissioned functions across 3 contracts, primarily receiving collateral from ActivePool during redistributions and sending it back. All calls are protocol-internal.",
       "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
@@ -3175,7 +3317,7 @@
           "contractName": "ActivePool",
           "functionName": "receiveColl",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3184,7 +3326,7 @@
           "contractName": "ActivePool",
           "functionName": "accountForReceivedColl",
           "impact": "critical",
-          "directFundsUsd": 61788821.364000306,
+          "directFundsUsd": 64143216.414889336,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3193,7 +3335,7 @@
           "contractName": "ActivePool",
           "functionName": "receiveColl",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3202,7 +3344,7 @@
           "contractName": "ActivePool",
           "functionName": "accountForReceivedColl",
           "impact": "critical",
-          "directFundsUsd": 13751256.20843068,
+          "directFundsUsd": 14274796.542198261,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3211,7 +3353,7 @@
           "contractName": "ActivePool",
           "functionName": "receiveColl",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3220,20 +3362,20 @@
           "contractName": "ActivePool",
           "functionName": "accountForReceivedColl",
           "impact": "critical",
-          "directFundsUsd": 12039453.163615538,
+          "directFundsUsd": 12936629.251747033,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         }
       ],
-      "totalDirectCapital": 87579530.73604652,
+      "totalDirectCapital": 91354642.20883462,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 87579530.73604652,
+      "totalReachableCapital": 91354642.20883462,
       "totalReachableTokenValue": 0
     },
     {
       "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-      "name": "rETH Branch ActivePool",
-      "description": "Internal protocol contract. The rETH ActivePool is authorized to call receiveColl on its DefaultPool and triggerBoldRewards on the rETH StabilityPool, coordinating redistribution accounting and interest distribution to depositors. Holds $13.75M in rETH collateral, and its authorized-caller set is fixed at deployment.",
+      "name": "ActivePool (rETH branch)",
+      "description": "Internal protocol contract that holds rETH collateral. Controls 5 permissioned functions across 5 contracts, gating collateral receipt from DefaultPool and BorrowerOperations. Holds (N/A) in rETH collateral.",
       "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
@@ -3269,7 +3411,7 @@
           "contractName": "StabilityPool",
           "functionName": "triggerBoldRewards",
           "impact": "critical",
-          "directFundsUsd": 3322228.0200613053,
+          "directFundsUsd": 3318423.695828019,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -3278,20 +3420,20 @@
           "contractName": "StabilityPool",
           "functionName": "triggerBoldRewards",
           "impact": "critical",
-          "directFundsUsd": 11150043.080251232,
+          "directFundsUsd": 11136200.135608597,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         }
       ],
-      "totalDirectCapital": 14472271.100312537,
+      "totalDirectCapital": 14454623.831436615,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 14472271.100312537,
+      "totalReachableCapital": 14454623.831436615,
       "totalReachableTokenValue": 0
     },
     {
       "address": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-      "name": "rETH Branch BorrowerOperations",
-      "description": "Internal protocol contract. The rETH branch BorrowerOperations is authorized to call insert, remove, reInsert, insertIntoBatch, removeFromBatch, and reInsertBatch on the rETH SortedTroves, maintaining the sorted-by-interest-rate linked list used for batch management and redemptions. SortedTroves holds no collateral, so direct capital exposure is zero.",
+      "name": "BorrowerOperations (rETH branch)",
+      "description": "Internal protocol contract that gates user-facing operations for the rETH collateral branch. Controls 18 permissioned functions across 6 contracts, mirroring the wstETH BorrowerOperations for rETH-collateralized troves. No capital directly at risk in this branch's pools as measured.",
       "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
@@ -3304,7 +3446,7 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
               "name": "TroveManager",
               "viewOnlyPath": true,
               "calledFunctions": [
@@ -3334,7 +3476,7 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
               "name": "TroveManager",
               "viewOnlyPath": true,
               "calledFunctions": [
@@ -3355,7 +3497,7 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
               "name": "TroveManager",
               "viewOnlyPath": true,
               "calledFunctions": [
@@ -3385,7 +3527,7 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+              "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
               "name": "TroveManager",
               "viewOnlyPath": true,
               "calledFunctions": [
@@ -3406,7 +3548,7 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
               "name": "TroveManager",
               "viewOnlyPath": true,
               "calledFunctions": [
@@ -3436,7 +3578,7 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
               "name": "TroveManager",
               "viewOnlyPath": true,
               "calledFunctions": [
@@ -3457,7 +3599,7 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
               "name": "TroveManager",
               "viewOnlyPath": true,
               "calledFunctions": [
@@ -3487,7 +3629,7 @@
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
-              "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+              "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
               "name": "TroveManager",
               "viewOnlyPath": true,
               "calledFunctions": [
@@ -3609,8 +3751,8 @@
     },
     {
       "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-      "name": "rETH Branch TroveManager",
-      "description": "Internal protocol contract. The rETH TroveManager is authorized to call remove and removeFromBatch on its SortedTroves, collateral accounting functions on its DefaultPool, and offset on the rETH StabilityPool during liquidations. Authorized access spans $14.47M in direct capital across 8 contracts.",
+      "name": "TroveManager (rETH branch)",
+      "description": "Internal protocol contract that manages trove lifecycle for the rETH branch. Controls 8 permissioned functions across 8 contracts including collateral redistribution, shutdown flags, and StabilityPool offsets.",
       "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
@@ -3673,7 +3815,7 @@
           "contractName": "StabilityPool",
           "functionName": "offset",
           "impact": "critical",
-          "directFundsUsd": 3322228.0200613053,
+          "directFundsUsd": 3318423.695828019,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -3684,7 +3826,7 @@
                 "burn"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -3694,7 +3836,7 @@
               "calledFunctions": [
                 "sendColl"
               ],
-              "fundsUsd": 13751256.20843068,
+              "fundsUsd": 14274796.542198261,
               "tokenValueUsd": 0,
               "fundsAtRisk": false
             }
@@ -3705,7 +3847,7 @@
           "contractName": "StabilityPool",
           "functionName": "offset",
           "impact": "critical",
-          "directFundsUsd": 11150043.080251232,
+          "directFundsUsd": 11136200.135608597,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -3716,7 +3858,7 @@
                 "burn"
               ],
               "fundsUsd": 0,
-              "tokenValueUsd": 30845627.959910788,
+              "tokenValueUsd": 31325385.25346636,
               "fundsAtRisk": false
             },
             {
@@ -3726,16 +3868,16 @@
               "calledFunctions": [
                 "sendColl"
               ],
-              "fundsUsd": 61788821.364000306,
+              "fundsUsd": 64143216.414889336,
               "tokenValueUsd": 0,
               "fundsAtRisk": true
             }
           ]
         }
       ],
-      "totalDirectCapital": 14472271.100312537,
+      "totalDirectCapital": 14454623.831436615,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 76261092.46431284,
+      "totalReachableCapital": 78597840.24632595,
       "totalReachableTokenValue": 0
     }
   ],
@@ -3743,24 +3885,200 @@
     {
       "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
       "name": "Chainlink ETH/USD Price Feed",
-      "description": "Chainlink EACAggregatorProxy supplying the ETH/USD spot price used by WETHPriceFeed for WETH collateral valuation. An oracle outage lasting beyond the fallback timeout causes the WETH branch to enter shutdown mode, halting new borrows and redemptions. The aggregator address can be updated by a Chainlink-operated 4/9 multisig.",
+      "description": "Chainlink EACAggregatorProxy providing the ETH/USD price. Used by all three collateral branches via their respective PriceFeed contracts — impacts 30 functions including openTrove, adjustTroveInterestRate, shutdown, and liquidation operations across BorrowerOperations and TroveManager contracts. Owned by a Chainlink 4/9 multisig.",
       "entity": "Chainlink",
-      "isAutoDetected": false,
+      "isAutoDetected": true,
       "viewOnlyPath": false,
-      "calledFunctions": [],
+      "calledFunctions": [
+        "latestRoundData"
+      ],
       "functions": [
         {
           "contractAddress": "eth:0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
           "contractName": "Unknown Contract",
           "functionName": "fetchPrice",
           "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTroveInterestRate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "kickFromBatch",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "removeFromBatch",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "shutdown",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTroveInterestRate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "removeFromBatch",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "shutdown",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTroveInterestRate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "kickFromBatch",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "removeFromBatch",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractName": "BorrowerOperations",
+          "functionName": "shutdown",
+          "viewOnlyPath": false
         }
       ]
     },
     {
-      "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+      "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
       "name": "Chainlink stETH/USD Price Feed",
-      "description": "Chainlink EACAggregatorProxy used by WSTETHPriceFeed as a price input for wstETH collateral valuation, combined with the on-chain stETH/wstETH exchange rate from the Lido contract. 29 borrowing and interest rate management functions in the wstETH branch depend on this feed being live and accurate.",
+      "description": "Chainlink EACAggregatorProxy providing the stETH/USD price, used by the WSTETHPriceFeed contract to value wstETH collateral. Impacts 10 functions in the wstETH BorrowerOperations branch.",
       "entity": "Chainlink",
       "isAutoDetected": true,
       "viewOnlyPath": false,
@@ -3827,127 +4145,13 @@
           "contractName": "BorrowerOperations",
           "functionName": "shutdown",
           "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTrove",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "removeFromBatch",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "switchBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "shutdown",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTrove",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "kickFromBatch",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "removeFromBatch",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "switchBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "shutdown",
-          "viewOnlyPath": false
         }
       ]
     },
     {
       "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-      "name": "Lido wstETH",
-      "description": "Lido's wrapped staked ETH token, queried by WSTETHPriceFeed for the current stETH/wstETH exchange rate as a component in collateral pricing. A sustained stETH depeg or Lido systemic failure would directly affect collateral ratios in the wstETH branch and could trigger mass liquidations.",
+      "name": "Lido wstETH Token",
+      "description": "Lido's wrapped staked ETH token contract, used by the WSTETHPriceFeed for the wstETH/stETH exchange rate via stEthPerToken(). Impacts 10 functions in the wstETH collateral branch. The largest collateral pool holds (N/A) in wstETH.",
       "entity": "Lido",
       "isAutoDetected": true,
       "viewOnlyPath": false,
@@ -4018,9 +4222,76 @@
       ]
     },
     {
+      "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+      "name": "Chainlink rETH/ETH Price Feed",
+      "description": "Chainlink EACAggregatorProxy providing the rETH/ETH exchange rate, used by the RETHPriceFeed contract to value rETH collateral. Impacts 9 functions in the rETH BorrowerOperations branch.",
+      "entity": "Chainlink",
+      "isAutoDetected": true,
+      "viewOnlyPath": false,
+      "calledFunctions": [
+        "latestRoundData"
+      ],
+      "functions": [
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTroveInterestRate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "removeFromBatch",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "shutdown",
+          "viewOnlyPath": false
+        }
+      ]
+    },
+    {
       "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-      "name": "Rocket Pool rETH",
-      "description": "Rocket Pool's liquid staking token, queried by RETHPriceFeed for the rETH/ETH exchange rate as a component in collateral pricing. A depeg or liquidity disruption in the rETH market would affect collateral valuations in the rETH branch.",
+      "name": "RocketPool rETH Token",
+      "description": "RocketPool's liquid staking token contract, used by the RETHPriceFeed for the rETH/ETH exchange rate via getExchangeRate(). Impacts 9 functions in the rETH collateral branch.",
       "entity": "RocketPool",
       "isAutoDetected": true,
       "viewOnlyPath": false,
@@ -4088,60 +4359,60 @@
   "funds": [
     {
       "address": "eth:0x531a8f99c70d6a56a7cee02d6b4281650d7919a0",
-      "name": "ActivePool (wstETH branch)",
-      "description": "Holds $61.79M in wstETH collateral deposited by wstETH-branch borrowers as backing for their BOLD debt. The largest collateral pool in the protocol; collateral moves to DefaultPool during redistribution liquidations and returns to borrowers on full repayment.",
+      "name": "ActivePool (wstETH)",
+      "description": "Main collateral pool for the wstETH branch, holding (N/A) in wstETH deposited by borrowers. The largest single pool in the protocol.",
       "balances": {
-        "totalUsdValue": 61788821.364000306
-      },
-      "positions": null,
-      "tokenInfo": null
-    },
-    {
-      "address": "eth:0xeb5a8c825582965f1d84606e078620a84ab16afe",
-      "name": "ActivePool (WETH branch)",
-      "description": "Holds $12.04M in WETH collateral deposited by WETH-branch borrowers. Collateral is transferred to BorrowerOperations on withdrawals, to DefaultPool during redistributions, and to the StabilityPool during offset liquidations.",
-      "balances": {
-        "totalUsdValue": 12039453.163615538
+        "totalUsdValue": 64143216.414889336
       },
       "positions": null,
       "tokenInfo": null
     },
     {
       "address": "eth:0x9074d72cc82dad1e13e454755aa8f144c479532f",
-      "name": "ActivePool (rETH branch)",
-      "description": "Holds $13.75M in rETH collateral deposited by rETH-branch borrowers. rETH accrues ETH staking rewards over time, so the collateral value changes independently of ETH spot price movements.",
+      "name": "ActivePool (rETH)",
+      "description": "Main collateral pool for the rETH branch, holding (N/A) in rETH deposited by borrowers.",
       "balances": {
-        "totalUsdValue": 13751256.20843068
+        "totalUsdValue": 14274796.542198261
+      },
+      "positions": null,
+      "tokenInfo": null
+    },
+    {
+      "address": "eth:0xeb5a8c825582965f1d84606e078620a84ab16afe",
+      "name": "ActivePool (WETH)",
+      "description": "Main collateral pool for the WETH branch, holding (N/A) in wrapped Ether deposited by borrowers.",
+      "balances": {
+        "totalUsdValue": 12936629.251747033
       },
       "positions": null,
       "tokenInfo": null
     },
     {
       "address": "eth:0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b",
-      "name": "StabilityPool (wstETH branch)",
-      "description": "Holds $11.15M in BOLD deposits and wstETH liquidation proceeds. Depositors absorb liquidated wstETH-branch troves by canceling BOLD against bad debt and receive the liquidated wstETH collateral at a discount.",
+      "name": "StabilityPool (wstETH)",
+      "description": "Stability pool for the wstETH branch, holding (N/A) in BOLD deposits and wstETH liquidation gains from borrowers.",
       "balances": {
-        "totalUsdValue": 11150043.080251232
+        "totalUsdValue": 11136200.135608597
       },
       "positions": null,
       "tokenInfo": null
     },
     {
       "address": "eth:0x5721cbbd64fc7ae3ef44a0a3f9a790a9264cf9bf",
-      "name": "StabilityPool (WETH branch)",
-      "description": "Holds $7.53M in BOLD deposits and WETH liquidation proceeds. Provides the primary liquidation backstop for the WETH branch; depositors earn liquidated WETH collateral and BOLD rewards from branch interest accrual.",
+      "name": "StabilityPool (WETH)",
+      "description": "Stability pool for the WETH branch, holding (N/A) in BOLD deposits and WETH liquidation gains.",
       "balances": {
-        "totalUsdValue": 7526038.957459795
+        "totalUsdValue": 7550908.855270761
       },
       "positions": null,
       "tokenInfo": null
     },
     {
       "address": "eth:0xd442e41019b7f5c4dd78f50dc03726c446148695",
-      "name": "StabilityPool (rETH branch)",
-      "description": "Holds $3.32M in BOLD deposits and rETH liquidation proceeds. Provides the primary liquidation backstop for the rETH branch; depositors earn liquidated rETH collateral and BOLD rewards from branch interest accrual.",
+      "name": "StabilityPool (rETH)",
+      "description": "Stability pool for the rETH branch, holding (N/A) in BOLD deposits and rETH liquidation gains.",
       "balances": {
-        "totalUsdValue": 3322228.0200613053
+        "totalUsdValue": 3318423.695828019
       },
       "positions": null,
       "tokenInfo": null
@@ -4149,14 +4420,14 @@
     {
       "address": "eth:0x6440f144b7e50d6a8439336510312d2f54beb01d",
       "name": "BOLD Stablecoin",
-      "description": "Protocol-native stablecoin with a circulating market cap of $30.85M. Minted when borrowers open Troves and burned on repayment or redemption. Token ownership was renounced to the zero address after the CollateralRegistry address was set; all subsequent minting and burning is exclusively controlled by the immutable branch contracts.",
+      "description": "The protocol's native stablecoin token contract with a market cap of (N/A). Ownership was renounced to the zero address after initialization — setBranchAddresses and setCollateralRegistry can no longer be called.",
       "balances": null,
       "positions": null,
       "tokenInfo": {
         "symbol": "BOLD",
-        "price": 1.0038028780586732,
-        "totalSupply": "30728770193970129332264404",
-        "tokenValue": 30845627.959910788
+        "price": 1.002788831669614,
+        "totalSupply": "31238266985194192048139156",
+        "tokenValue": 31325385.25346636
       }
     }
   ],

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -632,6 +632,25 @@ function getContractsToAnalyze(
 }
 
 /**
+ * Extract all eth: addresses from a value.
+ * Handles flat strings and one-level-deep object fields (e.g., oracle structs
+ * with an `aggregator` address alongside non-address fields like `stalenessThreshold`).
+ */
+export function extractEthAddresses(value: unknown): string[] {
+  if (typeof value === 'string' && value.startsWith('eth:')) return [value]
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const addresses: string[] = []
+    for (const v of Object.values(value)) {
+      if (typeof v === 'string' && v.startsWith('eth:')) {
+        addresses.push(v)
+      }
+    }
+    return addresses
+  }
+  return []
+}
+
+/**
  * Resolve storage variable to actual contract address using discovered.json
  */
 function resolveStorageVariable(
@@ -660,6 +679,20 @@ function resolveStorageVariable(
     )
     return {
       address: value,
+      name: resolvedContract?.name,
+    }
+  }
+
+  // Handle nested objects (e.g., oracle structs like { aggregator: "eth:0x...", decimals: 8 }).
+  // Only deterministic if exactly one address is found (unambiguous).
+  const addresses = extractEthAddresses(value)
+  if (addresses.length === 1) {
+    const addr = addresses[0]!
+    const resolvedContract = discovered.entries.find(
+      (e) => e.address.toLowerCase() === addr.toLowerCase(),
+    )
+    return {
+      address: addr,
       name: resolvedContract?.name,
     }
   }
@@ -894,6 +927,18 @@ function buildTypeSubstitutionMap(
     // If the argument is itself a substituted value from a parent scope, resolve it
     if (parentSubstitutions.has(argValue)) {
       argValue = parentSubstitutions.get(argValue)!
+    } else if (
+      (argValue.startsWith('REF_') || argValue.startsWith('TMP_')) &&
+      parentSubstitutions.size > 0
+    ) {
+      // The argument is a synthetic Slither reference (e.g., REF_1343 from a struct
+      // field access like _oracle.aggregator). The parent substitution holds the real
+      // context (e.g., {Oracle → ethUsdOracle}). Propagate it so that downstream calls
+      // differentiate _getOracleAnswer(ethUsdOracle) from _getOracleAnswer(rEthEthOracle).
+      const firstParentValue = parentSubstitutions.values().next().value
+      if (firstParentValue) {
+        argValue = firstParentValue
+      }
     }
 
     // Only store if we don't already have a mapping for this type
@@ -925,7 +970,18 @@ function collectHighLevelCalls(
   interfaceType: string
   calledFunction: string
 }[] {
-  const key = `${contractName}.${functionName}`
+  // Include type substitutions in the visited key so the same internal function
+  // called with different arguments (e.g., _fetchOracleData(ethUsdOracle) vs
+  // _fetchOracleData(rEthEthOracle)) produces separate call entries.
+  const subsKey =
+    typeSubstitutions.size > 0
+      ? '|' +
+        Array.from(typeSubstitutions.entries())
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([k, v]) => `${k}=${v}`)
+          .join(',')
+      : ''
+  const key = `${contractName}.${functionName}${subsKey}`
   if (visited.has(key)) return []
   visited.add(key)
 
@@ -947,9 +1003,31 @@ function collectHighLevelCalls(
     // This handles the case where a function parameter is used to make an external call
     const substitutedVar = typeSubstitutions.get(hlc.interfaceType)
 
+    let storageVariable = substitutedVar ?? hlc.storageVariable
+
+    // If the storageVariable is still a synthetic reference (REF_ or TMP_) and we have
+    // unused substitutions from the caller, use the first substitution value.
+    // This handles: fetchPrice → _getPrice(ethUsdOracle) → REF_1343.latestRoundData
+    // where the parameter type (Oracle) differs from the call interface (AggregatorV3Interface).
+    // Without this, both _getPrice(ethUsdOracle) and _getPrice(rEthEthOracle) produce
+    // the same REF_1343 and get deduplicated.
+    if (
+      !substitutedVar &&
+      (hlc.storageVariable.startsWith('REF_') ||
+        hlc.storageVariable.startsWith('TMP_')) &&
+      typeSubstitutions.size > 0
+    ) {
+      // Use the first substitution value as context (internal functions typically
+      // have one relevant parameter, e.g., _getPrice(Oracle oracle))
+      const firstSubValue = typeSubstitutions.values().next().value
+      if (firstSubValue) {
+        storageVariable = firstSubValue
+      }
+    }
+
     calls.push({
       ...hlc,
-      storageVariable: substitutedVar ?? hlc.storageVariable,
+      storageVariable,
     })
   }
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -935,15 +935,17 @@ function buildTypeSubstitutionMap(
       // field access like _oracle.aggregator). The parent substitution holds the real
       // context (e.g., {Oracle → ethUsdOracle}). Propagate it so that downstream calls
       // differentiate _getOracleAnswer(ethUsdOracle) from _getOracleAnswer(rEthEthOracle).
-      const firstParentValue = parentSubstitutions.values().next().value
-      if (firstParentValue) {
-        argValue = firstParentValue
+      if (parentSubstitutions.size === 1) {
+        const firstParentValue = parentSubstitutions.values().next().value
+        if (firstParentValue) {
+          argValue = firstParentValue
+        }
       }
     }
 
-    // Only store if we don't already have a mapping for this type
+    // Only store if we have a valid type and don't already have a mapping
     // (handles case where multiple params have same type - first one wins)
-    if (!substitutions.has(paramType)) {
+    if (paramType !== undefined && !substitutions.has(paramType)) {
       substitutions.set(paramType, argValue)
     }
   }
@@ -1017,11 +1019,13 @@ function collectHighLevelCalls(
         hlc.storageVariable.startsWith('TMP_')) &&
       typeSubstitutions.size > 0
     ) {
-      // Use the first substitution value as context (internal functions typically
-      // have one relevant parameter, e.g., _getPrice(Oracle oracle))
-      const firstSubValue = typeSubstitutions.values().next().value
-      if (firstSubValue) {
-        storageVariable = firstSubValue
+      // Use the substitution value as context when unambiguous (single entry).
+      // With multiple entries we can't determine which parameter the REF_ derived from.
+      if (typeSubstitutions.size === 1) {
+        const firstSubValue = typeSubstitutions.values().next().value
+        if (firstSubValue) {
+          storageVariable = firstSubValue
+        }
       }
     }
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -132,16 +132,33 @@ class VariableChainHeuristic implements ResolutionHeuristic {
     }
 
     // Handle nested objects (e.g., oracle structs like { aggregator: "eth:0x...", decimals: 8 })
+    // Filter to addresses that actually have the called function in their ABI
     const addresses = extractEthAddresses(value)
     if (addresses.length > 0) {
-      return {
-        matches: addresses.map((addr) => ({
-          address: addr,
-          contractName: discovered.entries.find(
+      const validMatches = addresses
+        .map((addr) => {
+          const entry = discovered.entries.find(
             (e) => e.address.toLowerCase() === addr.toLowerCase(),
-          )?.name,
-        })),
-        confidence: addresses.length === 1 ? 100 : 70,
+          )
+          return { address: addr, contractName: entry?.name, entry }
+        })
+        .filter(
+          (m) =>
+            m.entry &&
+            m.entry.type === 'Contract' &&
+            contractHasFunction(
+              discovered,
+              m.entry,
+              context.call.calledFunction,
+            ),
+        )
+        .map(({ address, contractName }) => ({ address, contractName }))
+
+      if (validMatches.length > 0) {
+        return {
+          matches: validMatches,
+          confidence: validMatches.length === 1 ? 100 : 70,
+        }
       }
     }
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -36,6 +36,40 @@ export interface HeuristicEngineResult {
 }
 
 // =============================================================================
+// Shared Helpers
+// =============================================================================
+
+/**
+ * Check if a contract (including proxy implementations) has a function in its ABI.
+ */
+function contractHasFunction(
+  discovered: DiscoveryOutput,
+  entry: DiscoveryOutput['entries'][number],
+  functionName: string,
+): boolean {
+  const abiAddresses = [entry.address]
+  const implValue = entry.values?.$implementation
+  if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
+    abiAddresses.push(implValue as typeof entry.address)
+  }
+
+  for (const abiAddress of abiAddresses) {
+    const abi = discovered.abis[abiAddress]
+    if (!abi) continue
+
+    const found = abi.some((abiEntry) => {
+      if (!abiEntry.startsWith('function ')) return false
+      const match = abiEntry.match(/^function\s+(\w+)\(/)
+      return match && match[1] === functionName
+    })
+
+    if (found) return true
+  }
+
+  return false
+}
+
+// =============================================================================
 // Heuristic Implementations
 // =============================================================================
 
@@ -250,29 +284,7 @@ class FunctionSignatureHeuristic implements ResolutionHeuristic {
     for (const entry of discovered.entries) {
       if (entry.type !== 'Contract') continue
 
-      // Collect ABI addresses: entry address + implementation address for proxies
-      const abiAddresses = [entry.address]
-      const implValue = entry.values?.$implementation
-      if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
-        abiAddresses.push(implValue as typeof entry.address)
-      }
-
-      // Check if any of the contract's ABIs have the function
-      let hasFunction = false
-      for (const abiAddress of abiAddresses) {
-        const abi = discovered.abis[abiAddress]
-        if (!abi) continue
-
-        hasFunction = abi.some((abiEntry) => {
-          if (!abiEntry.startsWith('function ')) return false
-          const match = abiEntry.match(/^function\s+(\w+)\(/)
-          return match && match[1] === functionName
-        })
-
-        if (hasFunction) break
-      }
-
-      if (hasFunction) {
+      if (contractHasFunction(discovered, entry, functionName)) {
         matches.push({
           address: entry.address,
           contractName: entry.name,
@@ -336,18 +348,8 @@ class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
     // Collect all eth: addresses from the caller's values (one level deep into objects)
     const valueAddresses = new Set<string>()
     for (const value of Object.values(callerContract.values)) {
-      if (typeof value === 'string' && value.startsWith('eth:')) {
-        valueAddresses.add(value.toLowerCase())
-      } else if (
-        typeof value === 'object' &&
-        value !== null &&
-        !Array.isArray(value)
-      ) {
-        for (const v of Object.values(value)) {
-          if (typeof v === 'string' && v.startsWith('eth:')) {
-            valueAddresses.add(v.toLowerCase())
-          }
-        }
+      for (const addr of extractEthAddresses(value)) {
+        valueAddresses.add(addr.toLowerCase())
       }
     }
 
@@ -363,28 +365,7 @@ class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
       if (entry.type !== 'Contract') continue
       if (!valueAddresses.has(entry.address.toLowerCase())) continue
 
-      // Check if this contract has the called function in its ABI
-      const abiAddresses = [entry.address]
-      const implValue = entry.values?.$implementation
-      if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
-        abiAddresses.push(implValue as typeof entry.address)
-      }
-
-      let hasFunction = false
-      for (const abiAddress of abiAddresses) {
-        const abi = discovered.abis[abiAddress]
-        if (!abi) continue
-
-        hasFunction = abi.some((abiEntry) => {
-          if (!abiEntry.startsWith('function ')) return false
-          const match = abiEntry.match(/^function\s+(\w+)\(/)
-          return match && match[1] === functionName
-        })
-
-        if (hasFunction) break
-      }
-
-      if (hasFunction) {
+      if (contractHasFunction(discovered, entry, functionName)) {
         matches.push({
           address: entry.address,
           contractName: entry.name,
@@ -632,7 +613,7 @@ export function parseVariableAssignments(
 export function createHeuristicEngine(): HeuristicEngine {
   const engine = new HeuristicEngine()
 
-  // Register heuristics in order of reliability
+  // Register heuristics (engine selects by highest confidence, order only affects tiebreaking)
   engine.register(new VariableChainHeuristic())
   engine.register(new DiscoveredValuesScanHeuristic())
   engine.register(new InterfaceNameHeuristic())

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -1,4 +1,5 @@
 import type { DiscoveryOutput } from '@l2beat/discovery'
+import { extractEthAddresses } from './callGraph'
 import type { ExternalCall, ResolutionCandidate } from './types'
 
 // =============================================================================
@@ -93,6 +94,20 @@ class VariableChainHeuristic implements ResolutionHeuristic {
           },
         ],
         confidence: 100, // Single match via chain = 100%
+      }
+    }
+
+    // Handle nested objects (e.g., oracle structs like { aggregator: "eth:0x...", decimals: 8 })
+    const addresses = extractEthAddresses(value)
+    if (addresses.length > 0) {
+      return {
+        matches: addresses.map((addr) => ({
+          address: addr,
+          contractName: discovered.entries.find(
+            (e) => e.address.toLowerCase() === addr.toLowerCase(),
+          )?.name,
+        })),
+        confidence: addresses.length === 1 ? 100 : 70,
       }
     }
 
@@ -282,6 +297,113 @@ class FunctionSignatureHeuristic implements ResolutionHeuristic {
     if (matchCount === 1) return 99
     if (matchCount === 2) return 50
     return 30
+  }
+}
+
+/**
+ * Discovered Values Scan Heuristic
+ *
+ * Scans the caller contract's discovered values (recursively) for eth: addresses,
+ * then finds contracts at those addresses that have the called function in their ABI.
+ * This catches dependencies stored in nested structs (e.g., oracle configs with
+ * an `aggregator` address) that other heuristics miss.
+ *
+ * Confidence: 1 match → 95%, 2 matches → 70%, 3+ matches → 50%
+ */
+class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
+  name = 'discovered-values-scan'
+  description =
+    'Match candidates against addresses found in caller contract values'
+
+  apply(context: HeuristicContext): HeuristicResult | null {
+    const { call, callerContractAddress, discovered } = context
+
+    // Find the caller contract's values
+    const callerContract = discovered.entries.find(
+      (e) =>
+        e.address.toLowerCase() === callerContractAddress.toLowerCase() &&
+        e.type === 'Contract',
+    )
+
+    if (
+      !callerContract ||
+      !('values' in callerContract) ||
+      !callerContract.values
+    ) {
+      return null
+    }
+
+    // Collect all eth: addresses from the caller's values (one level deep into objects)
+    const valueAddresses = new Set<string>()
+    for (const value of Object.values(callerContract.values)) {
+      if (typeof value === 'string' && value.startsWith('eth:')) {
+        valueAddresses.add(value.toLowerCase())
+      } else if (
+        typeof value === 'object' &&
+        value !== null &&
+        !Array.isArray(value)
+      ) {
+        for (const v of Object.values(value)) {
+          if (typeof v === 'string' && v.startsWith('eth:')) {
+            valueAddresses.add(v.toLowerCase())
+          }
+        }
+      }
+    }
+
+    if (valueAddresses.size === 0) {
+      return null
+    }
+
+    // Find contracts at those addresses that have the called function in their ABI
+    const functionName = call.calledFunction
+    const matches: HeuristicMatch[] = []
+
+    for (const entry of discovered.entries) {
+      if (entry.type !== 'Contract') continue
+      if (!valueAddresses.has(entry.address.toLowerCase())) continue
+
+      // Check if this contract has the called function in its ABI
+      const abiAddresses = [entry.address]
+      const implValue = entry.values?.$implementation
+      if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
+        abiAddresses.push(implValue as typeof entry.address)
+      }
+
+      let hasFunction = false
+      for (const abiAddress of abiAddresses) {
+        const abi = discovered.abis[abiAddress]
+        if (!abi) continue
+
+        hasFunction = abi.some((abiEntry) => {
+          if (!abiEntry.startsWith('function ')) return false
+          const match = abiEntry.match(/^function\s+(\w+)\(/)
+          return match && match[1] === functionName
+        })
+
+        if (hasFunction) break
+      }
+
+      if (hasFunction) {
+        matches.push({
+          address: entry.address,
+          contractName: entry.name,
+        })
+      }
+    }
+
+    if (matches.length === 0) {
+      return null
+    }
+
+    const confidence = this.calculateConfidence(matches.length)
+    return { matches, confidence }
+  }
+
+  private calculateConfidence(matchCount: number): number {
+    if (matchCount === 1) return 95
+    if (matchCount === 2) return 70
+    return 50
   }
 }
 
@@ -512,6 +634,7 @@ export function createHeuristicEngine(): HeuristicEngine {
 
   // Register heuristics in order of reliability
   engine.register(new VariableChainHeuristic())
+  engine.register(new DiscoveredValuesScanHeuristic())
   engine.register(new InterfaceNameHeuristic())
   engine.register(new FunctionSignatureHeuristic())
 


### PR DESCRIPTION
Improving the callgraph for a special case in liquity where the contract calls 2 different oracles, 

we now differentiate the calls and register the two dependencies.

Some small fixes in the liquity-v2 config as well.