### PR TITLE
Standardize address formatting: remove hardcoded eth: prefix 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,7 +366,7 @@ Internal helper: `contractHasFunction(discovered, entry, functionName)` — chec
 - `buildExternalAddressSet(tags)` / `buildTagsByAddress(tags)` — build lookup structures from contract tags
 - `isExternalAddress(address, externalAddresses)` / `findTag(tagsByAddress, address)` — address matching with `eth:` prefix normalization
 - `getCallGraphContractName(callGraphData, address)` — resolve contract name from call graph data
-- `extractEthAddresses(value)` — extract all `eth:` addresses from a value (handles flat strings and one-level-deep object fields)
+- `extractChainAddresses(value)` — extract all chain-prefixed addresses from a value (handles flat strings and one-level-deep object fields). Legacy alias `extractEthAddresses` is deprecated
 
 ### Enhanced Traversal & Function Analysis ✅
 
@@ -696,6 +696,7 @@ packages/
 │   ├── FunctionBreakdown.tsx         # Functions section
 │   ├── ReviewDescriptionsEditor.tsx  # Review descriptions editor (Descriptions tab)
 │   ├── ReviewResourcesEditor.tsx    # Resources editor (links, frontends, socials)
+│   ├── addressUtils.ts             # Frontend address utilities (stripChainPrefix, addressesEqual, normalizeForLookup, findByAddress)
 │   └── icons/
 ├── l2b/src/implementations/discovery-ui/defidisco/
 │   ├── permissionOverrides.ts
@@ -706,7 +707,8 @@ packages/
 │   ├── callGraph.ts                  # Slither-based external call detection
 │   ├── callGraphHeuristics.ts        # Heuristic engine for variable-to-address resolution
 │   ├── enhancedTraversal.ts          # Backward BFS governance chains
-│   └── functionAnalysis.ts           # Forward BFS impact & dependencies
+│   ├── functionAnalysis.ts           # Forward BFS impact & dependencies
+│   └── addressUtils.ts              # Backend address utilities (stripChainPrefix, ensureChainPrefix, addressesEqual, isChainAddress)
 ├── defiscan-frontend/                # Standalone public review website
 │   ├── scripts/compile-data.ts       # Build-time data aggregation
 │   └── src/                          # React app (see README.md for structure)
@@ -729,9 +731,9 @@ packages/
 - **Permission Overrides**: Use `useQuery` with `getPermissionOverrides(project)` directly (no hook exists)
 - **Address Format**:
   - **IMPORTANT**: Contract addresses use `eth:` prefix in ALL data files (functions.json, contract-tags.json, discovered.json)
-  - When comparing addresses, keep the prefix: `address1.toLowerCase() === address2.toLowerCase()`
+  - When comparing addresses, use `addressesEqual(a, b)` from `addressUtils.ts` (handles mixed prefix formats)
+  - For map lookups, use `normalizeForLookup(address)` which ensures chain prefix + lowercase
   - **Do NOT strip** the `eth:` prefix unless specifically needed for display purposes
-  - Example: `eth:0x123...` should match `eth:0x123...` (both lowercase)
 - **EOA Counting**: EOAs stored separately in `entry.eoas[]` array, not mixed with contracts
 
 **Contract Tags Data Structure**:

--- a/packages/defiscan-frontend/scripts/compile-data.ts
+++ b/packages/defiscan-frontend/scripts/compile-data.ts
@@ -115,14 +115,14 @@ function main() {
     const fundsDataPath = join(DATA_DIR, slug, 'funds-data.json')
     if (existsSync(fundsDataPath) && review.funds) {
       const fundsData: FundsData = JSON.parse(readFileSync(fundsDataPath, 'utf8'))
-      // Build case-insensitive lookup with eth: prefix normalization
+      // Build case-insensitive lookup with chain prefix normalization
       const fundsLookup = new Map<string, FundsData['contracts'][string]>()
       for (const [addr, data] of Object.entries(fundsData.contracts ?? {})) {
-        fundsLookup.set(addr.replace(/^eth:/i, '').toLowerCase(), data)
+        fundsLookup.set(addr.toLowerCase(), data)
       }
       let patched = 0
       for (const fund of review.funds) {
-        const normalizedAddr = fund.address.replace(/^eth:/i, '').toLowerCase()
+        const normalizedAddr = fund.address.toLowerCase()
         const contractFunds = fundsLookup.get(normalizedAddr)
         if (!contractFunds) continue
         if (contractFunds.balances) {
@@ -201,7 +201,7 @@ function main() {
     // For each dependency, sum capital of admins whose functions use this dependency
     // This avoids attributing the entire protocol TVL to every dependency
     for (const dep of review.dependencies) {
-      const key = dep.address.toLowerCase()
+      const key = dep.address.toLowerCase() // normalized for deduplication across protocols
       // Compute capital controlled by admins that call through this dependency
       const depContractAddresses = new Set(dep.functions.map((f) => f.contractAddress.toLowerCase()))
       let depCapital = 0

--- a/packages/defiscan-frontend/scripts/compile-data.ts
+++ b/packages/defiscan-frontend/scripts/compile-data.ts
@@ -5,6 +5,11 @@ import { fileURLToPath } from 'url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
+/** Strip chain prefix and lowercase for consistent address comparison */
+function stripChainPrefix(a: string): string {
+  return a.replace(/^[a-z0-9]+:/i, '').toLowerCase()
+}
+
 interface CompiledReview {
   metadata: {
     protocolName: string
@@ -118,11 +123,11 @@ function main() {
       // Build case-insensitive lookup with chain prefix normalization
       const fundsLookup = new Map<string, FundsData['contracts'][string]>()
       for (const [addr, data] of Object.entries(fundsData.contracts ?? {})) {
-        fundsLookup.set(addr.toLowerCase(), data)
+        fundsLookup.set(stripChainPrefix(addr), data)
       }
       let patched = 0
       for (const fund of review.funds) {
-        const normalizedAddr = fund.address.toLowerCase()
+        const normalizedAddr = stripChainPrefix(fund.address)
         const contractFunds = fundsLookup.get(normalizedAddr)
         if (!contractFunds) continue
         if (contractFunds.balances) {
@@ -201,13 +206,13 @@ function main() {
     // For each dependency, sum capital of admins whose functions use this dependency
     // This avoids attributing the entire protocol TVL to every dependency
     for (const dep of review.dependencies) {
-      const key = dep.address.toLowerCase() // normalized for deduplication across protocols
+      const key = stripChainPrefix(dep.address) // normalized for deduplication across protocols
       // Compute capital controlled by admins that call through this dependency
-      const depContractAddresses = new Set(dep.functions.map((f) => f.contractAddress.toLowerCase()))
+      const depContractAddresses = new Set(dep.functions.map((f) => stripChainPrefix(f.contractAddress)))
       let depCapital = 0
       for (const admin of review.admins) {
         const usesThisDep = admin.functions.some(
-          (f) => depContractAddresses.has(f.contractAddress.toLowerCase()),
+          (f) => depContractAddresses.has(stripChainPrefix(f.contractAddress)),
         )
         if (usesThisDep) {
           depCapital += admin.totalDirectCapital

--- a/packages/defiscan-frontend/src/utils/format.ts
+++ b/packages/defiscan-frontend/src/utils/format.ts
@@ -12,13 +12,32 @@ export function formatUsdValue(value: number): string {
   return `$${value.toFixed(2)}`
 }
 
+/**
+ * Strip the chain prefix from an address.
+ * Works with any chain prefix (eth:, arb1:, base:, etc.).
+ */
+export function stripChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(colonIdx + 1)
+  }
+  return address
+}
+
+/**
+ * Normalize an address for use as a lookup key (lowercase).
+ */
+export function normalizeForLookup(address: string): string {
+  return address.toLowerCase()
+}
+
 export function truncateAddress(address: string): string {
-  const raw = address.startsWith('eth:') ? address.slice(4) : address
+  const raw = stripChainPrefix(address)
   if (raw.length <= 10) return raw
   return `${raw.slice(0, 6)}...${raw.slice(-4)}`
 }
 
 export function etherscanUrl(address: string): string {
-  const raw = address.startsWith('eth:') ? address.slice(4) : address
+  const raw = stripChainPrefix(address)
   return `https://etherscan.io/address/${raw}`
 }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/addressUtils.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/addressUtils.ts
@@ -1,0 +1,172 @@
+import { EthereumAddress } from '@l2beat/shared-pure'
+
+/**
+ * Address utility functions for DeFiDisco.
+ *
+ * All internal addresses use the chain-prefixed format "chain:0xChecksummed".
+ * These helpers ensure addresses are always normalized on ingestion and
+ * compared without ad-hoc toLowerCase() calls scattered through the codebase.
+ */
+
+// ---------------------------------------------------------------------------
+// Core: normalize a chain-prefixed address to checksummed form
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a chain-prefixed address (e.g. "eth:0xabc...") so that:
+ *  - the chain prefix is preserved as-is (lowercase by convention)
+ *  - the hex address part is ERC-55 checksummed
+ *
+ * If the address has no chain prefix it is returned with "eth:" prepended
+ * (legacy compatibility). If the hex part is invalid the input is returned
+ * unchanged so callers don't crash on non-address strings.
+ */
+export function normalizeChainAddress(raw: string): string {
+  const colonIdx = raw.indexOf(':')
+
+  let chain: string
+  let hex: string
+
+  if (colonIdx !== -1 && !raw.startsWith('0x')) {
+    chain = raw.slice(0, colonIdx)
+    hex = raw.slice(colonIdx + 1)
+  } else {
+    // No chain prefix – treat as ethereum
+    chain = 'eth'
+    hex = raw
+  }
+
+  if (!hex.startsWith('0x') || hex.length !== 42) {
+    return raw // not an address, return as-is
+  }
+
+  try {
+    const checksummed = EthereumAddress(hex)
+    return `${chain}:${checksummed}`
+  } catch {
+    return raw
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Comparison helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two chain-prefixed addresses for equality.
+ * Handles mixed casing and optional chain prefix gracefully.
+ */
+export function addressesEqual(a: string, b: string): boolean {
+  return normalizeChainAddress(a) === normalizeChainAddress(b)
+}
+
+/**
+ * Strip the chain prefix from an address.
+ * Works with any chain prefix (eth:, arb1:, base:, etc.).
+ */
+export function stripChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(colonIdx + 1)
+  }
+  return address
+}
+
+/**
+ * Get only the chain prefix from a chain-specific address.
+ * Returns 'eth' as default if no prefix is found.
+ */
+export function getChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(0, colonIdx)
+  }
+  return 'eth'
+}
+
+/**
+ * Ensure an address has a chain prefix.
+ * If it already has one, normalizes the checksumming.
+ * If it doesn't, prepends 'eth:' by default.
+ */
+export function ensureChainPrefix(
+  address: string,
+  chain = 'eth',
+): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return normalizeChainAddress(address)
+  }
+  return normalizeChainAddress(`${chain}:${address}`)
+}
+
+/**
+ * Check if a string looks like a chain-prefixed address.
+ */
+export function isChainAddress(value: string): boolean {
+  const colonIdx = value.indexOf(':')
+  if (colonIdx === -1 || value.startsWith('0x')) return false
+  const hex = value.slice(colonIdx + 1)
+  return hex.startsWith('0x') && hex.length === 42
+}
+
+// ---------------------------------------------------------------------------
+// Collection helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a case-insensitive lookup Set from an array of addresses.
+ * All entries are normalized so lookups don't need toLowerCase().
+ */
+export function buildAddressSet(addresses: string[]): Set<string> {
+  return new Set(addresses.map(normalizeChainAddress))
+}
+
+/**
+ * Check if an address is in a normalized address set.
+ */
+export function isInAddressSet(address: string, set: Set<string>): boolean {
+  return set.has(normalizeChainAddress(address))
+}
+
+/**
+ * Build a Map keyed by normalized addresses.
+ */
+export function buildAddressMap<T>(
+  entries: Array<[string, T]>,
+): Map<string, T> {
+  const map = new Map<string, T>()
+  for (const [addr, value] of entries) {
+    map.set(normalizeChainAddress(addr), value)
+  }
+  return map
+}
+
+/**
+ * Look up a value in an address-keyed Map using normalized comparison.
+ */
+export function getFromAddressMap<T>(
+  map: Map<string, T>,
+  address: string,
+): T | undefined {
+  return map.get(normalizeChainAddress(address))
+}
+
+/**
+ * Look up a value in a plain object keyed by addresses.
+ * Tries the normalized form first, then falls back to scanning all keys.
+ */
+export function getFromAddressRecord<T>(
+  record: Record<string, T>,
+  address: string,
+): T | undefined {
+  const normalized = normalizeChainAddress(address)
+  if (normalized in record) return record[normalized]
+  // Fallback: scan keys (handles legacy data with non-checksummed keys)
+  for (const key of Object.keys(record)) {
+    if (normalizeChainAddress(key) === normalized) {
+      return record[key]
+    }
+  }
+  return undefined
+}

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/addressUtils.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/addressUtils.ts
@@ -89,10 +89,7 @@ export function getChainPrefix(address: string): string {
  * If it already has one, normalizes the checksumming.
  * If it doesn't, prepends 'eth:' by default.
  */
-export function ensureChainPrefix(
-  address: string,
-  chain = 'eth',
-): string {
+export function ensureChainPrefix(address: string, chain = 'eth'): string {
   const colonIdx = address.indexOf(':')
   if (colonIdx !== -1 && !address.startsWith('0x')) {
     return normalizeChainAddress(address)

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -7,6 +7,14 @@ import { spawn } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 import {
+  addressesEqual,
+  buildAddressSet,
+  isChainAddress,
+  isInAddressSet,
+  normalizeChainAddress,
+  stripChainPrefix,
+} from './addressUtils'
+import {
   createHeuristicEngine,
   type HeuristicContext,
   parseVariableAssignments,
@@ -472,7 +480,7 @@ function getSlithirCacheFilePath(
   contractAddress: string,
 ): string {
   // Use the address (without eth: prefix) as filename
-  const cleanAddress = contractAddress.replace(/^eth:/i, '')
+  const cleanAddress = stripChainPrefix(contractAddress)
   return path.join(
     getSlithirCacheFolderPath(paths, project),
     `${cleanAddress}.json`,
@@ -521,7 +529,7 @@ function getContractSourceHash(
   slitherAddress: string,
 ): string | undefined {
   const entry = discovered.entries.find(
-    (e) => e.address.toLowerCase() === entryAddress.toLowerCase(),
+    (e) => addressesEqual(e.address, entryAddress),
   )
 
   if (!entry?.sourceHashes || entry.sourceHashes.length === 0) {
@@ -531,7 +539,7 @@ function getContractSourceHash(
   // For proxies (entryAddress !== slitherAddress), use only the implementation hash
   // to avoid cache thrashing when two proxies share one implementation.
   // sourceHashes order: [proxy, implementation] — last element is the implementation.
-  if (entryAddress.toLowerCase() !== slitherAddress.toLowerCase()) {
+  if (!addressesEqual(entryAddress, slitherAddress)) {
     return entry.sourceHashes[entry.sourceHashes.length - 1]
   }
 
@@ -564,10 +572,10 @@ function getContractsToAnalyze(
 ): ContractToAnalyze[] {
   // Load contract tags to identify external contracts
   const tags = getContractTags(paths, project)
-  const externalAddresses = new Set(
+  const externalAddresses = buildAddressSet(
     tags.tags
       .filter((tag) => tag.isExternal)
-      .map((tag) => tag.contractAddress.toLowerCase()),
+      .map((tag) => tag.contractAddress),
   )
 
   const contracts: ContractToAnalyze[] = []
@@ -576,8 +584,7 @@ function getContractsToAnalyze(
     if (entry.type !== 'Contract') continue
 
     // Skip external contracts
-    const normalizedAddress = entry.address.toLowerCase()
-    if (externalAddresses.has(normalizedAddress)) continue
+    if (isInAddressSet(entry.address, externalAddresses)) continue
 
     const displayName = entry.name || 'Unknown'
     const implNames = entry.implementationNames
@@ -590,7 +597,7 @@ function getContractsToAnalyze(
       // Get implementation address from values.$implementation
       const implValue = entry.values?.$implementation
 
-      if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
+      if (typeof implValue === 'string' && isChainAddress(implValue)) {
         // Proxy contract — analyze the implementation
         const implAddress = implValue as typeof entry.address
         const implName = implNames?.[implAddress] ?? displayName
@@ -636,12 +643,12 @@ function getContractsToAnalyze(
  * Handles flat strings and one-level-deep object fields (e.g., oracle structs
  * with an `aggregator` address alongside non-address fields like `stalenessThreshold`).
  */
-export function extractEthAddresses(value: unknown): string[] {
-  if (typeof value === 'string' && value.startsWith('eth:')) return [value]
+export function extractChainAddresses(value: unknown): string[] {
+  if (typeof value === 'string' && isChainAddress(value)) return [value]
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
     const addresses: string[] = []
     for (const v of Object.values(value)) {
-      if (typeof v === 'string' && v.startsWith('eth:')) {
+      if (typeof v === 'string' && isChainAddress(v)) {
         addresses.push(v)
       }
     }
@@ -649,6 +656,9 @@ export function extractEthAddresses(value: unknown): string[] {
   }
   return []
 }
+
+/** @deprecated Use extractChainAddresses instead */
+export const extractEthAddresses = extractChainAddresses
 
 /**
  * Resolve storage variable to actual contract address using discovered.json
@@ -661,7 +671,7 @@ function resolveStorageVariable(
   // Find the contract in discovered data
   const contract = discovered.entries.find(
     (e) =>
-      e.address.toLowerCase() === contractAddress.toLowerCase() &&
+      addressesEqual(e.address, contractAddress) &&
       e.type === 'Contract',
   )
 
@@ -672,10 +682,10 @@ function resolveStorageVariable(
   // Look up the storage variable in contract values
   const value = contract.values[storageVariable]
 
-  if (typeof value === 'string' && value.startsWith('eth:')) {
+  if (typeof value === 'string' && isChainAddress(value)) {
     // Find the name of the resolved contract
     const resolvedContract = discovered.entries.find(
-      (e) => e.address.toLowerCase() === value.toLowerCase(),
+      (e) => addressesEqual(e.address, value),
     )
     return {
       address: value,
@@ -685,11 +695,11 @@ function resolveStorageVariable(
 
   // Handle nested objects (e.g., oracle structs like { aggregator: "eth:0x...", decimals: 8 }).
   // Only deterministic if exactly one address is found (unambiguous).
-  const addresses = extractEthAddresses(value)
+  const addresses = extractChainAddresses(value)
   if (addresses.length === 1) {
     const addr = addresses[0]!
     const resolvedContract = discovered.entries.find(
-      (e) => e.address.toLowerCase() === addr.toLowerCase(),
+      (e) => addressesEqual(e.address, addr),
     )
     return {
       address: addr,
@@ -1187,7 +1197,7 @@ async function runSlitherOnContract(
     }
 
     // Clean address - remove eth: prefix
-    const cleanAddress = address.replace(/^eth:/i, '')
+    const cleanAddress = stripChainPrefix(address)
 
     onProgress?.(`Running slither on ${cleanAddress}...`)
 
@@ -1311,7 +1321,7 @@ export function traverseWithPaths(
   while (queue.length > 0) {
     const { contract, function: func, pathIsViewOnly, path } = queue.shift()!
 
-    const visitKey = `${contract.toLowerCase()}:${func}`
+    const visitKey = `${normalizeChainAddress(contract)}:${func}`
     if (visited.has(visitKey)) continue
     visited.add(visitKey)
 
@@ -1394,19 +1404,15 @@ export function findContractGraph(
   const direct = callGraphData.contracts[contract]
   if (direct) return direct
   const entry = Object.entries(callGraphData.contracts).find(
-    ([addr]) => addr.toLowerCase() === contract.toLowerCase(),
+    ([addr]) => addressesEqual(addr, contract),
   )
   return entry ? entry[1] : undefined
 }
 
 export function buildExternalAddressSet(tags: ContractTag[]): Set<string> {
-  const set = new Set<string>()
-  for (const tag of tags) {
-    if (tag.isExternal) {
-      set.add(tag.contractAddress.toLowerCase())
-    }
-  }
-  return set
+  return buildAddressSet(
+    tags.filter((tag) => tag.isExternal).map((tag) => tag.contractAddress),
+  )
 }
 
 export function buildTagsByAddress(
@@ -1414,7 +1420,7 @@ export function buildTagsByAddress(
 ): Map<string, ContractTag> {
   const map = new Map<string, ContractTag>()
   for (const tag of tags) {
-    map.set(tag.contractAddress.toLowerCase(), tag)
+    map.set(normalizeChainAddress(tag.contractAddress), tag)
   }
   return map
 }
@@ -1423,32 +1429,22 @@ export function isExternalAddress(
   address: string,
   externalAddresses: Set<string>,
 ): boolean {
-  const normalized = address.toLowerCase()
-  if (externalAddresses.has(normalized)) return true
-  if (externalAddresses.has(normalized.replace('eth:', ''))) return true
-  if (externalAddresses.has(`eth:${normalized}`)) return true
-  return false
+  return isInAddressSet(address, externalAddresses)
 }
 
 export function findTag(
   tagsByAddress: Map<string, ContractTag>,
   address: string,
 ): ContractTag | undefined {
-  const normalized = address.toLowerCase()
-  return (
-    tagsByAddress.get(normalized) ??
-    tagsByAddress.get(normalized.replace('eth:', '')) ??
-    tagsByAddress.get(`eth:${normalized}`)
-  )
+  return tagsByAddress.get(normalizeChainAddress(address))
 }
 
 export function getCallGraphContractName(
   callGraphData: ApiCallGraphResponse,
   address: string,
 ): string | undefined {
-  const normalizedAddress = address.toLowerCase()
   const entry = Object.entries(callGraphData.contracts).find(
-    ([key]) => key.toLowerCase() === normalizedAddress,
+    ([key]) => addressesEqual(key, address),
   )
   return entry?.[1]?.name
 }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -528,8 +528,8 @@ function getContractSourceHash(
   entryAddress: string,
   slitherAddress: string,
 ): string | undefined {
-  const entry = discovered.entries.find(
-    (e) => addressesEqual(e.address, entryAddress),
+  const entry = discovered.entries.find((e) =>
+    addressesEqual(e.address, entryAddress),
   )
 
   if (!entry?.sourceHashes || entry.sourceHashes.length === 0) {
@@ -573,9 +573,7 @@ function getContractsToAnalyze(
   // Load contract tags to identify external contracts
   const tags = getContractTags(paths, project)
   const externalAddresses = buildAddressSet(
-    tags.tags
-      .filter((tag) => tag.isExternal)
-      .map((tag) => tag.contractAddress),
+    tags.tags.filter((tag) => tag.isExternal).map((tag) => tag.contractAddress),
   )
 
   const contracts: ContractToAnalyze[] = []
@@ -670,9 +668,7 @@ function resolveStorageVariable(
 ): { address: string | undefined; name: string | undefined } {
   // Find the contract in discovered data
   const contract = discovered.entries.find(
-    (e) =>
-      addressesEqual(e.address, contractAddress) &&
-      e.type === 'Contract',
+    (e) => addressesEqual(e.address, contractAddress) && e.type === 'Contract',
   )
 
   if (!contract || !('values' in contract) || !contract.values) {
@@ -684,8 +680,8 @@ function resolveStorageVariable(
 
   if (typeof value === 'string' && isChainAddress(value)) {
     // Find the name of the resolved contract
-    const resolvedContract = discovered.entries.find(
-      (e) => addressesEqual(e.address, value),
+    const resolvedContract = discovered.entries.find((e) =>
+      addressesEqual(e.address, value),
     )
     return {
       address: value,
@@ -698,8 +694,8 @@ function resolveStorageVariable(
   const addresses = extractChainAddresses(value)
   if (addresses.length === 1) {
     const addr = addresses[0]!
-    const resolvedContract = discovered.entries.find(
-      (e) => addressesEqual(e.address, addr),
+    const resolvedContract = discovered.entries.find((e) =>
+      addressesEqual(e.address, addr),
     )
     return {
       address: addr,
@@ -1403,8 +1399,8 @@ export function findContractGraph(
 ) {
   const direct = callGraphData.contracts[contract]
   if (direct) return direct
-  const entry = Object.entries(callGraphData.contracts).find(
-    ([addr]) => addressesEqual(addr, contract),
+  const entry = Object.entries(callGraphData.contracts).find(([addr]) =>
+    addressesEqual(addr, contract),
   )
   return entry ? entry[1] : undefined
 }
@@ -1443,8 +1439,8 @@ export function getCallGraphContractName(
   callGraphData: ApiCallGraphResponse,
   address: string,
 ): string | undefined {
-  const entry = Object.entries(callGraphData.contracts).find(
-    ([key]) => addressesEqual(key, address),
+  const entry = Object.entries(callGraphData.contracts).find(([key]) =>
+    addressesEqual(key, address),
   )
   return entry?.[1]?.name
 }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -1,5 +1,6 @@
 import type { DiscoveryOutput } from '@l2beat/discovery'
-import { extractEthAddresses } from './callGraph'
+import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+import { extractChainAddresses } from './callGraph'
 import type { ExternalCall, ResolutionCandidate } from './types'
 
 // =============================================================================
@@ -49,7 +50,7 @@ function contractHasFunction(
 ): boolean {
   const abiAddresses = [entry.address]
   const implValue = entry.values?.$implementation
-  if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
+  if (typeof implValue === 'string' && isChainAddress(implValue)) {
     abiAddresses.push(implValue as typeof entry.address)
   }
 
@@ -92,7 +93,7 @@ class VariableChainHeuristic implements ResolutionHeuristic {
     // Look up the caller contract's values first
     const contract = discovered.entries.find(
       (e) =>
-        e.address.toLowerCase() === callerContractAddress.toLowerCase() &&
+        addressesEqual(e.address, callerContractAddress) &&
         e.type === 'Contract',
     )
 
@@ -115,9 +116,9 @@ class VariableChainHeuristic implements ResolutionHeuristic {
 
     const value = contract.values[resolvedVar]
 
-    if (typeof value === 'string' && value.startsWith('eth:')) {
+    if (typeof value === 'string' && isChainAddress(value)) {
       const resolvedContract = discovered.entries.find(
-        (e) => e.address.toLowerCase() === value.toLowerCase(),
+        (e) => addressesEqual(e.address, value),
       )
 
       return {
@@ -133,12 +134,12 @@ class VariableChainHeuristic implements ResolutionHeuristic {
 
     // Handle nested objects (e.g., oracle structs like { aggregator: "eth:0x...", decimals: 8 })
     // Filter to addresses that actually have the called function in their ABI
-    const addresses = extractEthAddresses(value)
+    const addresses = extractChainAddresses(value)
     if (addresses.length > 0) {
       const validMatches = addresses
         .map((addr) => {
           const entry = discovered.entries.find(
-            (e) => e.address.toLowerCase() === addr.toLowerCase(),
+            (e) => addressesEqual(e.address, addr),
           )
           return { address: addr, contractName: entry?.name, entry }
         })
@@ -350,7 +351,7 @@ class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
     // Find the caller contract's values
     const callerContract = discovered.entries.find(
       (e) =>
-        e.address.toLowerCase() === callerContractAddress.toLowerCase() &&
+        addressesEqual(e.address, callerContractAddress) &&
         e.type === 'Contract',
     )
 
@@ -365,8 +366,8 @@ class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
     // Collect all eth: addresses from the caller's values (one level deep into objects)
     const valueAddresses = new Set<string>()
     for (const value of Object.values(callerContract.values)) {
-      for (const addr of extractEthAddresses(value)) {
-        valueAddresses.add(addr.toLowerCase())
+      for (const addr of extractChainAddresses(value)) {
+        valueAddresses.add(normalizeChainAddress(addr))
       }
     }
 
@@ -380,7 +381,7 @@ class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
 
     for (const entry of discovered.entries) {
       if (entry.type !== 'Contract') continue
-      if (!valueAddresses.has(entry.address.toLowerCase())) continue
+      if (!valueAddresses.has(normalizeChainAddress(entry.address))) continue
 
       if (contractHasFunction(discovered, entry, functionName)) {
         matches.push({

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -1,5 +1,9 @@
 import type { DiscoveryOutput } from '@l2beat/discovery'
-import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+import {
+  addressesEqual,
+  isChainAddress,
+  normalizeChainAddress,
+} from './addressUtils'
 import { extractChainAddresses } from './callGraph'
 import type { ExternalCall, ResolutionCandidate } from './types'
 
@@ -117,8 +121,8 @@ class VariableChainHeuristic implements ResolutionHeuristic {
     const value = contract.values[resolvedVar]
 
     if (typeof value === 'string' && isChainAddress(value)) {
-      const resolvedContract = discovered.entries.find(
-        (e) => addressesEqual(e.address, value),
+      const resolvedContract = discovered.entries.find((e) =>
+        addressesEqual(e.address, value),
       )
 
       return {
@@ -138,8 +142,8 @@ class VariableChainHeuristic implements ResolutionHeuristic {
     if (addresses.length > 0) {
       const validMatches = addresses
         .map((addr) => {
-          const entry = discovered.entries.find(
-            (e) => addressesEqual(e.address, addr),
+          const entry = discovered.entries.find((e) =>
+            addressesEqual(e.address, addr),
           )
           return { address: addr, contractName: entry?.name, entry }
         })

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphTraversal.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphTraversal.ts
@@ -74,7 +74,10 @@ export class CallGraphTraverser {
         // Try case-insensitive lookup
         const contractGraphEntry = Object.entries(
           this.callGraphData.contracts,
-        ).find(([addr]) => normalizeChainAddress(addr) === normalizeChainAddress(contract))
+        ).find(
+          ([addr]) =>
+            normalizeChainAddress(addr) === normalizeChainAddress(contract),
+        )
         if (!contractGraphEntry) continue
         // Use the found contract graph
         const [, foundGraph] = contractGraphEntry

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphTraversal.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphTraversal.ts
@@ -1,3 +1,4 @@
+import { normalizeChainAddress } from './addressUtils'
 import type {
   ApiCallGraphResponse,
   CallGraphTraversalResult,
@@ -63,7 +64,7 @@ export class CallGraphTraverser {
       const { contract, function: func, pathIsViewOnly } = queue.shift()!
 
       // Create visit key for cycle detection
-      const visitKey = `${contract.toLowerCase()}:${func}`
+      const visitKey = `${normalizeChainAddress(contract)}:${func}`
       if (visited.has(visitKey)) continue
       visited.add(visitKey)
 
@@ -73,7 +74,7 @@ export class CallGraphTraverser {
         // Try case-insensitive lookup
         const contractGraphEntry = Object.entries(
           this.callGraphData.contracts,
-        ).find(([addr]) => addr.toLowerCase() === contract.toLowerCase())
+        ).find(([addr]) => normalizeChainAddress(addr) === normalizeChainAddress(contract))
         if (!contractGraphEntry) continue
         // Use the found contract graph
         const [, foundGraph] = contractGraphEntry

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
@@ -211,8 +211,8 @@ export class CapitalAnalysisCalculator {
       // Check if we have call graph data for this contract
       const hasCallGraphData =
         this.callGraphData.contracts[func.contractAddress] !== undefined ||
-        Object.keys(this.callGraphData.contracts).some(
-          (addr) => addressesEqual(addr, func.contractAddress),
+        Object.keys(this.callGraphData.contracts).some((addr) =>
+          addressesEqual(addr, func.contractAddress),
         )
 
       if (!hasCallGraphData) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
@@ -1,3 +1,4 @@
+import { addressesEqual, normalizeChainAddress } from './addressUtils'
 import { CallGraphTraverser } from './callGraphTraversal'
 import type {
   AdminDetail,
@@ -45,10 +46,10 @@ export class CapitalAnalysisCalculator {
     functionName: string,
   ): boolean {
     // Case-insensitive lookup for the contract
-    const normalizedAddress = contractAddress.toLowerCase()
+    const normalizedAddress = normalizeChainAddress(contractAddress)
     const contractEntry = Object.entries(
       this.functionsData.contracts ?? {},
-    ).find(([key]) => key.toLowerCase() === normalizedAddress)
+    ).find(([key]) => normalizeChainAddress(key) === normalizedAddress)
 
     if (!contractEntry) return false
     const contractFunctions = contractEntry[1]
@@ -89,9 +90,9 @@ export class CapitalAnalysisCalculator {
     if (!this.fundsData?.contracts) return 0
 
     // Case-insensitive lookup
-    const normalizedAddress = contractAddress.toLowerCase()
+    const normalizedAddress = normalizeChainAddress(contractAddress)
     const fundsEntry = Object.entries(this.fundsData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddress,
+      ([key]) => normalizeChainAddress(key) === normalizedAddress,
     )
 
     if (!fundsEntry) return 0
@@ -111,9 +112,9 @@ export class CapitalAnalysisCalculator {
   getContractTokenValue(contractAddress: string): number {
     if (!this.fundsData?.contracts) return 0
 
-    const normalizedAddress = contractAddress.toLowerCase()
+    const normalizedAddress = normalizeChainAddress(contractAddress)
     const fundsEntry = Object.entries(this.fundsData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddress,
+      ([key]) => normalizeChainAddress(key) === normalizedAddress,
     )
 
     if (!fundsEntry) return 0
@@ -147,7 +148,7 @@ export class CapitalAnalysisCalculator {
 
     for (const [addr, data] of traversalResult.reachableContracts) {
       // Skip self-reference (the starting contract)
-      if (addr.toLowerCase() === contractAddress.toLowerCase()) continue
+      if (addressesEqual(addr, contractAddress)) continue
 
       const fundsUsd = this.getContractFunds(addr)
       const tokenValueUsd = this.getContractTokenValue(addr)
@@ -201,7 +202,7 @@ export class CapitalAnalysisCalculator {
     const functionsWithCapital: FunctionCapitalAnalysis[] = []
 
     // Track unique contracts to avoid double-counting
-    // Key: contract address (lowercase), Value: whether funds are at risk
+    // Key: contract address (normalized), Value: whether funds are at risk
     const contractsAtRisk = new Map<string, boolean>()
     const directContracts = new Set<string>()
 
@@ -211,12 +212,12 @@ export class CapitalAnalysisCalculator {
       const hasCallGraphData =
         this.callGraphData.contracts[func.contractAddress] !== undefined ||
         Object.keys(this.callGraphData.contracts).some(
-          (addr) => addr.toLowerCase() === func.contractAddress.toLowerCase(),
+          (addr) => addressesEqual(addr, func.contractAddress),
         )
 
       if (!hasCallGraphData) {
         // No call graph data - just track direct capital
-        directContracts.add(func.contractAddress.toLowerCase())
+        directContracts.add(normalizeChainAddress(func.contractAddress))
         continue
       }
 
@@ -230,11 +231,11 @@ export class CapitalAnalysisCalculator {
       functionsWithCapital.push(analysis)
 
       // Track direct contracts (always counted since the permissioned function has impact)
-      directContracts.add(func.contractAddress.toLowerCase())
+      directContracts.add(normalizeChainAddress(func.contractAddress))
 
       // Track reachable contracts - only mark as at risk if fundsAtRisk is true
       for (const reachable of analysis.reachableContracts) {
-        const addr = reachable.contractAddress.toLowerCase()
+        const addr = normalizeChainAddress(reachable.contractAddress)
         const existingRisk = contractsAtRisk.get(addr)
         // If any path marks it as at risk, it stays at risk
         if (existingRisk === true || reachable.fundsAtRisk) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/contractTags.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/contractTags.ts
@@ -1,6 +1,7 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
+import { addressesEqual, ensureChainPrefix } from './addressUtils'
 import type {
   ApiContractTagsResponse,
   ApiContractTagsUpdateRequest,
@@ -39,11 +40,8 @@ export function updateContractTag(
 ): void {
   const tagsPath = getContractTagsPath(paths, project)
 
-  // Ensure eth: prefix, preserve original case
-  const addressWithPrefix = updateRequest.contractAddress.startsWith('eth:')
-    ? updateRequest.contractAddress
-    : `eth:${updateRequest.contractAddress}`
-  const normalizedForLookup = addressWithPrefix.toLowerCase()
+  // Normalize address: ensure chain prefix and checksummed format
+  const normalizedAddress = ensureChainPrefix(updateRequest.contractAddress)
 
   // Load existing contract tags
   let contractTags: ContractTag[] = []
@@ -57,15 +55,10 @@ export function updateContractTag(
     }
   }
 
-  // Find existing tag for the same contract (case-insensitive comparison)
-  const existingTagIndex = contractTags.findIndex((tag) => {
-    const existingNormalized = (
-      tag.contractAddress.startsWith('eth:')
-        ? tag.contractAddress
-        : `eth:${tag.contractAddress}`
-    ).toLowerCase()
-    return existingNormalized === normalizedForLookup
-  })
+  // Find existing tag for the same contract (chain-aware comparison)
+  const existingTagIndex = contractTags.findIndex((tag) =>
+    addressesEqual(ensureChainPrefix(tag.contractAddress), normalizedAddress),
+  )
 
   // Determine the new values for all tag fields
   const existingTag =
@@ -97,7 +90,7 @@ export function updateContractTag(
   if (hasAnyTagData) {
     // Create or update tag entry
     const newTag: ContractTag = {
-      contractAddress: existingTag?.contractAddress ?? addressWithPrefix,
+      contractAddress: existingTag?.contractAddress ?? normalizedAddress,
       isExternal: newIsExternal,
       isGovernance: newIsGovernance || undefined, // Only store if true
       entity: newEntity || undefined,

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/enhancedTraversal.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/enhancedTraversal.ts
@@ -532,7 +532,10 @@ function deduplicateTerminals(
   const result: TraversalTerminal[] = []
   for (const terminal of terminals) {
     const chainSig = terminal.chain
-      .map((s) => `${normalizeChainAddress(s.contractAddress)}:${s.functionName ?? ''}`)
+      .map(
+        (s) =>
+          `${normalizeChainAddress(s.contractAddress)}:${s.functionName ?? ''}`,
+      )
       .join('→')
     const key = `${normalizeChainAddress(terminal.address)}|${chainSig}`
     if (seen.has(key)) continue

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/enhancedTraversal.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/enhancedTraversal.ts
@@ -6,6 +6,7 @@ import type {
 import * as fs from 'fs'
 import * as path from 'path'
 import { getProject } from '../getProject'
+import { normalizeChainAddress } from './addressUtils'
 import { getCallGraphData } from './callGraph'
 import {
   extractAddressesFromResolvedOwners,
@@ -118,7 +119,7 @@ function buildEnhancedGraph(
           }
         }
         if (errors.length > 0) {
-          const key = `${contractAddr.toLowerCase()}:${func.functionName}`
+          const key = `${normalizeChainAddress(contractAddr)}:${func.functionName}`
           constructionErrors.set(key, errors)
         }
 
@@ -150,7 +151,7 @@ function buildIndices(edges: EnhancedEdge[]): EnhancedGraph {
   const backwardIndex = new Map<string, EnhancedEdge[]>()
 
   for (const edge of edges) {
-    const fwdKey = edge.sourceContract.toLowerCase()
+    const fwdKey = normalizeChainAddress(edge.sourceContract)
     let fwdList = forwardIndex.get(fwdKey)
     if (!fwdList) {
       fwdList = []
@@ -158,7 +159,7 @@ function buildIndices(edges: EnhancedEdge[]): EnhancedGraph {
     }
     fwdList.push(edge)
 
-    const bwdKey = edge.targetContract.toLowerCase()
+    const bwdKey = normalizeChainAddress(edge.targetContract)
     let bwdList = backwardIndex.get(bwdKey)
     if (!bwdList) {
       bwdList = []
@@ -223,7 +224,7 @@ function traverse(
     return { terminals: [], errors: [], depthLimitReached: true }
   }
 
-  const visitKey = `${contractAddress.toLowerCase()}:${functionName ?? '*'}`
+  const visitKey = `${normalizeChainAddress(contractAddress)}:${functionName ?? '*'}`
 
   // Check memoization cache FIRST — reuse previous results with adjusted chain prefix.
   // Safe because cached results are fully computed (no risk of infinite loop).
@@ -401,7 +402,7 @@ function groupEdgesBySource(
 ): { sourceContract: string; edges: EnhancedEdge[] }[] {
   const groups = new Map<string, EnhancedEdge[]>()
   for (const edge of edges) {
-    const key = edge.sourceContract.toLowerCase()
+    const key = normalizeChainAddress(edge.sourceContract)
     let list = groups.get(key)
     if (!list) {
       list = []
@@ -420,7 +421,7 @@ function lookupBackwardEdges(
   ctx: TraversalContext,
   contractAddress: string,
 ): EnhancedEdge[] {
-  const normalized = contractAddress.toLowerCase()
+  const normalized = normalizeChainAddress(contractAddress)
 
   // Direct match
   const direct = ctx.graph.backwardIndex.get(normalized)
@@ -429,7 +430,7 @@ function lookupBackwardEdges(
   // impl → proxy fallback
   const proxyAddr = ctx.implToProxyMap.get(normalized)
   if (proxyAddr) {
-    const via = ctx.graph.backwardIndex.get(proxyAddr.toLowerCase())
+    const via = ctx.graph.backwardIndex.get(normalizeChainAddress(proxyAddr))
     if (via && via.length > 0) return via
   }
 
@@ -437,7 +438,7 @@ function lookupBackwardEdges(
   const implAddrs = ctx.proxyToImplsMap.get(normalized)
   if (implAddrs) {
     for (const implAddr of implAddrs) {
-      const via = ctx.graph.backwardIndex.get(implAddr.toLowerCase())
+      const via = ctx.graph.backwardIndex.get(normalizeChainAddress(implAddr))
       if (via && via.length > 0) return via
     }
   }
@@ -451,9 +452,9 @@ function findContractFunctions(
   contractAddress: string,
 ) {
   if (!functionsData.contracts) return undefined
-  const normalized = contractAddress.toLowerCase()
+  const normalized = normalizeChainAddress(contractAddress)
   const entry = Object.entries(functionsData.contracts).find(
-    ([key]) => key.toLowerCase() === normalized,
+    ([key]) => normalizeChainAddress(key) === normalized,
   )
   return entry ? entry[1] : undefined
 }
@@ -467,7 +468,7 @@ function findContractFunctionsWithMapping(
   let result = findContractFunctions(ctx.functionsData, address)
   if (result) return result
 
-  const normalized = address.toLowerCase()
+  const normalized = normalizeChainAddress(address)
 
   // impl → proxy fallback
   const proxyAddr = ctx.implToProxyMap.get(normalized)
@@ -505,9 +506,9 @@ function lookupType(
 ): ApiAddressType {
   const exact = typeMap.get(address)
   if (exact) return exact
-  const normalized = address.toLowerCase()
+  const normalized = normalizeChainAddress(address)
   for (const [key, value] of typeMap) {
-    if (key.toLowerCase() === normalized) return value
+    if (normalizeChainAddress(key) === normalized) return value
   }
   return 'Unknown'
 }
@@ -516,9 +517,9 @@ function lookupType(
 function lookupName(nameMap: Map<string, string>, address: string): string {
   const exact = nameMap.get(address)
   if (exact) return exact
-  const normalized = address.toLowerCase()
+  const normalized = normalizeChainAddress(address)
   for (const [key, value] of nameMap) {
-    if (key.toLowerCase() === normalized) return value
+    if (normalizeChainAddress(key) === normalized) return value
   }
   return address
 }
@@ -531,9 +532,9 @@ function deduplicateTerminals(
   const result: TraversalTerminal[] = []
   for (const terminal of terminals) {
     const chainSig = terminal.chain
-      .map((s) => `${s.contractAddress.toLowerCase()}:${s.functionName ?? ''}`)
+      .map((s) => `${normalizeChainAddress(s.contractAddress)}:${s.functionName ?? ''}`)
       .join('→')
-    const key = `${terminal.address.toLowerCase()}|${chainSig}`
+    const key = `${normalizeChainAddress(terminal.address)}|${chainSig}`
     if (seen.has(key)) continue
     seen.add(key)
     result.push(terminal)
@@ -611,12 +612,12 @@ export function resolveEnhancedTraversal(
     ]
     allContracts.forEach((contract: any) => {
       if (contract.implementationNames) {
-        const proxyAddr = contract.address.toLowerCase()
+        const proxyAddr = normalizeChainAddress(contract.address)
         const impls: string[] = []
         for (const implAddr of Object.keys(contract.implementationNames)) {
-          const implLower = implAddr.toLowerCase()
-          if (implLower !== proxyAddr) {
-            implToProxyMap.set(implLower, contract.address)
+          const implNormalized = normalizeChainAddress(implAddr)
+          if (implNormalized !== proxyAddr) {
+            implToProxyMap.set(implNormalized, contract.address)
             impls.push(implAddr)
           }
         }
@@ -679,7 +680,7 @@ export function resolveEnhancedTraversal(
         const terminals = deduplicateTerminals(result.terminals)
 
         // Merge construction errors for this function
-        const errorKey = `${contractAddress.toLowerCase()}:${func.functionName}`
+        const errorKey = `${normalizeChainAddress(contractAddress)}:${func.functionName}`
         const buildErrors = constructionErrors.get(errorKey) ?? []
         const allErrors = [
           ...new Set([

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/functionAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/functionAnalysis.ts
@@ -1,4 +1,5 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
+import { addressesEqual, normalizeChainAddress } from './addressUtils'
 import {
   buildExternalAddressSet,
   buildTagsByAddress,
@@ -117,7 +118,7 @@ function computeImpact(
 
   for (const [addr, data] of traversalResult.reachableContracts) {
     // Skip self-reference
-    if (addr.toLowerCase() === startContractAddress.toLowerCase()) continue
+    if (addressesEqual(addr, startContractAddress)) continue
 
     const fundsUsd = getContractFunds(fundsData, addr)
     const tokenValueUsd = getContractTokenValue(fundsData, addr)
@@ -186,12 +187,12 @@ function computeDependencies(
   // 1. Auto-detected: external contracts reachable via call graph
   for (const [addr, data] of traversalResult.reachableContracts) {
     // Skip self-reference
-    if (addr.toLowerCase() === startContractAddress.toLowerCase()) continue
+    if (addressesEqual(addr, startContractAddress)) continue
 
     // Only include external contracts
     if (!isExternalAddress(addr, externalAddresses)) continue
 
-    const normalized = addr.toLowerCase()
+    const normalized = normalizeChainAddress(addr)
     if (seenAddresses.has(normalized)) continue
     seenAddresses.add(normalized)
 
@@ -216,7 +217,7 @@ function computeDependencies(
   // 2. Manual dependencies (from functions.json)
   if (manualDeps) {
     for (const dep of manualDeps) {
-      const normalized = dep.contractAddress.toLowerCase()
+      const normalized = normalizeChainAddress(dep.contractAddress)
       if (seenAddresses.has(normalized)) continue
       seenAddresses.add(normalized)
 
@@ -249,9 +250,9 @@ function getContractFunds(
   contractAddress: string,
 ): number {
   if (!fundsData?.contracts) return 0
-  const normalizedAddress = contractAddress.toLowerCase()
+  const normalizedAddress = normalizeChainAddress(contractAddress)
   const fundsEntry = Object.entries(fundsData.contracts).find(
-    ([key]) => key.toLowerCase() === normalizedAddress,
+    ([key]) => normalizeChainAddress(key) === normalizedAddress,
   )
   if (!fundsEntry) return 0
   const funds = fundsEntry[1]
@@ -265,9 +266,9 @@ function getContractTokenValue(
   contractAddress: string,
 ): number {
   if (!fundsData?.contracts) return 0
-  const normalizedAddress = contractAddress.toLowerCase()
+  const normalizedAddress = normalizeChainAddress(contractAddress)
   const fundsEntry = Object.entries(fundsData.contracts).find(
-    ([key]) => key.toLowerCase() === normalizedAddress,
+    ([key]) => normalizeChainAddress(key) === normalizedAddress,
   )
   if (!fundsEntry) return 0
   return fundsEntry[1].tokenInfo?.tokenValue ?? 0
@@ -279,9 +280,9 @@ function isFunctionPermissioned(
   functionName: string,
 ): boolean {
   if (!functionsData.contracts) return false
-  const normalizedAddress = contractAddress.toLowerCase()
+  const normalizedAddress = normalizeChainAddress(contractAddress)
   const contractEntry = Object.entries(functionsData.contracts).find(
-    ([key]) => key.toLowerCase() === normalizedAddress,
+    ([key]) => normalizeChainAddress(key) === normalizedAddress,
   )
   if (!contractEntry) return false
   const func = contractEntry[1].functions.find(

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/functions.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/functions.ts
@@ -1,6 +1,7 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
+import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
 import { DiscoveredDataAccess, resolvePathExpression } from './ownerResolution'
 import type {
   ApiFunctionsResponse,
@@ -117,7 +118,7 @@ export function updateFunction(
 
   // Get or create contract entry (case-insensitive key lookup, preserve original case)
   const existingKey = Object.keys(userContracts).find(
-    (k) => k.toLowerCase() === contractAddress.toLowerCase(),
+    (k) => normalizeChainAddress(k) === normalizeChainAddress(contractAddress),
   )
   if (!existingKey) {
     userContracts[contractAddress] = { functions: [] }
@@ -250,7 +251,7 @@ export function deleteContractFunctions(
   // Remove the contract entry (case-insensitive key lookup)
   const keyToDelete =
     Object.keys(userContracts).find(
-      (k) => k.toLowerCase() === contractAddress.toLowerCase(),
+      (k) => normalizeChainAddress(k) === normalizeChainAddress(contractAddress),
     ) ?? contractAddress
   delete userContracts[keyToDelete]
 
@@ -372,7 +373,7 @@ function mergeContractFunctions(
   // Build case-insensitive lookup for user contracts
   const userLookup = new Map<string, ContractFunctions>()
   for (const [addr, contract] of Object.entries(userContracts)) {
-    userLookup.set(addr.toLowerCase(), contract)
+    userLookup.set(normalizeChainAddress(addr), contract)
   }
 
   // Track which discovered addresses we've processed (lowercase)
@@ -382,7 +383,7 @@ function mergeContractFunctions(
   for (const [contractAddress, discoveredContract] of Object.entries(
     discoveredContracts,
   )) {
-    const normalizedAddr = contractAddress.toLowerCase()
+    const normalizedAddr = normalizeChainAddress(contractAddress)
     discoveredAddrsLower.add(normalizedAddr)
     const userContract = userLookup.get(normalizedAddr)
 
@@ -416,7 +417,7 @@ function mergeContractFunctions(
 
   // Add user-only contracts (contracts that have user functions but no discovered data)
   for (const [contractAddress, userContract] of Object.entries(userContracts)) {
-    if (!discoveredAddrsLower.has(contractAddress.toLowerCase())) {
+    if (!discoveredAddrsLower.has(normalizeChainAddress(contractAddress))) {
       result[contractAddress] = { functions: [...userContract.functions] }
     }
   }
@@ -595,7 +596,7 @@ function extractAddressesFromValue(value: any, addresses: string[]): void {
   if (!value) return
 
   // If it's an address-like string
-  if (typeof value === 'string' && value.match(/^(eth:)?0x[a-fA-F0-9]{40}$/)) {
+  if (typeof value === 'string' && (isChainAddress(value) || /^0x[a-fA-F0-9]{40}$/.test(value))) {
     addresses.push(value)
     return
   }
@@ -647,7 +648,7 @@ export function resolveDelayFromDiscovered(
     const contractEntry = discovered.entries.find(
       (entry: any) =>
         entry.type === 'Contract' &&
-        entry.address.toLowerCase() === delayRef.contractAddress.toLowerCase(),
+        addressesEqual(entry.address, delayRef.contractAddress),
     )
 
     if (!contractEntry) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/functions.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/functions.ts
@@ -1,7 +1,11 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
-import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+import {
+  addressesEqual,
+  isChainAddress,
+  normalizeChainAddress,
+} from './addressUtils'
 import { DiscoveredDataAccess, resolvePathExpression } from './ownerResolution'
 import type {
   ApiFunctionsResponse,
@@ -251,7 +255,8 @@ export function deleteContractFunctions(
   // Remove the contract entry (case-insensitive key lookup)
   const keyToDelete =
     Object.keys(userContracts).find(
-      (k) => normalizeChainAddress(k) === normalizeChainAddress(contractAddress),
+      (k) =>
+        normalizeChainAddress(k) === normalizeChainAddress(contractAddress),
     ) ?? contractAddress
   delete userContracts[keyToDelete]
 
@@ -596,7 +601,10 @@ function extractAddressesFromValue(value: any, addresses: string[]): void {
   if (!value) return
 
   // If it's an address-like string
-  if (typeof value === 'string' && (isChainAddress(value) || /^0x[a-fA-F0-9]{40}$/.test(value))) {
+  if (
+    typeof value === 'string' &&
+    (isChainAddress(value) || /^0x[a-fA-F0-9]{40}$/.test(value))
+  ) {
     addresses.push(value)
     return
   }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/fundsData.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/fundsData.ts
@@ -1,6 +1,7 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
+import { addressesEqual, stripChainPrefix } from './addressUtils'
 import { getContractTags } from './contractTags'
 import type {
   ApiFundsDataResponse,
@@ -138,7 +139,7 @@ export async function fetchFundsForContract(
   let positionsCached = false
 
   // Normalize address - remove eth: prefix for API calls
-  const cleanAddress = contractAddress.replace(/^eth:/i, '')
+  const cleanAddress = stripChainPrefix(contractAddress)
   const forceRefreshParam = options.forceRefresh ? '&force_refresh=true' : ''
 
   try {
@@ -282,7 +283,7 @@ export async function fetchFundsForContract(
       if (options.discoveredData?.entries) {
         const contract = options.discoveredData.entries.find(
           (c: any) =>
-            c.address?.toLowerCase() === contractAddress.toLowerCase(),
+            c.address && addressesEqual(c.address, contractAddress),
         )
         if (contract?.values) {
           if (contract.values.totalSupply != null)
@@ -457,7 +458,7 @@ export async function fetchFundsForSingleContract(
 ): Promise<ApiFundsDataResponse> {
   const tags = getContractTags(paths, project)
   const tag = tags.tags.find(
-    (t) => t.contractAddress.toLowerCase() === contractAddress.toLowerCase(),
+    (t) => addressesEqual(t.contractAddress, contractAddress),
   )
 
   if (!tag || (!tag.fetchBalances && !tag.fetchPositions && !tag.isToken)) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/fundsData.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/fundsData.ts
@@ -282,8 +282,7 @@ export async function fetchFundsForContract(
       // discovered.json entries is a flat array of contracts with values
       if (options.discoveredData?.entries) {
         const contract = options.discoveredData.entries.find(
-          (c: any) =>
-            c.address && addressesEqual(c.address, contractAddress),
+          (c: any) => c.address && addressesEqual(c.address, contractAddress),
         )
         if (contract?.values) {
           if (contract.values.totalSupply != null)
@@ -457,8 +456,8 @@ export async function fetchFundsForSingleContract(
   forceRefresh = false,
 ): Promise<ApiFundsDataResponse> {
   const tags = getContractTags(paths, project)
-  const tag = tags.tags.find(
-    (t) => addressesEqual(t.contractAddress, contractAddress),
+  const tag = tags.tags.find((t) =>
+    addressesEqual(t.contractAddress, contractAddress),
   )
 
   if (!tag || (!tag.fetchBalances && !tag.fetchPositions && !tag.isToken)) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/ownerResolution.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/ownerResolution.ts
@@ -14,7 +14,11 @@
  *   "$self" → current contract itself is the owner
  */
 
-import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+import {
+  addressesEqual,
+  isChainAddress,
+  normalizeChainAddress,
+} from './addressUtils'
 
 // =============================================================================
 // Types
@@ -355,8 +359,8 @@ export class DiscoveredDataAccess implements IContractDataAccess {
       (entry: any) =>
         entry.type === 'Contract' &&
         entry.implementationNames &&
-        Object.keys(entry.implementationNames).some(
-          (implAddr: string) => addressesEqual(implAddr, normalized),
+        Object.keys(entry.implementationNames).some((implAddr: string) =>
+          addressesEqual(implAddr, normalized),
         ),
     )
     if (proxy) return proxy

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/ownerResolution.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/ownerResolution.ts
@@ -14,6 +14,8 @@
  *   "$self" → current contract itself is the owner
  */
 
+import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -121,7 +123,7 @@ export function parseValuePath(path: string): PathSegment[] {
  */
 export function extractAddresses(value: any, path: string): string[] {
   // Single string address
-  if (typeof value === 'string' && value.startsWith('eth:')) {
+  if (typeof value === 'string' && isChainAddress(value)) {
     return [value]
   }
 
@@ -129,7 +131,7 @@ export function extractAddresses(value: any, path: string): string[] {
   if (Array.isArray(value)) {
     const addresses: string[] = []
     for (const element of value) {
-      if (typeof element === 'string' && element.startsWith('eth:')) {
+      if (typeof element === 'string' && isChainAddress(element)) {
         addresses.push(element)
       } else if (typeof element === 'object' && element !== null) {
         // Recursively extract from object elements
@@ -146,7 +148,7 @@ export function extractAddresses(value: any, path: string): string[] {
     const addresses: string[] = []
     for (const key in value) {
       const prop = value[key]
-      if (typeof prop === 'string' && prop.startsWith('eth:')) {
+      if (typeof prop === 'string' && isChainAddress(prop)) {
         addresses.push(prop)
       } else if (typeof prop === 'object' && prop !== null) {
         // Recursively extract from nested objects/arrays
@@ -289,13 +291,13 @@ export function resolvePathExpression(
       if (
         !targetContractAddress ||
         typeof targetContractAddress !== 'string' ||
-        !targetContractAddress.startsWith('eth:')
+        !isChainAddress(targetContractAddress)
       ) {
         throw new Error(
           `Field "${fieldName}" not found or is not an address in current contract`,
         )
       }
-    } else if (contractRef.startsWith('eth:')) {
+    } else if (isChainAddress(contractRef)) {
       // Absolute contract address
       targetContractAddress = contractRef
     } else {
@@ -337,12 +339,12 @@ export class DiscoveredDataAccess implements IContractDataAccess {
       throw new Error('No entries found in discovered data')
     }
 
-    const normalized = address.toLowerCase()
+    const normalized = normalizeChainAddress(address)
 
     // Direct lookup by address
     const contract = this.discovered.entries.find(
       (entry: any) =>
-        entry.type === 'Contract' && entry.address.toLowerCase() === normalized,
+        entry.type === 'Contract' && addressesEqual(entry.address, normalized),
     )
     if (contract) return contract
 
@@ -354,7 +356,7 @@ export class DiscoveredDataAccess implements IContractDataAccess {
         entry.type === 'Contract' &&
         entry.implementationNames &&
         Object.keys(entry.implementationNames).some(
-          (implAddr: string) => implAddr.toLowerCase() === normalized,
+          (implAddr: string) => addressesEqual(implAddr, normalized),
         ),
     )
     if (proxy) return proxy
@@ -379,7 +381,7 @@ export class DiscoveredDataAccess implements IContractDataAccess {
     }
 
     // Handle string addresses (most common case)
-    if (typeof value === 'string' && value.startsWith('eth:')) {
+    if (typeof value === 'string' && isChainAddress(value)) {
       return value
     }
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -282,10 +282,7 @@ export class ReviewCompiler {
       ApiContractTagsResponse['tags'][number]
     >()
     for (const tag of contractTags.tags ?? []) {
-      tagsByAddress.set(
-        normalizeChainAddress(tag.contractAddress),
-        tag,
-      )
+      tagsByAddress.set(normalizeChainAddress(tag.contractAddress), tag)
     }
 
     // Case-insensitive lookup for funds data with eth: prefix normalization
@@ -298,10 +295,11 @@ export class ReviewCompiler {
     const admins: CompiledAdmin[] = []
     if (v2Score.inventory.admins.breakdown) {
       for (const admin of v2Score.inventory.admins.breakdown) {
-        const desc = getFromAddressRecord(reviewConfig.admins, admin.adminAddress)
-        const tag = tagsByAddress.get(
-          normalizeChainAddress(admin.adminAddress),
+        const desc = getFromAddressRecord(
+          reviewConfig.admins,
+          admin.adminAddress,
         )
+        const tag = tagsByAddress.get(normalizeChainAddress(admin.adminAddress))
 
         const withCapital = admin as AdminDetailWithCapital
         const hasCapital = 'totalDirectCapital' in withCapital
@@ -358,7 +356,10 @@ export class ReviewCompiler {
     if (v2Score.inventory.admins.breakdown) {
       for (const admin of v2Score.inventory.admins.breakdown) {
         for (const fn of admin.functions) {
-          contractNameMap.set(normalizeChainAddress(fn.contractAddress), fn.contractName)
+          contractNameMap.set(
+            normalizeChainAddress(fn.contractAddress),
+            fn.contractName,
+          )
         }
       }
     }
@@ -446,9 +447,7 @@ export class ReviewCompiler {
     // Build fund holders from funds data + review config descriptions
     const funds: CompiledFundHolder[] = []
     for (const [address, desc] of Object.entries(reviewConfig.funds ?? {})) {
-      const contractFunds = fundsLookup.get(
-        normalizeChainAddress(address),
-      )
+      const contractFunds = fundsLookup.get(normalizeChainAddress(address))
 
       funds.push({
         address,

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -16,6 +16,11 @@ import type {
 import { computeFunctionAnalysis } from './functionAnalysis'
 import { getFundsData } from './fundsData'
 import { getContractTags } from './contractTags'
+import {
+  normalizeChainAddress,
+  addressesEqual,
+  getFromAddressRecord,
+} from './addressUtils'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -278,7 +283,7 @@ export class ReviewCompiler {
     >()
     for (const tag of contractTags.tags ?? []) {
       tagsByAddress.set(
-        tag.contractAddress.replace(/^eth:/i, '').toLowerCase(),
+        normalizeChainAddress(tag.contractAddress),
         tag,
       )
     }
@@ -286,18 +291,16 @@ export class ReviewCompiler {
     // Case-insensitive lookup for funds data with eth: prefix normalization
     const fundsLookup = new Map<string, ContractFundsData>()
     for (const [addr, data] of Object.entries(fundsData.contracts ?? {})) {
-      fundsLookup.set(addr.replace(/^eth:/i, '').toLowerCase(), data)
+      fundsLookup.set(normalizeChainAddress(addr), data)
     }
 
     // Build admins from v2 scoring breakdown
     const admins: CompiledAdmin[] = []
     if (v2Score.inventory.admins.breakdown) {
       for (const admin of v2Score.inventory.admins.breakdown) {
-        const desc =
-          reviewConfig.admins[admin.adminAddress] ??
-          reviewConfig.admins[admin.adminAddress.toLowerCase()]
+        const desc = getFromAddressRecord(reviewConfig.admins, admin.adminAddress)
         const tag = tagsByAddress.get(
-          admin.adminAddress.replace(/^eth:/i, '').toLowerCase(),
+          normalizeChainAddress(admin.adminAddress),
         )
 
         const withCapital = admin as AdminDetailWithCapital
@@ -355,7 +358,7 @@ export class ReviewCompiler {
     if (v2Score.inventory.admins.breakdown) {
       for (const admin of v2Score.inventory.admins.breakdown) {
         for (const fn of admin.functions) {
-          contractNameMap.set(fn.contractAddress.toLowerCase(), fn.contractName)
+          contractNameMap.set(normalizeChainAddress(fn.contractAddress), fn.contractName)
         }
       }
     }
@@ -383,7 +386,7 @@ export class ReviewCompiler {
     )) {
       for (const [funcName, analysis] of Object.entries(contractFuncs)) {
         for (const dep of analysis.dependencies.entries) {
-          const key = dep.contractAddress.toLowerCase()
+          const key = normalizeChainAddress(dep.contractAddress)
           let existing = depMap.get(key)
           if (!existing) {
             existing = {
@@ -404,14 +407,14 @@ export class ReviewCompiler {
           // Add caller function (deduplicate)
           const alreadyAdded = existing.functions.some(
             (f) =>
-              f.contractAddress.toLowerCase() === contractAddr.toLowerCase() &&
+              addressesEqual(f.contractAddress, contractAddr) &&
               f.functionName === funcName,
           )
           if (!alreadyAdded) {
             existing.functions.push({
               contractAddress: contractAddr,
               contractName:
-                contractNameMap.get(contractAddr.toLowerCase()) ??
+                contractNameMap.get(normalizeChainAddress(contractAddr)) ??
                 'Unknown Contract',
               functionName: funcName,
               viewOnlyPath: dep.viewOnlyPath,
@@ -424,9 +427,7 @@ export class ReviewCompiler {
     // Build final CompiledDependency[] with review-config descriptions
     const dependencies: CompiledDependency[] = []
     for (const dep of depMap.values()) {
-      const desc =
-        reviewConfig.dependencies[dep.address] ??
-        reviewConfig.dependencies[dep.address.toLowerCase()]
+      const desc = getFromAddressRecord(reviewConfig.dependencies, dep.address)
 
       dependencies.push({
         address: dep.address,
@@ -446,7 +447,7 @@ export class ReviewCompiler {
     const funds: CompiledFundHolder[] = []
     for (const [address, desc] of Object.entries(reviewConfig.funds ?? {})) {
       const contractFunds = fundsLookup.get(
-        address.replace(/^eth:/i, '').toLowerCase(),
+        normalizeChainAddress(address),
       )
 
       funds.push({
@@ -609,14 +610,14 @@ export class ReviewCompiler {
           return this.resolveBreakdownPath(root, remainingPath)
         }
       } else if (dataPath.startsWith('fundsdata.')) {
-        // Lowercase contract address keys for case-insensitive matching
+        // Normalize contract address keys for case-insensitive matching
         const fundsData = { ...sources.fundsData }
         if (fundsData.contracts) {
-          const lowered: Record<string, any> = {}
+          const normalized: Record<string, any> = {}
           for (const [k, v] of Object.entries(fundsData.contracts)) {
-            lowered[k.toLowerCase()] = v
+            normalized[normalizeChainAddress(k)] = v
           }
-          fundsData.contracts = lowered as any
+          fundsData.contracts = normalized as any
         }
         root = fundsData
         remainingPath = dataPath.slice('fundsdata.'.length)
@@ -642,7 +643,7 @@ export class ReviewCompiler {
     if (!Array.isArray(breakdown)) return null
 
     const admin = breakdown.find(
-      (a: any) => a.adminAddress?.toLowerCase() === address.toLowerCase(),
+      (a: any) => a.adminAddress && addressesEqual(a.adminAddress, address),
     )
     if (!admin) return null
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewConfig.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewConfig.ts
@@ -1,6 +1,7 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
+import { ensureChainPrefix } from './addressUtils'
 import type {
   ApiReviewConfigResponse,
   ApiUpdateEntityDescriptionRequest,
@@ -66,9 +67,7 @@ export function updateEntityDescription(
     throw new Error('No review config exists for this project')
   }
 
-  const normalizedAddress = request.address.startsWith('eth:')
-    ? request.address
-    : `eth:${request.address}`
+  const normalizedAddress = ensureChainPrefix(request.address)
 
   const section = config[request.section]
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
@@ -381,7 +381,10 @@ class AdminInventoryModule {
           normalizeChainAddress(eoa.address),
           eoa.name || 'Unknown EOA',
         )
-        contractTypeMap.set(normalizeChainAddress(eoa.address), eoa.type || 'EOA')
+        contractTypeMap.set(
+          normalizeChainAddress(eoa.address),
+          eoa.type || 'EOA',
+        )
       })
     })
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
@@ -5,6 +5,11 @@ import type {
 } from '@l2beat/discovery'
 import { getProject } from '../getProject'
 import {
+  addressesEqual,
+  normalizeChainAddress,
+  stripChainPrefix,
+} from './addressUtils'
+import {
   buildExternalAddressSet,
   buildTagsByAddress,
   findTag,
@@ -150,8 +155,8 @@ class FunctionInventoryModule {
   private getContractName(projectData: any, contractAddress: string): string {
     if (!projectData?.entries) return contractAddress
 
-    // Normalize address for comparison (remove eth: prefix, lowercase for case-insensitive match)
-    const normalizedAddress = contractAddress.replace('eth:', '').toLowerCase()
+    // Normalize address for comparison (remove eth: prefix, checksummed for case-insensitive match)
+    const normalizedAddress = stripChainPrefix(contractAddress)
 
     for (const entry of projectData.entries) {
       // Check both initialContracts and discoveredContracts
@@ -161,8 +166,8 @@ class FunctionInventoryModule {
       ]
 
       for (const contract of contracts) {
-        const entryAddress = contract.address.replace('eth:', '').toLowerCase()
-        if (entryAddress === normalizedAddress) {
+        const entryAddress = stripChainPrefix(contract.address)
+        if (addressesEqual(entryAddress, normalizedAddress)) {
           return contract.name || contractAddress
         }
       }
@@ -181,7 +186,7 @@ class DependencyInventoryModule {
   name = 'dependencies'
 
   calculate(data: ScoringData): DependencyModuleScore {
-    // Build contract name lookup map (lowercase keys for case-insensitive lookup)
+    // Build contract name lookup map (normalized keys for case-insensitive lookup)
     const contractNameMap = new Map<string, string>()
     data.projectData.entries?.forEach((entry: any) => {
       const allContracts = [
@@ -190,7 +195,7 @@ class DependencyInventoryModule {
       ]
       allContracts.forEach((contract: any) => {
         contractNameMap.set(
-          contract.address.toLowerCase(),
+          normalizeChainAddress(contract.address),
           contract.name || 'Unknown Contract',
         )
       })
@@ -220,7 +225,7 @@ class DependencyInventoryModule {
 
             // 1. Auto-detected: external contracts reachable via call graph
             for (const [addr] of traversalResult.reachableContracts) {
-              if (addr.toLowerCase() === contractAddress.toLowerCase()) continue
+              if (addressesEqual(addr, contractAddress)) continue
               if (!isExternalAddress(addr, externalAddresses)) continue
 
               this.addDependency(
@@ -273,7 +278,7 @@ class DependencyInventoryModule {
     callerContractAddress: string,
     callerFunctionName: string,
   ) {
-    const normalizedDep = depAddress.toLowerCase()
+    const normalizedDep = normalizeChainAddress(depAddress)
 
     // Get or create dependency entry
     if (!dependenciesMap.has(normalizedDep)) {
@@ -300,7 +305,7 @@ class DependencyInventoryModule {
       depData.functions.push({
         contractAddress: callerContractAddress,
         contractName:
-          contractNameMap.get(callerContractAddress.toLowerCase()) ||
+          contractNameMap.get(normalizeChainAddress(callerContractAddress)) ||
           'Unknown Contract',
         functionName: callerFunctionName,
         impact: 'critical' as Impact,
@@ -322,8 +327,8 @@ function mapAdminType(
   normalizedAddress: string,
   proxyTypeMap: Map<string, string>,
 ): ApiAddressType {
-  // Strip eth: prefix for zero address comparison
-  const bareAddress = normalizedAddress.replace(/^eth:/i, '')
+  // Strip chain prefix for zero address comparison
+  const bareAddress = stripChainPrefix(normalizedAddress)
   if (bareAddress === ZERO_ADDRESS) {
     return 'Revoked'
   }
@@ -351,7 +356,7 @@ class AdminInventoryModule {
   name = 'admins'
 
   calculate(data: ScoringData): AdminModuleScore {
-    // Build contract name, type, and proxy type lookup maps (lowercase keys for case-insensitive lookup)
+    // Build contract name, type, and proxy type lookup maps (normalized keys for case-insensitive lookup)
     const contractNameMap = new Map<string, string>()
     const contractTypeMap = new Map<string, ApiAddressType>()
     const proxyTypeMap = new Map<string, string>()
@@ -362,7 +367,7 @@ class AdminInventoryModule {
         ...(entry.discoveredContracts || []),
       ]
       allContracts.forEach((contract: any) => {
-        const addr = contract.address.toLowerCase()
+        const addr = normalizeChainAddress(contract.address)
         contractNameMap.set(addr, contract.name || 'Unknown Contract')
         contractTypeMap.set(addr, contract.type || 'Contract')
         if (contract.proxyType) {
@@ -373,10 +378,10 @@ class AdminInventoryModule {
       // Also add EOAs
       entry.eoas?.forEach((eoa: any) => {
         contractNameMap.set(
-          eoa.address.toLowerCase(),
+          normalizeChainAddress(eoa.address),
           eoa.name || 'Unknown EOA',
         )
-        contractTypeMap.set(eoa.address.toLowerCase(), eoa.type || 'EOA')
+        contractTypeMap.set(normalizeChainAddress(eoa.address), eoa.type || 'EOA')
       })
     })
 
@@ -420,7 +425,7 @@ class AdminInventoryModule {
 
             // Process each admin address
             adminAddresses.forEach((adminAddr: string) => {
-              const normalizedAdmin = adminAddr.toLowerCase()
+              const normalizedAdmin = normalizeChainAddress(adminAddr)
               // Get or create admin entry
               if (!adminsMap.has(adminAddr)) {
                 const rawType =
@@ -444,7 +449,7 @@ class AdminInventoryModule {
               admin.functions.push({
                 contractAddress,
                 contractName:
-                  contractNameMap.get(contractAddress.toLowerCase()) ||
+                  contractNameMap.get(normalizeChainAddress(contractAddress)) ||
                   'Unknown Contract',
                 functionName: func.functionName,
                 impact: 'critical' as Impact,
@@ -489,7 +494,7 @@ class AdminInventoryModule {
       for (const admin of adminsWithCapital) {
         // Direct contracts (all functions, including those without call graph)
         for (const func of admin.functions) {
-          const addr = func.contractAddress.toLowerCase()
+          const addr = normalizeChainAddress(func.contractAddress)
           if (!contractCapitalMap.has(addr)) {
             contractCapitalMap.set(addr, {
               funds: capitalCalculator.getContractFunds(addr),
@@ -501,7 +506,7 @@ class AdminInventoryModule {
         for (const funcAnalysis of admin.functionsWithCapital) {
           for (const rc of funcAnalysis.reachableContracts) {
             if (!rc.fundsAtRisk) continue
-            const addr = rc.contractAddress.toLowerCase()
+            const addr = normalizeChainAddress(rc.contractAddress)
             if (!contractCapitalMap.has(addr)) {
               contractCapitalMap.set(addr, {
                 funds: rc.fundsUsd,

--- a/packages/protocolbeat/src/apps/discovery/defidisco/CallGraphPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/CallGraphPanel.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { getCallGraphData, getCode } from '../../../api/api'
 import type { ContractCallGraph, ExternalCall } from '../../../api/types'
+import { stripChainPrefix } from './addressUtils'
 import { useCodeStore } from '../../../components/editor/store'
 import { useMultiViewStore } from '../multi-view/store'
 import { usePanelStore } from '../store/panel-store'
@@ -308,7 +309,7 @@ function ContractSection({
             {contract.name}
           </span>
           <span className="text-coffee-400 text-xs">
-            {contract.address.replace('eth:', '').slice(0, 10)}...
+            {stripChainPrefix(contract.address).slice(0, 10)}...
           </span>
         </div>
         <span className={`text-xs ${getStatusColor()}`}>{getStatusText()}</span>

--- a/packages/protocolbeat/src/apps/discovery/defidisco/DeFiScanPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/DeFiScanPanel.tsx
@@ -8,6 +8,7 @@ import { V2ScoringSection } from '../../../defidisco/V2ScoringSection'
 import { usePanelStore } from '../store/panel-store'
 import { FundsSection } from './FundsSection'
 import { formatUsdValue } from '../../../defidisco/scoringShared'
+import { addressesEqual, normalizeForLookup, stripChainPrefix } from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { resolvePathExpression, UIContractDataAccess } from './ownerResolution'
 import { ProxyTypeTag } from './ProxyTypeTag'
@@ -52,13 +53,9 @@ export function DeFiScanPanel() {
     contracts: Object.fromEntries(
       Object.entries(functions.contracts || {}).filter(
         ([contractAddress, _]) => {
-          // Normalize address format - remove 'eth:' prefix and convert to lowercase
-          const normalizedAddress = contractAddress
-            .replace('eth:', '')
-            .toLowerCase()
           const tag = contractTags.tags.find(
             (tag: any) =>
-              tag.contractAddress.toLowerCase() === normalizedAddress,
+              addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(contractAddress)),
           )
           return tag?.isExternal !== true
         },
@@ -162,10 +159,8 @@ function StatusOfReviewSection({
 
   allContracts.forEach((contract) => {
     // Check if contract is explicitly marked as external in contract tags
-    // Both contracts and tags use 'eth:0x...' format - just normalize to lowercase
-    const contractAddr = contract.address.toLowerCase()
     const tag = contractTags.tags.find(
-      (tag: any) => tag.contractAddress.toLowerCase() === contractAddr,
+      (tag: any) => addressesEqual(tag.contractAddress, contract.address),
     )
     const isExternal = tag?.isExternal === true
 
@@ -199,9 +194,8 @@ function StatusOfReviewSection({
   // Check for external EOAs and adjust counts
   let externalEoas = 0
   allEoas.forEach((eoa) => {
-    const eoaAddress = eoa.address.replace('eth:', '').toLowerCase()
     const tag = contractTags.tags.find(
-      (tag: any) => tag.contractAddress?.toLowerCase() === eoaAddress,
+      (tag: any) => addressesEqual(stripChainPrefix(tag.contractAddress ?? ''), stripChainPrefix(eoa.address)),
     )
     if (tag?.isExternal === true) {
       externalEoas++
@@ -331,7 +325,7 @@ function getContractDisplayName(contract: {
   address: string
   name: string
 }): string {
-  const shortAddress = contract.address.replace('eth:', '').slice(0, 10)
+  const shortAddress = stripChainPrefix(contract.address).slice(0, 10)
   return `${contract.name} (${shortAddress}...)`
 }
 
@@ -429,9 +423,9 @@ function ContractsWithPermissionsTable({
   const getContractFunds = (address: string): number => {
     if (!fundsData?.contracts) return 0
     // Funds data keys may have different case, so do case-insensitive lookup
-    const normalizedAddress = address.toLowerCase()
+    const normalizedAddress = normalizeForLookup(address)
     const fundsEntry = Object.entries(fundsData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddress,
+      ([key]) => normalizeForLookup(key) === normalizedAddress,
     )
     if (!fundsEntry) return 0
     const funds = fundsEntry[1]
@@ -646,7 +640,7 @@ function ContractsWithPermissionsTable({
                     {getContractDisplayName(contract)}
                   </span>
                   <ProxyTypeTag
-                    proxyType={proxyTypeMap.get(contract.address.toLowerCase())}
+                    proxyType={proxyTypeMap.get(normalizeForLookup(contract.address))}
                   />
                   {hasFunds && (
                     <span className="text-aux-green">

--- a/packages/protocolbeat/src/apps/discovery/defidisco/DeFiScanPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/DeFiScanPanel.tsx
@@ -8,7 +8,11 @@ import { V2ScoringSection } from '../../../defidisco/V2ScoringSection'
 import { usePanelStore } from '../store/panel-store'
 import { FundsSection } from './FundsSection'
 import { formatUsdValue } from '../../../defidisco/scoringShared'
-import { addressesEqual, normalizeForLookup, stripChainPrefix } from './addressUtils'
+import {
+  addressesEqual,
+  normalizeForLookup,
+  stripChainPrefix,
+} from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { resolvePathExpression, UIContractDataAccess } from './ownerResolution'
 import { ProxyTypeTag } from './ProxyTypeTag'
@@ -53,9 +57,11 @@ export function DeFiScanPanel() {
     contracts: Object.fromEntries(
       Object.entries(functions.contracts || {}).filter(
         ([contractAddress, _]) => {
-          const tag = contractTags.tags.find(
-            (tag: any) =>
-              addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(contractAddress)),
+          const tag = contractTags.tags.find((tag: any) =>
+            addressesEqual(
+              stripChainPrefix(tag.contractAddress),
+              stripChainPrefix(contractAddress),
+            ),
           )
           return tag?.isExternal !== true
         },
@@ -159,8 +165,8 @@ function StatusOfReviewSection({
 
   allContracts.forEach((contract) => {
     // Check if contract is explicitly marked as external in contract tags
-    const tag = contractTags.tags.find(
-      (tag: any) => addressesEqual(tag.contractAddress, contract.address),
+    const tag = contractTags.tags.find((tag: any) =>
+      addressesEqual(tag.contractAddress, contract.address),
     )
     const isExternal = tag?.isExternal === true
 
@@ -194,8 +200,11 @@ function StatusOfReviewSection({
   // Check for external EOAs and adjust counts
   let externalEoas = 0
   allEoas.forEach((eoa) => {
-    const tag = contractTags.tags.find(
-      (tag: any) => addressesEqual(stripChainPrefix(tag.contractAddress ?? ''), stripChainPrefix(eoa.address)),
+    const tag = contractTags.tags.find((tag: any) =>
+      addressesEqual(
+        stripChainPrefix(tag.contractAddress ?? ''),
+        stripChainPrefix(eoa.address),
+      ),
     )
     if (tag?.isExternal === true) {
       externalEoas++
@@ -640,7 +649,9 @@ function ContractsWithPermissionsTable({
                     {getContractDisplayName(contract)}
                   </span>
                   <ProxyTypeTag
-                    proxyType={proxyTypeMap.get(normalizeForLookup(contract.address))}
+                    proxyType={proxyTypeMap.get(
+                      normalizeForLookup(contract.address),
+                    )}
                   />
                   {hasFunds && (
                     <span className="text-aux-green">

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ExternalButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ExternalButton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { ControlButton } from '../panel-nodes/controls/ControlButton'
 import { useStore } from '../panel-nodes/store/store'
+import { findByAddress } from './addressUtils'
 import { DependencyPropagationDialog } from './DependencyPropagationDialog'
 import { EntitySelector } from './EntitySelector'
 import {
@@ -126,13 +127,10 @@ function AttributePicker({
   // Get current entity from first selected node's tag
   const currentEntity = useMemo(() => {
     if (selectedNodes.length > 0 && selectedNodes[0]) {
-      const normalizedNodeAddress = selectedNodes[0].address
-        .toLowerCase()
-        .replace('eth:', '')
-      const tag = contractTags?.tags.find(
-        (tag) =>
-          tag.contractAddress.toLowerCase().replace('eth:', '') ===
-          normalizedNodeAddress,
+      const tag = findByAddress(
+        contractTags?.tags ?? [],
+        (t) => t.contractAddress,
+        selectedNodes[0].address,
       )
       return tag?.entity
     }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ExternalIndicator.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ExternalIndicator.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { IS_READONLY } from '../../../config/readonly'
+import { findByAddress } from './addressUtils'
 import { DependencyPropagationDialog } from './DependencyPropagationDialog'
 import { EntitySelector } from './EntitySelector'
 import { GovernanceIndicator } from './GovernanceIndicator'
@@ -30,11 +31,10 @@ export function ExternalIndicator({
   const [showEntityPicker, setShowEntityPicker] = useState(false)
 
   const currentEntity = useMemo(() => {
-    const normalizeAddress = (addr: string) =>
-      addr.toLowerCase().replace('eth:', '')
-    const normalized = normalizeAddress(address)
-    return contractTags?.tags.find(
-      (t) => normalizeAddress(t.contractAddress) === normalized,
+    return findByAddress(
+      contractTags?.tags ?? [],
+      (t) => t.contractAddress,
+      address,
     )?.entity
   }, [contractTags, address])
 

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FunctionFolder.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FunctionFolder.tsx
@@ -29,7 +29,11 @@ import {
   isZeroAddress,
   MIN_TOKEN_USD_VALUE,
 } from '../../../defidisco/scoringShared'
-import { addressesEqual, normalizeForLookup, stripChainPrefix } from './addressUtils'
+import {
+  addressesEqual,
+  normalizeForLookup,
+  stripChainPrefix,
+} from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { IconCheckFalse } from './IconCheckFalse'
 import { IconCheckTrue } from './IconCheckTrue'
@@ -84,7 +88,9 @@ function collapseChains(
   // Group by contract address sequence
   const groups = new Map<string, TraversalTerminal['chain'][]>()
   for (const chain of chains) {
-    const key = chain.map((s) => normalizeForLookup(s.contractAddress)).join('\u2192')
+    const key = chain
+      .map((s) => normalizeForLookup(s.contractAddress))
+      .join('\u2192')
     const group = groups.get(key)
     if (group) {
       group.push(chain)
@@ -578,9 +584,7 @@ export function FunctionFolder({
       // Address normalization is now handled in the backend when saving
       const contract = projectData.entries
         .flatMap((e) => [...e.initialContracts, ...e.discoveredContracts])
-        .find(
-          (c) => addressesEqual(c.address, tag.contractAddress),
-        )
+        .find((c) => addressesEqual(c.address, tag.contractAddress))
 
       if (contract) {
         contracts.push({
@@ -1471,7 +1475,10 @@ export function FunctionFolder({
                   if (!contractTags?.tags) return false
                   return contractTags.tags.some(
                     (tag) =>
-                      addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(addr)) && tag.isGovernance,
+                      addressesEqual(
+                        stripChainPrefix(tag.contractAddress),
+                        stripChainPrefix(addr),
+                      ) && tag.isGovernance,
                   )
                 }
                 const isKeyOwner = (owner: GroupedOwner) =>

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FunctionFolder.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FunctionFolder.tsx
@@ -29,6 +29,7 @@ import {
   isZeroAddress,
   MIN_TOKEN_USD_VALUE,
 } from '../../../defidisco/scoringShared'
+import { addressesEqual, normalizeForLookup, stripChainPrefix } from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { IconCheckFalse } from './IconCheckFalse'
 import { IconCheckTrue } from './IconCheckTrue'
@@ -83,7 +84,7 @@ function collapseChains(
   // Group by contract address sequence
   const groups = new Map<string, TraversalTerminal['chain'][]>()
   for (const chain of chains) {
-    const key = chain.map((s) => s.contractAddress.toLowerCase()).join('\u2192')
+    const key = chain.map((s) => normalizeForLookup(s.contractAddress)).join('\u2192')
     const group = groups.get(key)
     if (group) {
       group.push(chain)
@@ -126,7 +127,7 @@ function groupOwnersByAddress(owners: TraversalTerminal[]): GroupedOwner[] {
     }
   >()
   for (const owner of owners) {
-    const key = owner.address.toLowerCase()
+    const key = normalizeForLookup(owner.address)
     const existing = grouped.get(key)
     if (existing) {
       existing.chains.push(owner.chain)
@@ -346,9 +347,9 @@ export function FunctionFolder({
 
   const contractFunds: ContractFundsData | null = React.useMemo(() => {
     if (!fundsData?.contracts) return null
-    const normalizedAddr = contractAddress.toLowerCase()
+    const normalizedAddr = normalizeForLookup(contractAddress)
     const entry = Object.entries(fundsData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddr,
+      ([key]) => normalizeForLookup(key) === normalizedAddr,
     )
     return entry?.[1] ?? null
   }, [fundsData, contractAddress])
@@ -364,9 +365,9 @@ export function FunctionFolder({
     React.useMemo(() => {
       if (!traversalData?.contracts) return null
       // Case-insensitive lookup — functions.json keys may differ in case from project data
-      const normalizedAddr = contractAddress.toLowerCase()
+      const normalizedAddr = normalizeForLookup(contractAddress)
       const contractEntry = Object.entries(traversalData.contracts).find(
-        ([key]) => key.toLowerCase() === normalizedAddr,
+        ([key]) => normalizeForLookup(key) === normalizedAddr,
       )
       return contractEntry?.[1]?.[functionName] ?? null
     }, [traversalData, contractAddress, functionName])
@@ -380,9 +381,9 @@ export function FunctionFolder({
 
   const functionAnalysis: FunctionAnalysis | null = React.useMemo(() => {
     if (!analysisData?.contracts) return null
-    const normalizedAddr = contractAddress.toLowerCase()
+    const normalizedAddr = normalizeForLookup(contractAddress)
     const contractEntry = Object.entries(analysisData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddr,
+      ([key]) => normalizeForLookup(key) === normalizedAddr,
     )
     return contractEntry?.[1]?.[functionName] ?? null
   }, [analysisData, contractAddress, functionName])
@@ -578,7 +579,7 @@ export function FunctionFolder({
       const contract = projectData.entries
         .flatMap((e) => [...e.initialContracts, ...e.discoveredContracts])
         .find(
-          (c) => c.address.toLowerCase() === tag.contractAddress.toLowerCase(),
+          (c) => addressesEqual(c.address, tag.contractAddress),
         )
 
       if (contract) {
@@ -1468,11 +1469,9 @@ export function FunctionFolder({
                 )
                 const isGovernanceAddress = (addr: string) => {
                   if (!contractTags?.tags) return false
-                  const norm = addr.toLowerCase().replace('eth:', '')
                   return contractTags.tags.some(
                     (tag) =>
-                      tag.contractAddress.toLowerCase().replace('eth:', '') ===
-                        norm && tag.isGovernance,
+                      addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(addr)) && tag.isGovernance,
                   )
                 }
                 const isKeyOwner = (owner: GroupedOwner) =>

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FundsSection.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FundsSection.tsx
@@ -11,6 +11,7 @@ import {
   formatUsdValue,
   MIN_TOKEN_USD_VALUE,
 } from '../../../defidisco/scoringShared'
+import { normalizeForLookup, stripChainPrefix } from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { ProxyTypeTag } from './ProxyTypeTag'
 import { buildProxyTypeMap } from './proxyTypeUtils'
@@ -48,7 +49,7 @@ function ContractFundsRow({
     (fundsData.balances?.totalUsdValue ?? 0) +
     (fundsData.positions?.totalUsdValue ?? 0)
 
-  const shortAddress = contractAddress.replace('eth:', '').slice(0, 10) + '...'
+  const shortAddress = stripChainPrefix(contractAddress).slice(0, 10) + '...'
   const displayName = contractName || shortAddress
 
   const handleSelectClick = (e: React.MouseEvent) => {
@@ -187,7 +188,7 @@ function TokenContractRow({
   const [isExpanded, setIsExpanded] = useState(false)
   const tokenInfo = fundsData.tokenInfo
 
-  const shortAddress = contractAddress.replace('eth:', '').slice(0, 10) + '...'
+  const shortAddress = stripChainPrefix(contractAddress).slice(0, 10) + '...'
   const displayName = contractName || shortAddress
 
   const handleSelectClick = (e: React.MouseEvent) => {
@@ -442,7 +443,7 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
     projectData.entries.forEach((entry: any) => {
       ;[...entry.initialContracts, ...entry.discoveredContracts].forEach(
         (c: any) => {
-          map.set(c.address.toLowerCase(), c.name)
+          map.set(normalizeForLookup(c.address), c.name)
         },
       )
     })
@@ -461,12 +462,7 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
     if (contractTags?.tags) {
       for (const tag of contractTags.tags) {
         if (tag.isToken) {
-          const normalized = tag.contractAddress
-            .toLowerCase()
-            .startsWith('eth:')
-            ? tag.contractAddress.toLowerCase()
-            : `eth:${tag.contractAddress.toLowerCase()}`
-          set.add(normalized)
+          set.add(normalizeForLookup(tag.contractAddress))
         }
       }
     }
@@ -479,7 +475,7 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
     const fundsEntries: [string, ContractFundsData][] = []
     if (fundsData?.contracts) {
       for (const [address, data] of Object.entries(fundsData.contracts)) {
-        if (tokenAddressSet.has(address.toLowerCase())) {
+        if (tokenAddressSet.has(normalizeForLookup(address))) {
           tokenEntries.push([address, data])
         } else {
           fundsEntries.push([address, data])
@@ -669,8 +665,8 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
                       key={address}
                       contractAddress={address}
                       fundsData={data}
-                      contractName={contractNameMap.get(address.toLowerCase())}
-                      proxyType={proxyTypeMap.get(address.toLowerCase())}
+                      contractName={contractNameMap.get(normalizeForLookup(address))}
+                      proxyType={proxyTypeMap.get(normalizeForLookup(address))}
                       onSelect={() => usePanelStore.getState().select(address)}
                     />
                   ))}
@@ -690,8 +686,8 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
                       key={address}
                       contractAddress={address}
                       fundsData={data}
-                      contractName={contractNameMap.get(address.toLowerCase())}
-                      proxyType={proxyTypeMap.get(address.toLowerCase())}
+                      contractName={contractNameMap.get(normalizeForLookup(address))}
+                      proxyType={proxyTypeMap.get(normalizeForLookup(address))}
                       onSelect={() => usePanelStore.getState().select(address)}
                     />
                   ))}

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FundsSection.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FundsSection.tsx
@@ -665,7 +665,9 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
                       key={address}
                       contractAddress={address}
                       fundsData={data}
-                      contractName={contractNameMap.get(normalizeForLookup(address))}
+                      contractName={contractNameMap.get(
+                        normalizeForLookup(address),
+                      )}
                       proxyType={proxyTypeMap.get(normalizeForLookup(address))}
                       onSelect={() => usePanelStore.getState().select(address)}
                     />
@@ -686,7 +688,9 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
                       key={address}
                       contractAddress={address}
                       fundsData={data}
-                      contractName={contractNameMap.get(normalizeForLookup(address))}
+                      contractName={contractNameMap.get(
+                        normalizeForLookup(address),
+                      )}
                       proxyType={proxyTypeMap.get(normalizeForLookup(address))}
                       onSelect={() => usePanelStore.getState().select(address)}
                     />

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FundsTagsButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FundsTagsButton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { ControlButton } from '../panel-nodes/controls/ControlButton'
 import { useStore } from '../panel-nodes/store/store'
+import { findByAddress } from './addressUtils'
 import { useContractTags, useUpdateContractTag } from './hooks/useContractTags'
 
 export function FundsTagsButton() {
@@ -24,13 +25,10 @@ export function FundsTagsButton() {
   // Get current funds settings for first selected node
   const getCurrentSettings = () => {
     if (selectedNodes.length > 0 && selectedNodes[0]) {
-      const normalizedNodeAddress = selectedNodes[0].address
-        .toLowerCase()
-        .replace('eth:', '')
-      const tag = contractTags?.tags.find(
-        (tag) =>
-          tag.contractAddress.toLowerCase().replace('eth:', '') ===
-          normalizedNodeAddress,
+      const tag = findByAddress(
+        contractTags?.tags ?? [],
+        (t) => t.contractAddress,
+        selectedNodes[0].address,
       )
       return {
         fetchBalances: tag?.fetchBalances ?? false,
@@ -111,11 +109,10 @@ export function FundsTagsButton() {
 
   // Count selected nodes that have funds fetching enabled
   const fundsEnabledCount = selectedNodes.filter((node) => {
-    const normalizedNodeAddress = node.address.toLowerCase().replace('eth:', '')
-    const tag = contractTags?.tags.find(
-      (tag) =>
-        tag.contractAddress.toLowerCase().replace('eth:', '') ===
-        normalizedNodeAddress,
+    const tag = findByAddress(
+      contractTags?.tags ?? [],
+      (t) => t.contractAddress,
+      node.address,
     )
     return tag?.fetchBalances || tag?.fetchPositions || tag?.isToken
   }).length

--- a/packages/protocolbeat/src/apps/discovery/defidisco/GovernanceButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/GovernanceButton.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { ControlButton } from '../panel-nodes/controls/ControlButton'
 import { useStore } from '../panel-nodes/store/store'
+import { findByAddress } from './addressUtils'
 import { useContractTags, useUpdateContractTag } from './hooks/useContractTags'
 
 export function GovernanceButton() {
@@ -18,12 +19,12 @@ export function GovernanceButton() {
   const selectionExists = selected.length > 0
 
   const hasGovernanceContract = selectedNodes.some((node) => {
-    const normalizedNodeAddress = node.address.toLowerCase().replace('eth:', '')
-    return contractTags?.tags.some(
-      (tag) =>
-        tag.contractAddress.toLowerCase().replace('eth:', '') ===
-          normalizedNodeAddress && tag.isGovernance,
+    const tag = findByAddress(
+      contractTags?.tags ?? [],
+      (t) => t.contractAddress,
+      node.address,
     )
+    return tag?.isGovernance
   })
 
   const handleToggle = async () => {

--- a/packages/protocolbeat/src/apps/discovery/defidisco/GovernanceIndicator.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/GovernanceIndicator.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom'
 import { IS_READONLY } from '../../../config/readonly'
+import { findByAddress } from './addressUtils'
 import { useContractTags, useUpdateContractTag } from './hooks/useContractTags'
 
 export function GovernanceIndicator({ address }: { address: string }) {
@@ -9,11 +10,10 @@ export function GovernanceIndicator({ address }: { address: string }) {
   const { data: contractTags } = useContractTags(project)
   const updateContractTag = useUpdateContractTag(project)
 
-  const normalizeAddress = (addr: string) =>
-    addr.toLowerCase().replace('eth:', '')
-
-  const tag = contractTags?.tags.find(
-    (t) => normalizeAddress(t.contractAddress) === normalizeAddress(address),
+  const tag = findByAddress(
+    contractTags?.tags ?? [],
+    (t) => t.contractAddress,
+    address,
   )
   const isGovernance = tag?.isGovernance ?? false
 

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ListItemExternalDeps.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ListItemExternalDeps.tsx
@@ -7,6 +7,7 @@ import { IconChevronDown } from '../../../icons/IconChevronDown'
 import { IconChevronRight } from '../../../icons/IconChevronRight'
 import { IconFolder } from '../../../icons/IconFolder'
 import { IconFolderOpened } from '../../../icons/IconFolderOpened'
+import { addressesEqual, stripChainPrefix } from './addressUtils'
 import { usePanelStore } from '../store/panel-store'
 import { AddressEntry } from './AddressEntry'
 
@@ -184,9 +185,8 @@ function getEntity(
   contractTags: ApiContractTagsResponse | undefined,
 ): string | undefined {
   if (!contractTags?.tags) return undefined
-  const normalized = address.toLowerCase().replace('eth:', '')
   return contractTags.tags.find(
     (tag) =>
-      tag.contractAddress.toLowerCase().replace('eth:', '') === normalized,
+      addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(address)),
   )?.entity
 }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ListItemExternalDeps.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ListItemExternalDeps.tsx
@@ -185,8 +185,10 @@ function getEntity(
   contractTags: ApiContractTagsResponse | undefined,
 ): string | undefined {
   if (!contractTags?.tags) return undefined
-  return contractTags.tags.find(
-    (tag) =>
-      addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(address)),
+  return contractTags.tags.find((tag) =>
+    addressesEqual(
+      stripChainPrefix(tag.contractAddress),
+      stripChainPrefix(address),
+    ),
   )?.entity
 }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/PermissionsDisplay.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/PermissionsDisplay.tsx
@@ -15,6 +15,7 @@ import type {
 } from '../../../api/types'
 import { useCodeStore } from '../../../components/editor/store'
 import { partition } from '../../../utils/partition'
+import { addressesEqual, normalizeForLookup } from './addressUtils'
 import { useMultiViewStore } from '../multi-view/store'
 import { Folder } from '../panel-values/Folder'
 import { usePanelStore } from '../store/panel-store'
@@ -107,16 +108,16 @@ export function PermissionsDisplay({
 
   // Get functions for the specific contracts we're displaying (case-insensitive lookup)
   const getFunctionsForContract = (contractAddress: string) => {
-    const normalizedAddr = contractAddress.toLowerCase()
+    const normalizedAddr = normalizeForLookup(contractAddress)
     const matchingKey = Object.keys(functionsData?.contracts || {}).find(
-      (k) => k.toLowerCase() === normalizedAddr,
+      (k) => normalizeForLookup(k) === normalizedAddr,
     )
     const contractFunctions =
       (matchingKey
         ? functionsData?.contracts?.[matchingKey]?.functions
         : undefined) || []
     const localFunctionsForContract = localFunctions.filter(
-      (o) => o.contractAddress.toLowerCase() === normalizedAddr,
+      (o) => addressesEqual(o.contractAddress, contractAddress),
     )
 
     // Map contract functions to include contractAddress (functions in contracts don't have it)

--- a/packages/protocolbeat/src/apps/discovery/defidisco/PermissionsDisplay.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/PermissionsDisplay.tsx
@@ -116,8 +116,8 @@ export function PermissionsDisplay({
       (matchingKey
         ? functionsData?.contracts?.[matchingKey]?.functions
         : undefined) || []
-    const localFunctionsForContract = localFunctions.filter(
-      (o) => addressesEqual(o.contractAddress, contractAddress),
+    const localFunctionsForContract = localFunctions.filter((o) =>
+      addressesEqual(o.contractAddress, contractAddress),
     )
 
     // Map contract functions to include contractAddress (functions in contracts don't have it)

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ResultsSection.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ResultsSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { ApiAddressType, OwnerDefinition } from '../../../api/types'
+import { stripChainPrefix } from './addressUtils'
 
 interface ResultsSectionProps {
   projectData: any
@@ -168,19 +169,19 @@ function calculateUpgradeabilityStats(
   projectData.entries?.forEach((entry: any) => {
     // Add initial contracts
     entry.initialContracts?.forEach((contract: any) => {
-      const normalizedAddr = contract.address.replace('eth:', '').toLowerCase()
+      const normalizedAddr = stripChainPrefix(contract.address).toLowerCase()
       addressTypeMap.set(normalizedAddr, contract.type)
     })
 
     // Add discovered contracts
     entry.discoveredContracts?.forEach((contract: any) => {
-      const normalizedAddr = contract.address.replace('eth:', '').toLowerCase()
+      const normalizedAddr = stripChainPrefix(contract.address).toLowerCase()
       addressTypeMap.set(normalizedAddr, contract.type)
     })
 
     // Add EOAs
     entry.eoas?.forEach((eoa: any) => {
-      const normalizedAddr = eoa.address.replace('eth:', '').toLowerCase()
+      const normalizedAddr = stripChainPrefix(eoa.address).toLowerCase()
       addressTypeMap.set(normalizedAddr, eoa.type || 'EOA')
     })
   })
@@ -226,7 +227,7 @@ function calculateUpgradeabilityStats(
               )
 
               ownerAddresses.forEach((address) => {
-                const normalizedAddr = address.replace('eth:', '').toLowerCase()
+                const normalizedAddr = stripChainPrefix(address).toLowerCase()
                 const addressType = addressTypeMap.get(normalizedAddr)
 
                 if (addressType) {

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ReviewDescriptionsEditor.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ReviewDescriptionsEditor.tsx
@@ -7,6 +7,7 @@ import type {
   ReviewProjectType,
 } from '../../../api/types'
 import { ReviewResourcesEditor } from './ReviewResourcesEditor'
+import { ensureChainPrefix } from './addressUtils'
 
 const PROTOCOL_TYPES: ReviewProjectType[] = [
   'stablecoin',
@@ -57,9 +58,7 @@ export function ReviewDescriptionsEditor({
       // Optimistically update localConfig
       onUpdateConfig((prev) => {
         const sectionData = { ...prev[section] }
-        const normalizedAddress = address.startsWith('eth:')
-          ? address
-          : `eth:${address}`
+        const normalizedAddress = ensureChainPrefix(address)
         if (!description && !name) {
           delete sectionData[normalizedAddress]
         } else {

--- a/packages/protocolbeat/src/apps/discovery/defidisco/addressUtils.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/addressUtils.ts
@@ -1,0 +1,97 @@
+/**
+ * Address utility functions for DeFiDisco frontend.
+ *
+ * All internal addresses use the chain-prefixed format "chain:0xChecksummed".
+ * The backend is responsible for checksumming; the frontend uses these helpers
+ * for consistent prefix handling and comparisons.
+ */
+
+/**
+ * Strip the chain prefix from an address.
+ * Works with any chain prefix (eth:, arb1:, base:, etc.).
+ */
+export function stripChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(colonIdx + 1)
+  }
+  return address
+}
+
+/**
+ * Get the chain prefix from a chain-specific address.
+ * Returns 'eth' as default if no prefix is found.
+ */
+export function getChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(0, colonIdx)
+  }
+  return 'eth'
+}
+
+/**
+ * Ensure an address has a chain prefix.
+ * If it already has one, returns as-is.
+ * If it doesn't, prepends 'eth:' by default.
+ */
+export function ensureChainPrefix(address: string, chain = 'eth'): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address
+  }
+  return `${chain}:${address}`
+}
+
+/**
+ * Compare two addresses for equality, case-insensitively.
+ * Handles addresses with or without chain prefix.
+ */
+export function addressesEqual(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+/**
+ * Normalize an address for use as a lookup key.
+ * Lowercases and ensures chain prefix consistency.
+ *
+ * NOTE: On the backend, addresses should be checksummed at ingestion.
+ * This frontend normalizer is for display/comparison only.
+ */
+export function normalizeForLookup(address: string): string {
+  return ensureChainPrefix(address).toLowerCase()
+}
+
+/**
+ * Check if a string looks like a chain-prefixed address.
+ */
+export function isChainAddress(value: string): boolean {
+  const colonIdx = value.indexOf(':')
+  if (colonIdx === -1 || value.startsWith('0x')) return false
+  const hex = value.slice(colonIdx + 1)
+  return hex.startsWith('0x') && hex.length === 42
+}
+
+/**
+ * Shorten an address for display: "0x1234...abcd"
+ * Handles chain-prefixed addresses by stripping the prefix first.
+ */
+export function shortenAddress(address: string, chars = 4): string {
+  const hex = stripChainPrefix(address)
+  if (hex.length <= chars * 2 + 2) return hex
+  return `${hex.slice(0, chars + 2)}...${hex.slice(-chars)}`
+}
+
+/**
+ * Find a value in an array by matching an address field.
+ */
+export function findByAddress<T>(
+  items: T[],
+  getAddress: (item: T) => string,
+  targetAddress: string,
+): T | undefined {
+  const normalizedTarget = normalizeForLookup(targetAddress)
+  return items.find(
+    (item) => normalizeForLookup(getAddress(item)) === normalizedTarget,
+  )
+}

--- a/packages/protocolbeat/src/apps/discovery/defidisco/addressUtils.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/addressUtils.ts
@@ -48,7 +48,7 @@ export function ensureChainPrefix(address: string, chain = 'eth'): string {
  * Handles addresses with or without chain prefix.
  */
 export function addressesEqual(a: string, b: string): boolean {
-  return a.toLowerCase() === b.toLowerCase()
+  return normalizeForLookup(a) === normalizeForLookup(b)
 }
 
 /**

--- a/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useContractTags.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useContractTags.ts
@@ -3,6 +3,7 @@ import { getContractTags, updateContractTag } from '../../../../api/api'
 import type { ApiContractTagsUpdateRequest } from '../../../../api/types'
 import type { OklchColor } from '../../panel-nodes/view/colors/oklch'
 import oklchColors from '../../../../oklchColors.json'
+import { findByAddress } from '../addressUtils'
 
 export function useContractTags(project: string) {
   return useQuery({
@@ -37,16 +38,9 @@ export function useIsContractExternal(
   const { data: contractTags } = useContractTags(project)
 
   // Normalize both addresses for comparison (handle eth: prefix)
-  const normalizeAddress = (addr: string) => {
-    return addr.toLowerCase().replace('eth:', '')
-  }
-
-  const normalizedNodeAddress = normalizeAddress(contractAddress)
-
-  const tag = contractTags?.tags.find((tag) => {
-    const normalizedTagAddress = normalizeAddress(tag.contractAddress)
-    return normalizedTagAddress === normalizedNodeAddress
-  })
+  const tag = contractTags?.tags
+    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    : undefined
 
   return tag?.isExternal ?? false
 }
@@ -57,16 +51,9 @@ export function useIsContractGovernance(
 ) {
   const { data: contractTags } = useContractTags(project)
 
-  const normalizeAddress = (addr: string) => {
-    return addr.toLowerCase().replace('eth:', '')
-  }
-
-  const normalizedNodeAddress = normalizeAddress(contractAddress)
-
-  const tag = contractTags?.tags.find((tag) => {
-    const normalizedTagAddress = normalizeAddress(tag.contractAddress)
-    return normalizedTagAddress === normalizedNodeAddress
-  })
+  const tag = contractTags?.tags
+    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    : undefined
 
   return tag?.isGovernance ?? false
 }
@@ -89,13 +76,9 @@ export function useContractTagColor(
 ): { color: OklchColor; isDark: boolean } | undefined {
   const { data: contractTags } = useContractTags(project)
 
-  const normalizeAddress = (addr: string) =>
-    addr.toLowerCase().replace('eth:', '')
-  const normalizedAddress = normalizeAddress(contractAddress)
-
-  const tag = contractTags?.tags.find(
-    (t) => normalizeAddress(t.contractAddress) === normalizedAddress,
-  )
+  const tag = contractTags?.tags
+    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    : undefined
 
   if (tag?.isExternal) return { color: oklchColors.aux.orange, isDark: false }
   if (tag?.isGovernance) return { color: oklchColors.aux.green, isDark: false }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useContractTags.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useContractTags.ts
@@ -39,7 +39,11 @@ export function useIsContractExternal(
 
   // Normalize both addresses for comparison (handle eth: prefix)
   const tag = contractTags?.tags
-    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    ? findByAddress(
+        contractTags.tags,
+        (t) => t.contractAddress,
+        contractAddress,
+      )
     : undefined
 
   return tag?.isExternal ?? false
@@ -52,7 +56,11 @@ export function useIsContractGovernance(
   const { data: contractTags } = useContractTags(project)
 
   const tag = contractTags?.tags
-    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    ? findByAddress(
+        contractTags.tags,
+        (t) => t.contractAddress,
+        contractAddress,
+      )
     : undefined
 
   return tag?.isGovernance ?? false
@@ -77,7 +85,11 @@ export function useContractTagColor(
   const { data: contractTags } = useContractTags(project)
 
   const tag = contractTags?.tags
-    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    ? findByAddress(
+        contractTags.tags,
+        (t) => t.contractAddress,
+        contractAddress,
+      )
     : undefined
 
   if (tag?.isExternal) return { color: oklchColors.aux.orange, isDark: false }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useExternalToggle.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useExternalToggle.ts
@@ -6,6 +6,7 @@ import type {
   AffectedFunction,
   ExternalContract,
 } from '../DependencyPropagationDialog'
+import { addressesEqual, normalizeForLookup } from '../addressUtils'
 import { useContractTags, useUpdateContractTag } from './useContractTags'
 
 export interface ExternalToggleTarget {
@@ -55,11 +56,10 @@ export function useExternalToggle(
 
   // Check if any of the targets are external
   const hasExternalContract = targets.some((target) => {
-    const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
+    const normalized = normalizeForLookup(target.address)
     const tag = contractTags?.tags.find(
       (tag) =>
-        tag.contractAddress.toLowerCase().replace('eth:', '') ===
-        normalizedAddress,
+        normalizeForLookup(tag.contractAddress) === normalized,
     )
     return tag?.isExternal ?? false
   })
@@ -76,13 +76,9 @@ export function useExternalToggle(
   // Helper function to get contract name from address
   const getContractName = (address: string): string => {
     const allContracts = getAllContracts()
-    const normalizedAddress = address.toLowerCase().replace('eth:', '')
-    const contract = allContracts.find((c) => {
-      const normalizedContractAddress = c.address
-        .toLowerCase()
-        .replace('eth:', '')
-      return normalizedContractAddress === normalizedAddress
-    })
+    const contract = allContracts.find((c) =>
+      addressesEqual(c.address, address),
+    )
     return contract?.name || address.slice(0, 10) + '...'
   }
 
@@ -99,13 +95,9 @@ export function useExternalToggle(
 
     // Map targets to external contracts, using the actual contract address from project data (with prefix)
     const externalContractsList: ExternalContract[] = targets.map((target) => {
-      const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
-      const contract = allContracts.find((c) => {
-        const normalizedContractAddress = c.address
-          .toLowerCase()
-          .replace('eth:', '')
-        return normalizedContractAddress === normalizedAddress
-      })
+      const contract = allContracts.find((c) =>
+        addressesEqual(c.address, target.address),
+      )
       // Use the contract's actual address (with prefix) or fallback to target address
       return {
         address: contract?.address || target.address,
@@ -117,27 +109,21 @@ export function useExternalToggle(
 
     // Create a set of target addresses for quick lookup (these are all being marked external)
     const targetAddresses = new Set(
-      targets.map((t) => t.address.toLowerCase().replace('eth:', '')),
+      targets.map((t) => normalizeForLookup(t.address)),
     )
 
     // For each external contract, find referencing contracts
     for (const target of targets) {
-      const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
-      const extContract = allContracts.find((c) => {
-        const normalizedContractAddress = c.address
-          .toLowerCase()
-          .replace('eth:', '')
-        return normalizedContractAddress === normalizedAddress
-      })
+      const extContract = allContracts.find((c) =>
+        addressesEqual(c.address, target.address),
+      )
 
       if (!extContract?.referencedBy) continue
 
       // Filter to only internal contracts
       for (const ref of extContract.referencedBy) {
         // Check if the referencing contract is one of the targets being marked external
-        const normalizedRefAddress = ref.address
-          .toLowerCase()
-          .replace('eth:', '')
+        const normalizedRefAddress = normalizeForLookup(ref.address)
         if (targetAddresses.has(normalizedRefAddress)) {
           continue // Skip contracts being marked external in this batch
         }
@@ -145,8 +131,7 @@ export function useExternalToggle(
         // Check if the referencing contract is already external
         const refTag = contractTags.tags.find(
           (tag) =>
-            tag.contractAddress.toLowerCase().replace('eth:', '') ===
-            normalizedRefAddress,
+            normalizeForLookup(tag.contractAddress) === normalizedRefAddress,
         )
 
         if (refTag?.isExternal) continue // Skip already external contracts
@@ -155,12 +140,9 @@ export function useExternalToggle(
         const allFunctionNames = new Set<string>()
 
         // Find the contract data to get ABIs
-        const refContractData = allContracts.find((c) => {
-          const normalizedContractAddr = c.address
-            .toLowerCase()
-            .replace('eth:', '')
-          return normalizedContractAddr === normalizedRefAddress
-        })
+        const refContractData = allContracts.find((c) =>
+          addressesEqual(c.address, ref.address),
+        )
 
         if (refContractData?.abis) {
           for (const abi of refContractData.abis) {
@@ -218,13 +200,9 @@ export function useExternalToggle(
 
     // Map targets to external contracts, using the actual contract address from project data (with prefix)
     const externalContractsList: ExternalContract[] = targets.map((target) => {
-      const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
-      const contract = allContracts.find((c) => {
-        const normalizedContractAddress = c.address
-          .toLowerCase()
-          .replace('eth:', '')
-        return normalizedContractAddress === normalizedAddress
-      })
+      const contract = allContracts.find((c) =>
+        addressesEqual(c.address, target.address),
+      )
       return {
         address: contract?.address || target.address,
         name: target.name || getContractName(target.address),
@@ -235,26 +213,20 @@ export function useExternalToggle(
 
     // Create a set of target addresses for quick lookup
     const targetAddresses = new Set(
-      targets.map((t) => t.address.toLowerCase().replace('eth:', '')),
+      targets.map((t) => normalizeForLookup(t.address)),
     )
 
     // Use referencedBy from project data to find referencing contracts (same as add analysis)
     for (const target of targets) {
-      const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
-      const extContract = allContracts.find((c) => {
-        const normalizedContractAddress = c.address
-          .toLowerCase()
-          .replace('eth:', '')
-        return normalizedContractAddress === normalizedAddress
-      })
+      const extContract = allContracts.find((c) =>
+        addressesEqual(c.address, target.address),
+      )
 
       if (!extContract?.referencedBy) continue
 
       for (const ref of extContract.referencedBy) {
         // Skip contracts being marked internal in this batch
-        const normalizedRefAddress = ref.address
-          .toLowerCase()
-          .replace('eth:', '')
+        const normalizedRefAddress = normalizeForLookup(ref.address)
         if (targetAddresses.has(normalizedRefAddress)) {
           continue
         }
@@ -262,19 +234,15 @@ export function useExternalToggle(
         // Skip already-external contracts (they wouldn't have dependencies on this one)
         const refTag = contractTags.tags.find(
           (tag) =>
-            tag.contractAddress.toLowerCase().replace('eth:', '') ===
-            normalizedRefAddress,
+            normalizeForLookup(tag.contractAddress) === normalizedRefAddress,
         )
         if (refTag?.isExternal) continue
 
         // Get ALL write functions for this contract from ABIs
         const allFunctionNames = new Set<string>()
-        const refContractData = allContracts.find((c) => {
-          const normalizedContractAddr = c.address
-            .toLowerCase()
-            .replace('eth:', '')
-          return normalizedContractAddr === normalizedRefAddress
-        })
+        const refContractData = allContracts.find((c) =>
+          addressesEqual(c.address, ref.address),
+        )
 
         if (refContractData?.abis) {
           for (const abi of refContractData.abis) {
@@ -387,8 +355,7 @@ export function useExternalToggle(
       .filter(
         (ext) =>
           !currentDependencies.some(
-            (dep) =>
-              dep.contractAddress.toLowerCase() === ext.address.toLowerCase(),
+            (dep) => addressesEqual(dep.contractAddress, ext.address),
           ),
       )
       .map((ext) => ({ contractAddress: ext.address }))
@@ -418,11 +385,10 @@ export function useExternalToggle(
     }
 
     // Remove specified external contracts from dependencies
-    const externalAddresses = externalContracts.map((ext) =>
-      ext.address.toLowerCase(),
-    )
     const newDependencies = currentFunc.dependencies.filter(
-      (dep) => !externalAddresses.includes(dep.contractAddress.toLowerCase()),
+      (dep) => !externalContracts.some((ext) =>
+        addressesEqual(dep.contractAddress, ext.address),
+      ),
     )
 
     // Update function with filtered dependencies
@@ -535,13 +501,10 @@ export function useExternalToggle(
   // Get initial entity from first target's tag
   const initialEntity = (() => {
     if (targets.length === 0) return undefined
-    const normalizedAddress = targets[0].address
-      .toLowerCase()
-      .replace('eth:', '')
+    const normalized = normalizeForLookup(targets[0].address)
     const tag = contractTags?.tags.find(
       (tag) =>
-        tag.contractAddress.toLowerCase().replace('eth:', '') ===
-        normalizedAddress,
+        normalizeForLookup(tag.contractAddress) === normalized,
     )
     return tag?.entity
   })()

--- a/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useExternalToggle.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useExternalToggle.ts
@@ -58,8 +58,7 @@ export function useExternalToggle(
   const hasExternalContract = targets.some((target) => {
     const normalized = normalizeForLookup(target.address)
     const tag = contractTags?.tags.find(
-      (tag) =>
-        normalizeForLookup(tag.contractAddress) === normalized,
+      (tag) => normalizeForLookup(tag.contractAddress) === normalized,
     )
     return tag?.isExternal ?? false
   })
@@ -354,8 +353,8 @@ export function useExternalToggle(
     const newDependencies = externalContracts
       .filter(
         (ext) =>
-          !currentDependencies.some(
-            (dep) => addressesEqual(dep.contractAddress, ext.address),
+          !currentDependencies.some((dep) =>
+            addressesEqual(dep.contractAddress, ext.address),
           ),
       )
       .map((ext) => ({ contractAddress: ext.address }))
@@ -386,9 +385,10 @@ export function useExternalToggle(
 
     // Remove specified external contracts from dependencies
     const newDependencies = currentFunc.dependencies.filter(
-      (dep) => !externalContracts.some((ext) =>
-        addressesEqual(dep.contractAddress, ext.address),
-      ),
+      (dep) =>
+        !externalContracts.some((ext) =>
+          addressesEqual(dep.contractAddress, ext.address),
+        ),
     )
 
     // Update function with filtered dependencies
@@ -503,8 +503,7 @@ export function useExternalToggle(
     if (targets.length === 0) return undefined
     const normalized = normalizeForLookup(targets[0].address)
     const tag = contractTags?.tags.find(
-      (tag) =>
-        normalizeForLookup(tag.contractAddress) === normalized,
+      (tag) => normalizeForLookup(tag.contractAddress) === normalized,
     )
     return tag?.entity
   })()

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ownerResolution.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ownerResolution.ts
@@ -1,3 +1,5 @@
+import { isChainAddress } from './addressUtils'
+
 /**
  * Shared owner resolution logic for DeFiDisco
  *
@@ -119,7 +121,7 @@ export function parseValuePath(path: string): PathSegment[] {
  */
 export function extractAddresses(value: any, path: string): string[] {
   // Single string address
-  if (typeof value === 'string' && value.startsWith('eth:')) {
+  if (typeof value === 'string' && isChainAddress(value)) {
     return [value]
   }
 
@@ -127,7 +129,7 @@ export function extractAddresses(value: any, path: string): string[] {
   if (Array.isArray(value)) {
     const addresses: string[] = []
     for (const element of value) {
-      if (typeof element === 'string' && element.startsWith('eth:')) {
+      if (typeof element === 'string' && isChainAddress(element)) {
         addresses.push(element)
       } else if (typeof element === 'object' && element !== null) {
         // Recursively extract from object elements
@@ -144,7 +146,7 @@ export function extractAddresses(value: any, path: string): string[] {
     const addresses: string[] = []
     for (const key in value) {
       const prop = value[key]
-      if (typeof prop === 'string' && prop.startsWith('eth:')) {
+      if (typeof prop === 'string' && isChainAddress(prop)) {
         addresses.push(prop)
       } else if (typeof prop === 'object' && prop !== null) {
         // Recursively extract from nested objects/arrays
@@ -287,13 +289,13 @@ export function resolvePathExpression(
       if (
         !targetContractAddress ||
         typeof targetContractAddress !== 'string' ||
-        !targetContractAddress.startsWith('eth:')
+        !isChainAddress(targetContractAddress)
       ) {
         throw new Error(
           `Field "${fieldName}" not found or is not an address in current contract`,
         )
       }
-    } else if (contractRef.startsWith('eth:')) {
+    } else if (isChainAddress(contractRef)) {
       // Absolute contract address
       targetContractAddress = contractRef
     } else {
@@ -465,7 +467,7 @@ export class DiscoveredDataAccess implements IContractDataAccess {
     }
 
     // Handle string addresses (most common case)
-    if (typeof value === 'string' && value.startsWith('eth:')) {
+    if (typeof value === 'string' && isChainAddress(value)) {
       return value
     }
 

--- a/packages/protocolbeat/src/apps/discovery/defidisco/proxyTypeUtils.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/proxyTypeUtils.ts
@@ -1,3 +1,5 @@
+import { normalizeForLookup } from './addressUtils'
+
 /**
  * Builds a map of contract address -> proxyType for O(1) lookups
  * @param projectData - The project data containing entries with contracts
@@ -18,7 +20,7 @@ export function buildProxyTypeMap(projectData: any): Map<string, string> {
 
     allContracts.forEach((contract: any) => {
       if (contract.proxyType) {
-        map.set(contract.address.toLowerCase(), contract.proxyType)
+        map.set(normalizeForLookup(contract.address), contract.proxyType)
       }
     })
   })

--- a/packages/protocolbeat/src/apps/discovery/defidisco/reviewDataSources.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/reviewDataSources.ts
@@ -87,9 +87,7 @@ function isExternalContract(
   if (!contractTags) return false
   const normalized = normalizeForLookup(address)
   return contractTags.tags.some(
-    (t) =>
-      normalizeForLookup(t.contractAddress) === normalized &&
-      t.isExternal,
+    (t) => normalizeForLookup(t.contractAddress) === normalized && t.isExternal,
   )
 }
 
@@ -100,9 +98,7 @@ function isTokenContract(
   if (!contractTags) return false
   const normalized = normalizeForLookup(address)
   return contractTags.tags.some(
-    (t) =>
-      normalizeForLookup(t.contractAddress) === normalized &&
-      t.isToken,
+    (t) => normalizeForLookup(t.contractAddress) === normalized && t.isToken,
   )
 }
 
@@ -482,7 +478,8 @@ const permissionedFunctionsSource: DataSourceDefinition = {
 
         items.push({
           contractName:
-            contractNameMap.get(normalizeForLookup(addr)) ?? shortenAddress(addr),
+            contractNameMap.get(normalizeForLookup(addr)) ??
+            shortenAddress(addr),
           contractAddress: addr,
           functionName: func.functionName,
           score: func.score ?? 'unscored',

--- a/packages/protocolbeat/src/apps/discovery/defidisco/reviewDataSources.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/reviewDataSources.ts
@@ -9,6 +9,7 @@ import type {
   DataColumnFormat,
   DataTableColumn,
 } from '../../../api/types'
+import { normalizeForLookup, stripChainPrefix } from './addressUtils'
 
 // ============================================================================
 // Types
@@ -84,10 +85,10 @@ function isExternalContract(
   contractTags?: ApiContractTagsResponse,
 ): boolean {
   if (!contractTags) return false
-  const normalized = address.replace(/^eth:/, '').toLowerCase()
+  const normalized = normalizeForLookup(address)
   return contractTags.tags.some(
     (t) =>
-      t.contractAddress.replace(/^eth:/, '').toLowerCase() === normalized &&
+      normalizeForLookup(t.contractAddress) === normalized &&
       t.isExternal,
   )
 }
@@ -97,10 +98,10 @@ function isTokenContract(
   contractTags?: ApiContractTagsResponse,
 ): boolean {
   if (!contractTags) return false
-  const normalized = address.replace(/^eth:/, '').toLowerCase()
+  const normalized = normalizeForLookup(address)
   return contractTags.tags.some(
     (t) =>
-      t.contractAddress.replace(/^eth:/, '').toLowerCase() === normalized &&
+      normalizeForLookup(t.contractAddress) === normalized &&
       t.isToken,
   )
 }
@@ -110,7 +111,7 @@ function hasCapitalData(admin: AdminDetail): admin is AdminDetailWithCapital {
 }
 
 function shortenAddress(address: string): string {
-  const addr = address.replace(/^eth:/, '')
+  const addr = stripChainPrefix(address)
   if (addr.length <= 12) return addr
   return `${addr.slice(0, 6)}...${addr.slice(-4)}`
 }
@@ -398,7 +399,7 @@ const fundsContractBalancesSource: DataSourceDefinition = {
       })
       .map(([addr, cfd]) => ({
         contractName:
-          contractNameMap.get(addr.toLowerCase()) ?? shortenAddress(addr),
+          contractNameMap.get(normalizeForLookup(addr)) ?? shortenAddress(addr),
         address: addr,
         balancesTotal: cfd.balances?.totalUsdValue ?? 0,
         positionsTotal: cfd.positions?.totalUsdValue ?? 0,
@@ -481,7 +482,7 @@ const permissionedFunctionsSource: DataSourceDefinition = {
 
         items.push({
           contractName:
-            contractNameMap.get(addr.toLowerCase()) ?? shortenAddress(addr),
+            contractNameMap.get(normalizeForLookup(addr)) ?? shortenAddress(addr),
           contractAddress: addr,
           functionName: func.functionName,
           score: func.score ?? 'unscored',
@@ -512,7 +513,7 @@ function buildContractNameMap(
   if (!entry) return map
   for (const c of [...entry.initialContracts, ...entry.discoveredContracts]) {
     if (c.name) {
-      map.set(c.address.toLowerCase(), c.name)
+      map.set(normalizeForLookup(c.address), c.name)
     }
   }
   return map

--- a/packages/protocolbeat/src/apps/discovery/panel-list/ListPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-list/ListPanel.tsx
@@ -12,6 +12,7 @@ import { IconChevronRight } from '../../../icons/IconChevronRight'
 import { IconFolder } from '../../../icons/IconFolder'
 import { IconFolderOpened } from '../../../icons/IconFolderOpened'
 import { toShortenedAddress } from '../../../utils/toShortenedAddress'
+import { addressesEqual } from '../defidisco/addressUtils'
 import { useContractTags } from '../defidisco/hooks/useContractTags'
 import { ListItemExternalDeps } from '../defidisco/ListItemExternalDeps'
 import { useGlobalSettingsStore } from '../store/global-settings-store'
@@ -57,11 +58,9 @@ function ListItemChain(props: { entry: ApiProjectChain; first: boolean }) {
 
   const isExternal = (address: string) => {
     if (!contractTags?.tags) return false
-    const normalized = address.toLowerCase().replace('eth:', '')
     return contractTags.tags.some(
       (tag) =>
-        tag.isExternal &&
-        tag.contractAddress.toLowerCase().replace('eth:', '') === normalized,
+        tag.isExternal && addressesEqual(tag.contractAddress, address),
     )
   }
 

--- a/packages/protocolbeat/src/defidisco/AdminsInventoryBreakdown.tsx
+++ b/packages/protocolbeat/src/defidisco/AdminsInventoryBreakdown.tsx
@@ -6,6 +6,10 @@ import type { AdminModuleScore } from '../api/types'
 import { useContractTags } from '../apps/discovery/defidisco/hooks/useContractTags'
 import { buildProxyTypeMap } from '../apps/discovery/defidisco/proxyTypeUtils'
 import {
+  addressesEqual,
+  normalizeForLookup,
+} from '../apps/discovery/defidisco/addressUtils'
+import {
   computeDeduplicatedCapital,
   formatUsdValue,
   hasCapitalData,
@@ -47,8 +51,8 @@ export function AdminsInventoryBreakdown({
     if (!contractTags?.tags) return false
     return contractTags.tags.some(
       (tag) =>
-        tag.contractAddress.toLowerCase() ===
-          admin.adminAddress.toLowerCase() && tag.isExternal,
+        addressesEqual(tag.contractAddress, admin.adminAddress) &&
+        tag.isExternal,
     )
   }
 
@@ -56,8 +60,8 @@ export function AdminsInventoryBreakdown({
     if (!contractTags?.tags) return false
     return contractTags.tags.some(
       (tag) =>
-        tag.contractAddress.toLowerCase() ===
-          admin.adminAddress.toLowerCase() && tag.isGovernance,
+        addressesEqual(tag.contractAddress, admin.adminAddress) &&
+        tag.isGovernance,
     )
   }
 
@@ -154,7 +158,7 @@ export function AdminsInventoryBreakdown({
               <OwnerSection
                 key={admin.adminAddress}
                 admin={admin}
-                proxyType={proxyTypeMap.get(admin.adminAddress.toLowerCase())}
+                proxyType={proxyTypeMap.get(normalizeForLookup(admin.adminAddress))}
                 isGovernance={isGovernanceOwner(admin)}
               />
             ))}

--- a/packages/protocolbeat/src/defidisco/DependencyInventoryBreakdown.tsx
+++ b/packages/protocolbeat/src/defidisco/DependencyInventoryBreakdown.tsx
@@ -7,6 +7,10 @@ import type {
   DependencyDetail,
   DependencyModuleScore,
 } from '../api/types'
+import {
+  addressesEqual,
+  normalizeForLookup,
+} from '../apps/discovery/defidisco/addressUtils'
 import { useContractTags } from '../apps/discovery/defidisco/hooks/useContractTags'
 import { buildProxyTypeMap } from '../apps/discovery/defidisco/proxyTypeUtils'
 import { usePanelStore } from '../apps/discovery/store/panel-store'
@@ -160,15 +164,15 @@ export function DependencyInventoryBreakdown({
     return adminScore.breakdown.filter((admin) => {
       return contractTags.tags.some(
         (tag) =>
-          tag.contractAddress.toLowerCase() ===
-            admin.adminAddress.toLowerCase() && tag.isExternal,
+          addressesEqual(tag.contractAddress, admin.adminAddress) &&
+          tag.isExternal,
       )
     })
   }, [adminScore, contractTags])
 
   // Filter immutable/revoked external owners based on toggle
   const isImmutableOrRevoked = (admin: any) =>
-    proxyTypeMap.get(admin.adminAddress.toLowerCase()) === 'immutable' ||
+    proxyTypeMap.get(normalizeForLookup(admin.adminAddress)) === 'immutable' ||
     isZeroAddress(admin.adminAddress)
 
   const displayedExternalOwners = useMemo(() => {
@@ -300,7 +304,7 @@ export function DependencyInventoryBreakdown({
               <OwnerSection
                 key={admin.adminAddress}
                 admin={admin}
-                proxyType={proxyTypeMap.get(admin.adminAddress.toLowerCase())}
+                proxyType={proxyTypeMap.get(normalizeForLookup(admin.adminAddress))}
               />
             ))}
           </>

--- a/packages/protocolbeat/src/defidisco/scoringShared.tsx
+++ b/packages/protocolbeat/src/defidisco/scoringShared.tsx
@@ -8,6 +8,7 @@ import type {
   ApiAddressType,
   FunctionCapitalAnalysis,
 } from '../api/types'
+import { stripChainPrefix } from '../apps/discovery/defidisco/addressUtils'
 import { ProxyTypeTag } from '../apps/discovery/defidisco/ProxyTypeTag'
 import { usePanelStore } from '../apps/discovery/store/panel-store'
 
@@ -59,7 +60,7 @@ export function hasCapitalData(admin: any): admin is AdminDetailWithCapital {
 }
 
 export function isZeroAddress(address: string): boolean {
-  const normalized = address.toLowerCase().replace('eth:', '')
+  const normalized = stripChainPrefix(address).toLowerCase()
   return normalized === '0x0000000000000000000000000000000000000000'
 }
 


### PR DESCRIPTION
Replace all hardcoded 'eth:' prefix handling with chain-agnostic address utilities. This eliminates technical debt from two issues:
1. Hardcoded 'eth:' prefix stripping/adding that would break with non-Ethereum chains
2. Scattered toLowerCase() address comparisons instead of proper normalization

Changes:
- Add addressUtils.ts for backend (l2b) with ERC-55 checksumming via EthereumAddress
- Add addressUtils.ts for frontend (protocolbeat) with chain-agnostic prefix handling
- Replace all .replace('eth:', ''), .replace(/^eth:/i, ''), .startsWith('eth:') with stripChainPrefix(), isChainAddress(), ensureChainPrefix()
- Replace scattered .toLowerCase() address comparisons with addressesEqual() and normalizeChainAddress()/normalizeForLookup() for map keys
- Rename extractEthAddresses to extractChainAddresses (with backward-compat alias)
- Update defiscan-frontend format.ts with stripChainPrefix utility

35 files changed across backend, frontend, and defiscan-frontend packages.

