### PR TITLE
Add contract names, types, and exclude tag to compiled review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,7 +366,7 @@ Internal helper: `contractHasFunction(discovered, entry, functionName)` — chec
 - `buildExternalAddressSet(tags)` / `buildTagsByAddress(tags)` — build lookup structures from contract tags
 - `isExternalAddress(address, externalAddresses)` / `findTag(tagsByAddress, address)` — address matching with `eth:` prefix normalization
 - `getCallGraphContractName(callGraphData, address)` — resolve contract name from call graph data
-- `extractEthAddresses(value)` — extract all `eth:` addresses from a value (handles flat strings and one-level-deep object fields)
+- `extractChainAddresses(value)` — extract all chain-prefixed addresses from a value (handles flat strings and one-level-deep object fields). Legacy alias `extractEthAddresses` is deprecated
 
 ### Enhanced Traversal & Function Analysis ✅
 
@@ -696,6 +696,7 @@ packages/
 │   ├── FunctionBreakdown.tsx         # Functions section
 │   ├── ReviewDescriptionsEditor.tsx  # Review descriptions editor (Descriptions tab)
 │   ├── ReviewResourcesEditor.tsx    # Resources editor (links, frontends, socials)
+│   ├── addressUtils.ts             # Frontend address utilities (stripChainPrefix, addressesEqual, normalizeForLookup, findByAddress)
 │   └── icons/
 ├── l2b/src/implementations/discovery-ui/defidisco/
 │   ├── permissionOverrides.ts
@@ -706,7 +707,8 @@ packages/
 │   ├── callGraph.ts                  # Slither-based external call detection
 │   ├── callGraphHeuristics.ts        # Heuristic engine for variable-to-address resolution
 │   ├── enhancedTraversal.ts          # Backward BFS governance chains
-│   └── functionAnalysis.ts           # Forward BFS impact & dependencies
+│   ├── functionAnalysis.ts           # Forward BFS impact & dependencies
+│   └── addressUtils.ts              # Backend address utilities (stripChainPrefix, ensureChainPrefix, addressesEqual, isChainAddress)
 ├── defiscan-frontend/                # Standalone public review website
 │   ├── scripts/compile-data.ts       # Build-time data aggregation
 │   └── src/                          # React app (see README.md for structure)
@@ -729,9 +731,9 @@ packages/
 - **Permission Overrides**: Use `useQuery` with `getPermissionOverrides(project)` directly (no hook exists)
 - **Address Format**:
   - **IMPORTANT**: Contract addresses use `eth:` prefix in ALL data files (functions.json, contract-tags.json, discovered.json)
-  - When comparing addresses, keep the prefix: `address1.toLowerCase() === address2.toLowerCase()`
+  - When comparing addresses, use `addressesEqual(a, b)` from `addressUtils.ts` (handles mixed prefix formats)
+  - For map lookups, use `normalizeForLookup(address)` which ensures chain prefix + lowercase
   - **Do NOT strip** the `eth:` prefix unless specifically needed for display purposes
-  - Example: `eth:0x123...` should match `eth:0x123...` (both lowercase)
 - **EOA Counting**: EOAs stored separately in `entry.eoas[]` array, not mixed with contracts
 
 **Contract Tags Data Structure**:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,16 @@ git fetch upstream && git merge upstream/main
 - **Backend**: `/defidisco/contractTags.ts` preserves attributes across updates; entity accepts `null` to clear
 - **Address Format**: Normalizes `eth:0x...` → `0x...` when comparing with tags
 
+### Exclude from Review Tag ✅
+
+**Binary tag**: `excludeFromReview` in `contract-tags.json`, hides contracts from compiled review
+
+- **Purpose**: Discovery follows all contract references recursively, so external contracts' dependencies (e.g., Chainlink's multisig owners) end up in `discovered.json`. This tag lets researchers explicitly hide irrelevant contracts from the compiled output.
+- **Behavior**: All contracts are included by default. Researcher explicitly marks ones to exclude via the Exclude button in node controls.
+- **UI**: `ExcludeButton.tsx` (node controls toggle, follows GovernanceButton pattern)
+- **Backend**: `contractTags.ts` handles `excludeFromReview` like other boolean tags
+- **Compiler**: `reviewCompiler.ts` filters out contracts with `excludeFromReview: true` before building the compiled review
+
 ### Governance Contract Tag ✅
 
 **Binary tag**: `isGovernance` in `contract-tags.json`, green in graph view
@@ -687,6 +697,7 @@ packages/
 │   ├── PermissionsDisplay.tsx
 │   ├── FunctionFolder.tsx
 │   ├── ExternalButton.tsx
+│   ├── ExcludeButton.tsx               # Toggle excludeFromReview tag in node controls
 │   ├── GovernanceButton.tsx            # Toggle governance tag in node controls
 │   ├── GovernanceIndicator.tsx         # Inline governance label + toggle in Values panel
 │   ├── V2ScoringSection.tsx          # V2 scoring entry point
@@ -757,7 +768,7 @@ packages/
 - **File Location**: `packages/config/src/projects/{project}/contract-tags.json`
 - **Fields**: `isExternal` (boolean), `isGovernance` (boolean), `entity` (string, groups external contracts by provider)
 - **Update Pattern**: Backend preserves existing attributes when updating individual fields
-- **Cleanup**: When all boolean tag fields (`isExternal`, `isGovernance`, `fetchBalances`, `fetchPositions`, `isToken`) are false, the entry is removed from the file
+- **Cleanup**: When all boolean tag fields (`isExternal`, `isGovernance`, `fetchBalances`, `fetchPositions`, `isToken`, `excludeFromReview`) are false, the entry is removed from the file
 
 ### Permission Overrides Data Structure ✅
 

--- a/docs/researchers/getting-started.md
+++ b/docs/researchers/getting-started.md
@@ -152,6 +152,8 @@ Using 4 panels
 
 You go through the discovered contracts (with list and nodes), see if there are missing links to other system relevant contracts, you mark contract as external if you find oracles/bridges/yield sources etc.
 
+Discovery follows all contract references recursively, which means external contracts' own dependencies (e.g., Chainlink's multisig owners) also appear in the results. If a contract is irrelevant to the protocol being reviewed, select it in the graph view and click the **Exclude** button in the node controls. This sets the `excludeFromReview` tag, which removes the contract from the compiled review output. The tag can be toggled off to re-include the contract.
+
 Then you adapt the `config.jsonc`, once you're satisfied to run another discovery episode, you select the terminal view and you press `Run discovery`.
 
 ## Working with Factory Patterns (Templates)

--- a/packages/defiscan-frontend/public/data/Steakhouse-USDC/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/Steakhouse-USDC/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-06T07:53:53.710Z",
+  "compiledAt": "2026-03-09T00:37:47.891Z",
   "project": "Steakhouse-USDC",
   "metadata": {
     "protocolName": "Steakhouse USDC",
@@ -16,8 +16,9 @@
     "scoredFunctionCount": 0,
     "adminCount": 7,
     "dependencyCount": 8,
-    "totalCapitalAtRisk": 160440859.57738438,
-    "totalTokenValueAtRisk": 0
+    "totalCapitalAtRisk": 169519102.78369424,
+    "totalTokenValueAtRisk": 0,
+    "totalTokenValue": 0
   },
   "admins": [
     {
@@ -32,7 +33,7 @@
           "contractName": "MetaMorpho",
           "functionName": "setCurator",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -41,7 +42,7 @@
           "contractName": "MetaMorpho",
           "functionName": "setIsAllocator",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -50,7 +51,7 @@
           "contractName": "MetaMorpho",
           "functionName": "setSkimRecipient",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -59,7 +60,7 @@
           "contractName": "MetaMorpho",
           "functionName": "submitTimelock",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -68,7 +69,7 @@
           "contractName": "MetaMorpho",
           "functionName": "setFee",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -91,7 +92,7 @@
           "contractName": "MetaMorpho",
           "functionName": "setFeeRecipient",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -114,7 +115,7 @@
           "contractName": "MetaMorpho",
           "functionName": "submitGuardian",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -123,7 +124,7 @@
           "contractName": "MetaMorpho",
           "functionName": "submitCap",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -145,7 +146,7 @@
           "contractName": "MetaMorpho",
           "functionName": "submitMarketRemoval",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -154,7 +155,7 @@
           "contractName": "MetaMorpho",
           "functionName": "setSupplyQueue",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -163,7 +164,7 @@
           "contractName": "MetaMorpho",
           "functionName": "updateWithdrawQueue",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -184,7 +185,7 @@
           "contractName": "MetaMorpho",
           "functionName": "reallocate",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -209,7 +210,7 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingTimelock",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -218,7 +219,7 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingGuardian",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -227,7 +228,7 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingCap",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -236,14 +237,14 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingMarketRemoval",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         }
       ],
-      "totalDirectCapital": 160440859.57738438,
+      "totalDirectCapital": 169519102.78369424,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 160440859.57738438,
+      "totalReachableCapital": 169519102.78369424,
       "totalReachableTokenValue": 0
     },
     {
@@ -258,7 +259,7 @@
           "contractName": "MetaMorpho",
           "functionName": "submitCap",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -280,7 +281,7 @@
           "contractName": "MetaMorpho",
           "functionName": "submitMarketRemoval",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -289,7 +290,7 @@
           "contractName": "MetaMorpho",
           "functionName": "setSupplyQueue",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -298,7 +299,7 @@
           "contractName": "MetaMorpho",
           "functionName": "updateWithdrawQueue",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -319,7 +320,7 @@
           "contractName": "MetaMorpho",
           "functionName": "reallocate",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -344,7 +345,7 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingCap",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -353,14 +354,14 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingMarketRemoval",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         }
       ],
-      "totalDirectCapital": 160440859.57738438,
+      "totalDirectCapital": 169519102.78369424,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 160440859.57738438,
+      "totalReachableCapital": 169519102.78369424,
       "totalReachableTokenValue": 0
     },
     {
@@ -375,7 +376,7 @@
           "contractName": "MetaMorpho",
           "functionName": "updateWithdrawQueue",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -396,7 +397,7 @@
           "contractName": "MetaMorpho",
           "functionName": "reallocate",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -417,9 +418,9 @@
           ]
         }
       ],
-      "totalDirectCapital": 160440859.57738438,
+      "totalDirectCapital": 169519102.78369424,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 160440859.57738438,
+      "totalReachableCapital": 169519102.78369424,
       "totalReachableTokenValue": 0
     },
     {
@@ -434,7 +435,7 @@
           "contractName": "MetaMorpho",
           "functionName": "updateWithdrawQueue",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -455,7 +456,7 @@
           "contractName": "MetaMorpho",
           "functionName": "reallocate",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -476,9 +477,9 @@
           ]
         }
       ],
-      "totalDirectCapital": 160440859.57738438,
+      "totalDirectCapital": 169519102.78369424,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 160440859.57738438,
+      "totalReachableCapital": 169519102.78369424,
       "totalReachableTokenValue": 0
     },
     {
@@ -493,7 +494,7 @@
           "contractName": "MetaMorpho",
           "functionName": "updateWithdrawQueue",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -514,7 +515,7 @@
           "contractName": "MetaMorpho",
           "functionName": "reallocate",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -535,9 +536,9 @@
           ]
         }
       ],
-      "totalDirectCapital": 160440859.57738438,
+      "totalDirectCapital": 169519102.78369424,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 160440859.57738438,
+      "totalReachableCapital": 169519102.78369424,
       "totalReachableTokenValue": 0
     },
     {
@@ -552,7 +553,7 @@
           "contractName": "MetaMorpho",
           "functionName": "updateWithdrawQueue",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -573,7 +574,7 @@
           "contractName": "MetaMorpho",
           "functionName": "reallocate",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": [
             {
@@ -594,9 +595,9 @@
           ]
         }
       ],
-      "totalDirectCapital": 160440859.57738438,
+      "totalDirectCapital": 169519102.78369424,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 160440859.57738438,
+      "totalReachableCapital": 169519102.78369424,
       "totalReachableTokenValue": 0
     },
     {
@@ -604,14 +605,14 @@
       "name": "Governance DAO",
       "description": "Designated guardian contract in the vault's governance structure. Can revoke pending governance changes including timelock updates and market parameter modifications. This governance contract provides an additional layer of oversight for timelock-protected changes.",
       "adminType": "Contract",
-      "isGovernance": false,
+      "isGovernance": true,
       "functions": [
         {
           "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
           "contractName": "MetaMorpho",
           "functionName": "revokePendingTimelock",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -620,7 +621,7 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingGuardian",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -629,7 +630,7 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingCap",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         },
@@ -638,14 +639,14 @@
           "contractName": "MetaMorpho",
           "functionName": "revokePendingMarketRemoval",
           "impact": "critical",
-          "directFundsUsd": 160440859.57738438,
+          "directFundsUsd": 169519102.78369424,
           "directTokenValueUsd": 0,
           "reachableContracts": []
         }
       ],
-      "totalDirectCapital": 160440859.57738438,
+      "totalDirectCapital": 169519102.78369424,
       "totalDirectTokenValue": 0,
-      "totalReachableCapital": 160440859.57738438,
+      "totalReachableCapital": 169519102.78369424,
       "totalReachableTokenValue": 0
     }
   ],
@@ -824,10 +825,10 @@
       "name": "MetaMorpho Vault (steakUSDC)",
       "description": "Main vault contract holding all depositor assets. Contains USDC positions across four Morpho Blue lending markets, generating yield through optimized capital allocation. The vault implements a MetaMorpho architecture with timelock-protected governance and curator-managed market selection.",
       "balances": {
-        "totalUsdValue": 0.006015270354208777
+        "totalUsdValue": 0.006014494273977912
       },
       "positions": {
-        "totalUsdValue": 160440859.5713691
+        "totalUsdValue": 169519102.77767974
       },
       "tokenInfo": null
     }
@@ -835,254 +836,199 @@
   "functions": [],
   "contracts": [
     {
-      "address": "eth:0xaa0500198b4425dfc4e272fbe42c8e64e21fc03d",
-      "name": "eth:0xaa0500198b4425dfc4e272fbe42c8e64e21fc03d",
+      "address": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+      "name": "MetaMorpho Vault (steakUSDC)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x0000aeB716a0DF7A9A1AAd119b772644Bc089dA8",
+      "name": "Guardian 1/6 Multisig",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "gnosis safe"
+    },
+    {
+      "address": "eth:0x255c7705e8BB334DfCae438197f7C4297988085a",
+      "name": "2/4 Multisig",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "gnosis safe"
+    },
+    {
+      "address": "eth:0x827e86072B06674a077f592A531dcE4590aDeCdB",
+      "name": "Steakhouse/Morpho 2/5 Curator Multisig",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "gnosis safe"
+    },
+    {
+      "address": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
+      "name": "4/9 Multisig",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "gnosis safe"
+    },
+    {
+      "address": "eth:0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD",
+      "name": "Steakhouse 5/8 Multisig",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "gnosis safe"
+    },
+    {
+      "address": "eth:0xcBa28b38103307Ec8dA98377ffF9816C164f9AFa",
+      "name": "5/9 Multisig",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "gnosis safe"
+    },
+    {
+      "address": "eth:0x48F7E36EB6B826B2dF4B2E630B62Cd25e89E40e2",
+      "name": "ChainlinkOracle",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xDddd770BADd886dF3864029e4B377B5F6a2B6b83",
+      "name": "ChainlinkOracle",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x2e1B5a40Edc922bCE489668b11749B8eAbd67f6b",
+      "name": "ConfirmedTransactionModule",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xaa0500198B4425DfC4E272FbE42C8E64E21fc03d",
+      "name": "Governance DAO",
       "isExternal": false,
       "isGovernance": true,
       "entity": null,
-      "proxyType": null
+      "proxyType": "EIP1967 proxy"
     },
     {
-      "address": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
-      "name": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+      "address": "eth:0x86392dC19c0b719886221c78AB11eb8Cf5c52812",
+      "name": "Chainlink USDC/USD Price Feed",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x8fFfFfd4AfB6115b954Bd326cbe7B4BA576818f6",
+      "name": "Chainlink USDC/USD Price Feed",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x986b5E1e1755e3C2440e960477f25201B0a8bbD4",
+      "name": "Chainlink USDC/USD Price Feed",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xc0053f3FBcCD593758258334Dfce24C2A9A673aD",
+      "name": "Chainlink USDC/USD Price Feed",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
+      "name": "Chainlink BTC/USD Price Feed",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xfdFD9C85aD200c506Cf9e21F1FD8dd01932FBB23",
+      "name": "Chainlink USDC/USD Price Feed",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+      "name": "Morpho Blue",
       "isExternal": true,
       "isGovernance": false,
       "entity": "Morpho",
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0xcba28b38103307ec8da98377fff9816c164f9afa",
-      "name": "eth:0xcba28b38103307ec8da98377fff9816c164f9afa",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x13ca8756e9470b71b8e998352c8741706217f963",
-      "name": "eth:0x13ca8756e9470b71b8e998352c8741706217f963",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x264c86dbbd2e4165fbbf0c35b0ddf0e00aec6b31",
-      "name": "eth:0x264c86dbbd2e4165fbbf0c35b0ddf0e00aec6b31",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xcf263cee139763114faafc5f52865135412f50ec",
-      "name": "eth:0xcf263cee139763114faafc5f52865135412f50ec",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x30e7c016fc702cde9a50720a469d418490b7b652",
-      "name": "eth:0x30e7c016fc702cde9a50720a469d418490b7b652",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xe0aeb6811d33df42a09066857cdafca16b506086",
-      "name": "eth:0xe0aeb6811d33df42a09066857cdafca16b506086",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x69fcefde2b48503d675181448b3d4272128bca9c",
-      "name": "eth:0x69fcefde2b48503d675181448b3d4272128bca9c",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x84d3e4ee550dd5f99e76a548ac59a6be1c8dcf79",
-      "name": "eth:0x84d3e4ee550dd5f99e76a548ac59a6be1c8dcf79",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x8f02b4a44eacd9b8ee7739aa0ba58833dd45d002",
-      "name": "eth:0x8f02b4a44eacd9b8ee7739aa0ba58833dd45d002",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xc100c251bdd297a66795112f04356e6ba5f89d80",
-      "name": "eth:0xc100c251bdd297a66795112f04356e6ba5f89d80",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x21f73d42eb58ba49ddb685dc29d3bf5c0f0373ca",
-      "name": "eth:0x21f73d42eb58ba49ddb685dc29d3bf5c0f0373ca",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x2e1b5a40edc922bce489668b11749b8eabd67f6b",
-      "name": "eth:0x2e1b5a40edc922bce489668b11749b8eabd67f6b",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x7052cb84079905400ea52b635cab6a275fda8823",
-      "name": "eth:0x7052cb84079905400ea52b635cab6a275fda8823",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x80efdee7f82d0f2abf3bf29a9a85edf0b42c9e19",
-      "name": "eth:0x80efdee7f82d0f2abf3bf29a9a85edf0b42c9e19",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xb65b6d224351cd61f856c227b2d5cfc611e9b2d8",
-      "name": "eth:0xb65b6d224351cd61f856c227b2d5cfc611e9b2d8",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xb7f0643d4ca8c296564ce335062833e1afa3afdb",
-      "name": "eth:0xb7f0643d4ca8c296564ce335062833e1afa3afdb",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x86392dc19c0b719886221c78ab11eb8cf5c52812",
-      "name": "eth:0x86392dc19c0b719886221c78ab11eb8cf5c52812",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xfde996f00e42b33bde7c640786333623acc3f298",
-      "name": "eth:0xfde996f00e42b33bde7c640786333623acc3f298",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x05724b9c8c1dde1b2f659d7c0676ff63f6d5e781",
-      "name": "eth:0x05724b9c8c1dde1b2f659d7c0676ff63f6d5e781",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x3f7b49f03375aa588b828a5ffbaac5727fb8202d",
-      "name": "eth:0x3f7b49f03375aa588b828a5ffbaac5727fb8202d",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x47a1dd4e277530fffb5b5f70a43ccbd542f54e17",
-      "name": "eth:0x47a1dd4e277530fffb5b5f70a43ccbd542f54e17",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x480496c0884d61f2f56707adb11697f8018898c2",
-      "name": "eth:0x480496c0884d61f2f56707adb11697f8018898c2",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
-      "name": "eth:0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xc0053f3fbccd593758258334dfce24c2a9a673ad",
-      "name": "eth:0xc0053f3fbccd593758258334dfce24c2a9a673ad",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
-      "name": "eth:0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xf4030086522a5beea4988f8ca5b36dbc97bee88c",
-      "name": "eth:0xf4030086522a5beea4988f8ca5b36dbc97bee88c",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xfdfd9c85ad200c506cf9e21f1fd8dd01932fbb23",
-      "name": "eth:0xfdfd9c85ad200c506cf9e21f1fd8dd01932fbb23",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
-      "name": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "address": "eth:0x0F948CBa8231Db7898ef36A4212581Ad7b1B4580",
+      "name": "MorphoChainlinkOracleV2",
       "isExternal": false,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0x4f67e4d9bd67efa28236013288737d39aef48e79",
-      "name": "eth:0x4f67e4d9bd67efa28236013288737d39aef48e79",
+      "address": "eth:0xA6D6950c9F177F1De7f7757FB33539e3Ec60182a",
+      "name": "MorphoChainlinkOracleV2",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x9E9110cFd24cd851ea5bc73a27975B33E308f9e1",
+      "name": "MorphoHelper",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "EIP1967 proxy"
+    },
+    {
+      "address": "eth:0xfd32fA2ca22c76dD6E550706Ad913FC6CE91c75D",
+      "name": "PublicAllocator",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x4F67e4d9BD67eFa28236013288737D39AeF48e79",
+      "name": "Chainlink wstETH Price Feed",
       "isExternal": true,
       "isGovernance": false,
       "entity": "Chainlink",
-      "proxyType": null
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xfeed46c11F57B7126a773EeC6ae9cA7aE1C03C9a",
+      "name": "EOA (0xfeed...c9a)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "EOA"
     }
   ],
+  "resources": [],
   "sections": {
     "codeAndAudits": {
       "title": "Code & Audits",

--- a/packages/defiscan-frontend/public/data/Steakhouse-USDC/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/Steakhouse-USDC/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-09T00:37:47.891Z",
+  "compiledAt": "2026-03-09T06:55:30.622Z",
   "project": "Steakhouse-USDC",
   "metadata": {
     "protocolName": "Steakhouse USDC",
@@ -13,7 +13,7 @@
   "totals": {
     "contractCount": 23,
     "permissionedFunctionCount": 16,
-    "scoredFunctionCount": 0,
+    "scoredFunctionCount": 16,
     "adminCount": 7,
     "dependencyCount": 8,
     "totalCapitalAtRisk": 169519102.78369424,
@@ -833,7 +833,104 @@
       "tokenInfo": null
     }
   ],
-  "functions": [],
+  "functions": [
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "setCurator",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "setIsAllocator",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "setSkimRecipient",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "submitTimelock",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "setFee",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "setFeeRecipient",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "submitGuardian",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "submitCap",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "submitMarketRemoval",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "setSupplyQueue",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "updateWithdrawQueue",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "reallocate",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "revokePendingTimelock",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "revokePendingGuardian",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "revokePendingCap",
+      "impact": "critical"
+    },
+    {
+      "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
+      "contractName": "MetaMorpho",
+      "functionName": "revokePendingMarketRemoval",
+      "impact": "critical"
+    }
+  ],
   "contracts": [
     {
       "address": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",

--- a/packages/defiscan-frontend/public/data/index.json
+++ b/packages/defiscan-frontend/public/data/index.json
@@ -61,7 +61,7 @@
   },
   "dependencies": [
     {
-      "address": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+      "address": "0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
       "name": "Morpho Blue",
       "entity": "Morpho",
       "totalFundsAtRisk": 1186633719.4858596,
@@ -73,7 +73,7 @@
       ]
     },
     {
-      "address": "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+      "address": "0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
       "name": "Chainlink ETH/USD Price Feed",
       "entity": null,
       "totalFundsAtRisk": 266964315.50836384,
@@ -89,7 +89,7 @@
       ]
     },
     {
-      "address": "eth:0xad430500ecda11e38c9bcb08a702274b94641112",
+      "address": "0xad430500ecda11e38c9bcb08a702274b94641112",
       "name": "Tellor Price Feed",
       "entity": null,
       "totalFundsAtRisk": 175609673.29952922,
@@ -101,7 +101,7 @@
       ]
     },
     {
-      "address": "eth:0xcfe54b5cd566ab89272946f602d76ea879cab4a8",
+      "address": "0xcfe54b5cd566ab89272946f602d76ea879cab4a8",
       "name": "Chainlink stETH/USD Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 91354642.20883462,
@@ -113,7 +113,7 @@
       ]
     },
     {
-      "address": "eth:0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+      "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
       "name": "Lido wstETH Token",
       "entity": "Lido",
       "totalFundsAtRisk": 91354642.20883462,
@@ -125,7 +125,7 @@
       ]
     },
     {
-      "address": "eth:0x536218f9e9eb48863970252233c8f271f554c2d0",
+      "address": "0x536218f9e9eb48863970252233c8f271f554c2d0",
       "name": "Chainlink rETH/ETH Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 91354642.20883462,
@@ -137,7 +137,7 @@
       ]
     },
     {
-      "address": "eth:0xae78736cd615f374d3085123a210448e74fc6393",
+      "address": "0xae78736cd615f374d3085123a210448e74fc6393",
       "name": "RocketPool rETH Token",
       "entity": "RocketPool",
       "totalFundsAtRisk": 91354642.20883462,
@@ -149,7 +149,7 @@
       ]
     },
     {
-      "address": "eth:0x86392dc19c0b719886221c78ab11eb8cf5c52812",
+      "address": "0x86392dc19c0b719886221c78ab11eb8cf5c52812",
       "name": "Chainlink USDC/USD Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 0,
@@ -161,7 +161,7 @@
       ]
     },
     {
-      "address": "eth:0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
+      "address": "0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
       "name": "Chainlink USDC/USD Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 0,
@@ -173,7 +173,7 @@
       ]
     },
     {
-      "address": "eth:0xc0053f3fbccd593758258334dfce24c2a9a673ad",
+      "address": "0xc0053f3fbccd593758258334dfce24c2a9a673ad",
       "name": "Chainlink USDC/USD Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 0,
@@ -185,7 +185,7 @@
       ]
     },
     {
-      "address": "eth:0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
+      "address": "0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
       "name": "Chainlink USDC/USD Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 0,
@@ -197,7 +197,7 @@
       ]
     },
     {
-      "address": "eth:0xf4030086522a5beea4988f8ca5b36dbc97bee88c",
+      "address": "0xf4030086522a5beea4988f8ca5b36dbc97bee88c",
       "name": "Chainlink BTC/USD Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 0,
@@ -209,7 +209,7 @@
       ]
     },
     {
-      "address": "eth:0xfdfd9c85ad200c506cf9e21f1fd8dd01932fbb23",
+      "address": "0xfdfd9c85ad200c506cf9e21f1fd8dd01932fbb23",
       "name": "Chainlink USDC/USD Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 0,
@@ -221,7 +221,7 @@
       ]
     },
     {
-      "address": "eth:0x4f67e4d9bd67efa28236013288737d39aef48e79",
+      "address": "0x4f67e4d9bd67efa28236013288737d39aef48e79",
       "name": "Chainlink wstETH Price Feed",
       "entity": "Chainlink",
       "totalFundsAtRisk": 0,

--- a/packages/defiscan-frontend/public/data/index.json
+++ b/packages/defiscan-frontend/public/data/index.json
@@ -13,7 +13,7 @@
         "scoredFunctionCount": 0,
         "adminCount": 6,
         "dependencyCount": 2,
-        "totalCapitalAtRisk": 160440859.57738438,
+        "totalCapitalAtRisk": 169519102.78369424,
         "totalTokenValueAtRisk": 0,
         "totalTokenValue": 0
       }
@@ -25,10 +25,10 @@
       "projectType": "cdp",
       "tokenName": "LUSD",
       "totals": {
-        "contractCount": 18,
+        "contractCount": 21,
         "permissionedFunctionCount": 17,
         "scoredFunctionCount": 0,
-        "adminCount": 2,
+        "adminCount": 0,
         "dependencyCount": 2,
         "totalCapitalAtRisk": 175609673.29952922,
         "totalTokenValueAtRisk": 31203451.700806536,
@@ -54,7 +54,7 @@
     }
   ],
   "globalTotals": {
-    "totalCapitalAtRisk": 441859798.9171848,
+    "totalCapitalAtRisk": 450938042.1234947,
     "totalTokenValueAtRisk": 0,
     "totalTokenValue": 91728836.9542729,
     "protocolsReviewed": 3
@@ -64,7 +64,7 @@
       "address": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
       "name": "Morpho Blue",
       "entity": "Morpho",
-      "totalFundsAtRisk": 1123086017.0416906,
+      "totalFundsAtRisk": 1186633719.4858596,
       "protocols": [
         {
           "slug": "Steakhouse-USDC",

--- a/packages/defiscan-frontend/public/data/liquity-v1/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/liquity-v1/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-05T04:56:23.703Z",
+  "compiledAt": "2026-03-09T00:37:48.128Z",
   "project": "liquity-v1",
   "metadata": {
     "protocolName": "Liquity V1",
@@ -11,7 +11,7 @@
     "description": "Liquity V1 is an immutable, governance-free borrowing protocol on Ethereum that issues LUSD stablecoins against ETH collateral at a minimum 110% collateralization ratio. All smart contracts are non-upgradeable with ownership renounced to the zero address, making the protocol fully autonomous. The system relies on Chainlink and Tellor as dual oracle sources for ETH/USD pricing, with an automatic fallback mechanism between the two. The protocol holds $175.61M in total value across its contracts."
   },
   "totals": {
-    "contractCount": 18,
+    "contractCount": 21,
     "permissionedFunctionCount": 17,
     "scoredFunctionCount": 0,
     "adminCount": 4,
@@ -163,7 +163,7 @@
       "address": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
       "name": "TroveManager",
       "description": "",
-      "adminType": "Contract",
+      "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
         {
@@ -203,7 +203,7 @@
       "address": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
       "name": "BorrowerOperations",
       "description": "",
-      "adminType": "Contract",
+      "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
         {
@@ -405,94 +405,183 @@
   "functions": [],
   "contracts": [
     {
-      "address": "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
-      "name": "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+      "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+      "name": "ActivePool (ETH)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+      "name": "BorrowerOperations",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x3D7aE7E594f2f2091Ad8798313450130d0Aba3a0",
+      "name": "Chainlink LUSD/USD Price Feed",
       "isExternal": true,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0x3d7ae7e594f2f2091ad8798313450130d0aba3a0",
-      "name": "eth:0x3d7ae7e594f2f2091ad8798313450130d0aba3a0",
+      "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+      "name": "CollSurplusPool (ETH)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xD8c9D9071123a059C6E0A945cF0e0c82b508d816",
+      "name": "CommunityIssuance",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x896a3F03176f05CFbb4f006BfCd8723F2B0D741C",
+      "name": "DefaultPool",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x9555b042F969E561855e5F28cB1230819149A8d9",
+      "name": "GasPool (LUSD)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0",
+      "name": "HintHelpers",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+      "name": "LQTY Token",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d",
+      "name": "LQTYStaking",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+      "name": "LUSD Stablecoin Token",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xFc92d0E9Fa35df17E3A6d9F40716ca2cE749922B",
+      "name": "MultiTroveGetter",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
+      "name": "PriceFeed",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6",
+      "name": "SortedTroves",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+      "name": "StabilityPool (LUSD + ETH)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xAd430500ECDa11E38C9bCB08a702274b94641112",
+      "name": "Tellor Price Feed",
       "isExternal": true,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
-      "name": "eth:0x88df592f8eb5d7bd38bfef7deb0fbc02cf3778a0",
+      "address": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+      "name": "TroveManager",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xb8a9faDA75c6d891fB77a7988Ff9BaD9e485Ca1C",
+      "name": "3/8 Multisig",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "gnosis safe"
+    },
+    {
+      "address": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
+      "name": "4/9 Multisig",
       "isExternal": true,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "gnosis safe"
     },
     {
-      "address": "eth:0xad430500ecda11e38c9bcb08a702274b94641112",
-      "name": "eth:0xad430500ecda11e38c9bcb08a702274b94641112",
+      "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+      "name": "Chainlink ETH/USD Price Feed",
       "isExternal": true,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0x21f73d42eb58ba49ddb685dc29d3bf5c0f0373ca",
-      "name": "eth:0x21f73d42eb58ba49ddb685dc29d3bf5c0f0373ca",
+      "address": "eth:0x88dF592F8eb5D7Bd38bFeF7dEb0fBc02cf3778a0",
+      "name": "Tellor Tributes Token",
       "isExternal": true,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "ZeppelinOS proxy"
     },
     {
-      "address": "eth:0x66017d22b0f8556afdd19fc67041899eb65a21bb",
-      "name": "eth:0x66017d22b0f8556afdd19fc67041899eb65a21bb",
+      "address": "eth:0xD98C3b7f0297f2eD1861893cFD80C4CfA24Fb687",
+      "name": "eth:0xD98C3b7f0297f2eD1861893cFD80C4CfA24Fb687",
       "isExternal": false,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f",
-      "name": "eth:0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
-      "name": "eth:0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x3d32e8b97ed5881324241cf03b2da5e2ebce5521",
-      "name": "eth:0x3d32e8b97ed5881324241cf03b2da5e2ebce5521",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x9555b042f969e561855e5f28cb1230819149a8d9",
-      "name": "eth:0x9555b042f969e561855e5f28cb1230819149a8d9",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
-      "name": "eth:0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
+      "proxyType": "EOA"
     }
   ],
+  "resources": [],
   "sections": {
     "codeAndAudits": {
       "title": "Code & Audits",

--- a/packages/defiscan-frontend/public/data/liquity-v1/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/liquity-v1/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-09T00:37:48.128Z",
+  "compiledAt": "2026-03-09T06:55:32.100Z",
   "project": "liquity-v1",
   "metadata": {
     "protocolName": "Liquity V1",
@@ -12,7 +12,7 @@
   },
   "totals": {
     "contractCount": 21,
-    "permissionedFunctionCount": 17,
+    "permissionedFunctionCount": 0,
     "scoredFunctionCount": 0,
     "adminCount": 4,
     "dependencyCount": 2,
@@ -338,7 +338,7 @@
     {
       "address": "eth:0xdf9eb223bafbe5c5271415c75aecd68c21fe3d7f",
       "name": "ActivePool (ETH)",
-      "description": "Holds $158.37M in ETH collateral deposited by borrowers with active troves. This is the primary collateral pool backing all outstanding LUSD debt.",
+      "description": "Holds (N/A) in ETH collateral deposited by borrowers with active troves. This is the primary collateral pool backing all outstanding LUSD debt.",
       "balances": {
         "totalUsdValue": 158367997.90465567
       },
@@ -348,7 +348,7 @@
     {
       "address": "eth:0x66017d22b0f8556afdd19fc67041899eb65a21bb",
       "name": "StabilityPool (LUSD + ETH)",
-      "description": "Holds $14.02M in LUSD deposits from stability providers and ETH gains from liquidations. Stability depositors absorb liquidated debt in exchange for discounted ETH collateral.",
+      "description": "Holds (N/A) in LUSD deposits from stability providers and ETH gains from liquidations. Stability depositors absorb liquidated debt in exchange for discounted ETH collateral.",
       "balances": {
         "totalUsdValue": 14016796.67580555
       },
@@ -358,7 +358,7 @@
     {
       "address": "eth:0x3d32e8b97ed5881324241cf03b2da5e2ebce5521",
       "name": "CollSurplusPool (ETH)",
-      "description": "Holds $3.22M in excess ETH collateral from liquidated troves that exceeded the 110% ratio at liquidation time. Borrowers can claim their surplus collateral from this pool.",
+      "description": "Holds (N/A) in excess ETH collateral from liquidated troves that exceeded the 110% ratio at liquidation time. Borrowers can claim their surplus collateral from this pool.",
       "balances": {
         "totalUsdValue": 3224878.719068009
       },
@@ -368,7 +368,7 @@
     {
       "address": "eth:0x9555b042f969e561855e5f28cb1230819149a8d9",
       "name": "GasPool (LUSD)",
-      "description": "Holds $21.30K in LUSD reserved as gas compensation for liquidators. Each trove deposits 200 LUSD into the GasPool at opening, which is returned or used to compensate the liquidator upon closure.",
+      "description": "Holds (N/A) in LUSD reserved as gas compensation for liquidators. Each trove deposits 200 LUSD into the GasPool at opening, which is returned or used to compensate the liquidator upon closure.",
       "balances": {
         "totalUsdValue": 21296.177581812874
       },
@@ -378,7 +378,7 @@
     {
       "address": "eth:0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
       "name": "LQTY Token",
-      "description": "Liquity governance token with a market cap of $29.20M. Used for staking in LQTYStaking to earn borrowing and redemption fee revenue. The token contract includes a one-year lockup mechanism and a multisig-controlled sendToLQTYStaking function, though the token itself is non-upgradeable.",
+      "description": "Liquity governance token with a market cap of (N/A). Used for staking in LQTYStaking to earn borrowing and redemption fee revenue. The token contract includes a one-year lockup mechanism and a multisig-controlled sendToLQTYStaking function, though the token itself is non-upgradeable.",
       "balances": null,
       "positions": null,
       "tokenInfo": {
@@ -391,7 +391,7 @@
     {
       "address": "eth:0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
       "name": "LUSD Stablecoin Token",
-      "description": "USD-pegged stablecoin with a market cap of $31.20M. Minting and burning are restricted to BorrowerOperations, TroveManager, and StabilityPool contracts. The token is non-upgradeable and has no admin mint function.",
+      "description": "USD-pegged stablecoin with a market cap of (N/A). Minting and burning are restricted to BorrowerOperations, TroveManager, and StabilityPool contracts. The token is non-upgradeable and has no admin mint function.",
       "balances": null,
       "positions": null,
       "tokenInfo": {
@@ -571,14 +571,6 @@
       "isGovernance": false,
       "entity": null,
       "proxyType": "ZeppelinOS proxy"
-    },
-    {
-      "address": "eth:0xD98C3b7f0297f2eD1861893cFD80C4CfA24Fb687",
-      "name": "eth:0xD98C3b7f0297f2eD1861893cFD80C4CfA24Fb687",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": "EOA"
     }
   ],
   "resources": [],

--- a/packages/defiscan-frontend/public/data/liquity-v2/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/liquity-v2/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-09T00:37:49.421Z",
+  "compiledAt": "2026-03-09T06:55:31.884Z",
   "project": "liquity-v2",
   "metadata": {
     "protocolName": "Liquity V2",
@@ -12,8 +12,8 @@
   },
   "totals": {
     "contractCount": 44,
-    "permissionedFunctionCount": 115,
-    "scoredFunctionCount": 17,
+    "permissionedFunctionCount": 0,
+    "scoredFunctionCount": 0,
     "adminCount": 7,
     "dependencyCount": 5,
     "totalCapitalAtRisk": 105809266.04027124,
@@ -3376,7 +3376,7 @@
     {
       "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
       "name": "ActivePool (rETH branch)",
-      "description": "Immutable protocol contract holding rETH collateral deposited by borrowers. Authorized to send collateral to the DefaultPool and trigger BOLD reward distributions to the StabilityPool. Controls $14.27M in rETH collateral through internal protocol logic only.",
+      "description": "Immutable protocol contract holding rETH collateral deposited by borrowers. Authorized to send collateral to the DefaultPool and trigger BOLD reward distributions to the StabilityPool. Controls (N/A) in rETH collateral through internal protocol logic only.",
       "adminType": "Immutable",
       "isGovernance": false,
       "functions": [
@@ -4152,7 +4152,7 @@
     {
       "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
       "name": "Lido wstETH Token",
-      "description": "Wrapped staked ETH token contract used as collateral in the wstETH borrowing branch. The WSTETHPriceFeed contract calls wstETH's exchange rate function to convert between stETH and wstETH values. The ActivePool for this branch holds $64.14M in wstETH deposits.",
+      "description": "Wrapped staked ETH token contract used as collateral in the wstETH borrowing branch. The WSTETHPriceFeed contract calls wstETH's exchange rate function to convert between stETH and wstETH values. The ActivePool for this branch holds (N/A) in wstETH deposits.",
       "entity": "Lido",
       "isAutoDetected": true,
       "viewOnlyPath": false,
@@ -4292,7 +4292,7 @@
     {
       "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
       "name": "RocketPool rETH Token",
-      "description": "Rocket Pool's liquid staking token used as collateral in the rETH borrowing branch. The RETHPriceFeed contract queries the rETH exchange rate to derive USD pricing. The ActivePool for this branch holds $14.27M in rETH deposits.",
+      "description": "Rocket Pool's liquid staking token used as collateral in the rETH borrowing branch. The RETHPriceFeed contract queries the rETH exchange rate to derive USD pricing. The ActivePool for this branch holds (N/A) in rETH deposits.",
       "entity": "RocketPool",
       "isAutoDetected": true,
       "viewOnlyPath": false,
@@ -4361,7 +4361,7 @@
     {
       "address": "eth:0x531a8f99c70d6a56a7cee02d6b4281650d7919a0",
       "name": "ActivePool (wstETH)",
-      "description": "Holds $64.14M in wstETH collateral deposited by borrowers in the wstETH branch. This is the largest collateral pool in the protocol. Collateral is locked here while Troves remain open and is released during closures, liquidations, or redemptions.",
+      "description": "Holds (N/A) in wstETH collateral deposited by borrowers in the wstETH branch. This is the largest collateral pool in the protocol. Collateral is locked here while Troves remain open and is released during closures, liquidations, or redemptions.",
       "balances": {
         "totalUsdValue": 64143216.414889336
       },
@@ -4371,7 +4371,7 @@
     {
       "address": "eth:0x9074d72cc82dad1e13e454755aa8f144c479532f",
       "name": "ActivePool (rETH)",
-      "description": "Holds $14.27M in rETH collateral deposited by borrowers in the rETH branch. Functions identically to the wstETH ActivePool but for Rocket Pool ETH collateral.",
+      "description": "Holds (N/A) in rETH collateral deposited by borrowers in the rETH branch. Functions identically to the wstETH ActivePool but for Rocket Pool ETH collateral.",
       "balances": {
         "totalUsdValue": 14274796.542198261
       },
@@ -4381,7 +4381,7 @@
     {
       "address": "eth:0xeb5a8c825582965f1d84606e078620a84ab16afe",
       "name": "ActivePool (WETH)",
-      "description": "Holds $12.94M in WETH collateral deposited by borrowers in the WETH branch. The simplest collateral branch using native wrapped Ether without additional liquid staking token exchange rate dependencies.",
+      "description": "Holds (N/A) in WETH collateral deposited by borrowers in the WETH branch. The simplest collateral branch using native wrapped Ether without additional liquid staking token exchange rate dependencies.",
       "balances": {
         "totalUsdValue": 12936629.251747033
       },
@@ -4391,7 +4391,7 @@
     {
       "address": "eth:0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b",
       "name": "StabilityPool (wstETH)",
-      "description": "Holds $11.14M in BOLD deposits and liquidated wstETH collateral. Depositors provide BOLD to absorb liquidations in the wstETH branch and receive discounted wstETH collateral plus BOLD interest rewards in return.",
+      "description": "Holds (N/A) in BOLD deposits and liquidated wstETH collateral. Depositors provide BOLD to absorb liquidations in the wstETH branch and receive discounted wstETH collateral plus BOLD interest rewards in return.",
       "balances": {
         "totalUsdValue": 11136200.135608597
       },
@@ -4401,7 +4401,7 @@
     {
       "address": "eth:0x5721cbbd64fc7ae3ef44a0a3f9a790a9264cf9bf",
       "name": "StabilityPool (WETH)",
-      "description": "Holds $7.55M in BOLD deposits and liquidated WETH collateral. Depositors provide BOLD to absorb liquidations in the WETH branch and receive discounted WETH collateral plus BOLD interest rewards in return.",
+      "description": "Holds (N/A) in BOLD deposits and liquidated WETH collateral. Depositors provide BOLD to absorb liquidations in the WETH branch and receive discounted WETH collateral plus BOLD interest rewards in return.",
       "balances": {
         "totalUsdValue": 7550908.855270761
       },
@@ -4411,7 +4411,7 @@
     {
       "address": "eth:0xd442e41019b7f5c4dd78f50dc03726c446148695",
       "name": "StabilityPool (rETH)",
-      "description": "Holds $3.32M in BOLD deposits and liquidated rETH collateral. Depositors provide BOLD to absorb liquidations in the rETH branch and receive discounted rETH collateral plus BOLD interest rewards in return.",
+      "description": "Holds (N/A) in BOLD deposits and liquidated rETH collateral. Depositors provide BOLD to absorb liquidations in the rETH branch and receive discounted rETH collateral plus BOLD interest rewards in return.",
       "balances": {
         "totalUsdValue": 3318423.695828019
       },
@@ -4421,7 +4421,7 @@
     {
       "address": "eth:0x6440f144b7e50d6a8439336510312d2f54beb01d",
       "name": "BOLD Stablecoin",
-      "description": "The protocol's native stablecoin with a market capitalization of $31.33M. BOLD is minted when users open Troves and burned during repayments and Stability Pool liquidation offsets. Ownership is renounced to the zero address, making the token contract immutable with no admin minting capability.",
+      "description": "The protocol's native stablecoin with a market capitalization of (N/A). BOLD is minted when users open Troves and burned during repayments and Stability Pool liquidation offsets. Ownership is renounced to the zero address, making the token contract immutable with no admin minting capability.",
       "balances": null,
       "positions": null,
       "tokenInfo": {
@@ -4432,110 +4432,7 @@
       }
     }
   ],
-  "functions": [
-    {
-      "contractAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-      "contractName": "ActivePool",
-      "functionName": "sendColl",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-      "contractName": "ActivePool",
-      "functionName": "sendCollToDefaultPool",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-      "contractName": "ActivePool",
-      "functionName": "mintAggInterestAndAccountForTroveChange",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-      "contractName": "ActivePool",
-      "functionName": "mintAggInterest",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-      "contractName": "ActivePool",
-      "functionName": "mintBatchManagementFeeAndAccountForChange",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-      "contractName": "ActivePool",
-      "functionName": "setShutdownFlag",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
-      "contractName": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
-      "functionName": "setAddresses",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
-      "contractName": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
-      "functionName": "setAddresses",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x896a3F03176f05CFbb4f006BfCd8723F2B0D741C",
-      "contractName": "eth:0x896a3F03176f05CFbb4f006BfCd8723F2B0D741C",
-      "functionName": "setAddresses",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6",
-      "contractName": "eth:0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6",
-      "functionName": "setParams",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
-      "contractName": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
-      "functionName": "setAddresses",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
-      "contractName": "StabilityPool",
-      "functionName": "triggerBoldRewards",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
-      "contractName": "StabilityPool",
-      "functionName": "offset",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x6440f144b7e50d6a8439336510312d2f54beb01d",
-      "contractName": "BoldToken",
-      "functionName": "setBranchAddresses",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x6440f144b7e50d6a8439336510312d2f54beb01d",
-      "contractName": "BoldToken",
-      "functionName": "setCollateralRegistry",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b",
-      "contractName": "StabilityPool",
-      "functionName": "triggerBoldRewards",
-      "impact": "critical"
-    },
-    {
-      "contractAddress": "eth:0x9502b7c397e9aa22fe9db7ef7daf21cd2aebe56b",
-      "contractName": "StabilityPool",
-      "functionName": "offset",
-      "impact": "critical"
-    }
-  ],
+  "functions": [],
   "contracts": [
     {
       "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
@@ -4888,14 +4785,6 @@
       "isGovernance": false,
       "entity": null,
       "proxyType": "immutable"
-    },
-    {
-      "address": "eth:0x6048896546837818165748415000000000000000",
-      "name": "eth:0x6048896546837818165748415000000000000000",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": "EOA"
     }
   ],
   "resources": [

--- a/packages/defiscan-frontend/public/data/liquity-v2/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/liquity-v2/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-06T13:45:34.018Z",
+  "compiledAt": "2026-03-09T00:37:49.421Z",
   "project": "liquity-v2",
   "metadata": {
     "protocolName": "Liquity V2",
@@ -17,7 +17,8 @@
     "adminCount": 7,
     "dependencyCount": 5,
     "totalCapitalAtRisk": 105809266.04027124,
-    "totalTokenValueAtRisk": 0
+    "totalTokenValueAtRisk": 0,
+    "totalTokenValue": 31325385.25346636
   },
   "admins": [
     {
@@ -4537,364 +4538,364 @@
   ],
   "contracts": [
     {
+      "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+      "name": "BOLD Stablecoin",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xf949982B91C8c61e952B3bA942cbbfaef5386684",
+      "name": "CollateralRegistry",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
       "address": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
-      "name": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
+      "name": "4/9 Multisig",
       "isExternal": true,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x4CB67cfee180B6B73B70c7B3fC162E5FCF6532f1",
-      "name": "eth:0x4CB67cfee180B6B73B70c7B3fC162E5FCF6532f1",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x55AA0f5e955aBa989f69C6216405B7d3624E5E16",
-      "name": "eth:0x55AA0f5e955aBa989f69C6216405B7d3624E5E16",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x5C026B7107f1F92a9768CF64f8B2a22252B0788d",
-      "name": "eth:0x5C026B7107f1F92a9768CF64f8B2a22252B0788d",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x6aEeF00A3A55b2a11C96e59b48bdb3f30DD8125A",
-      "name": "eth:0x6aEeF00A3A55b2a11C96e59b48bdb3f30DD8125A",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x6D53d5E35F5226a1613877e071b81217387aC6B5",
-      "name": "eth:0x6D53d5E35F5226a1613877e071b81217387aC6B5",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x7B740d24396B09F992B655A590139D7Fbb5C73c8",
-      "name": "eth:0x7B740d24396B09F992B655A590139D7Fbb5C73c8",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x8AaDF849561DcCeC75DA44d1147E736E0cc0134E",
-      "name": "eth:0x8AaDF849561DcCeC75DA44d1147E736E0cc0134E",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x97360A89B5adb7D82Dbde6C66A49de8a48D550E6",
-      "name": "eth:0x97360A89B5adb7D82Dbde6C66A49de8a48D550E6",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x9A5B545aA8B6289288E529c4099B0CcA62bcB708",
-      "name": "eth:0x9A5B545aA8B6289288E529c4099B0CcA62bcB708",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x9ef7D53aa6B62e272467B86ce724885D4e2853BE",
-      "name": "eth:0x9ef7D53aa6B62e272467B86ce724885D4e2853BE",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xC0C7eB4A39BAa77fD52715BD1dcE2246Df85E489",
-      "name": "eth:0xC0C7eB4A39BAa77fD52715BD1dcE2246Df85E489",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xC917E3BF6c211b326ffD4ed13E7D9a67682095CA",
-      "name": "eth:0xC917E3BF6c211b326ffD4ed13E7D9a67682095CA",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xd8D2297bDf4a84569bCec83C92A81549bE9c51E6",
-      "name": "eth:0xd8D2297bDf4a84569bCec83C92A81549bE9c51E6",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xE9DcbaCc91dB0e37562a8455c80d0734D7CF3bd1",
-      "name": "eth:0xE9DcbaCc91dB0e37562a8455c80d0734D7CF3bd1",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xF38326579519377178725A741C35999E8051e907",
-      "name": "eth:0xF38326579519377178725A741C35999E8051e907",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xFe31f3EcfDE29Fc4915d80Eb8A9d67bFF14180B3",
-      "name": "eth:0xFe31f3EcfDE29Fc4915d80Eb8A9d67bFF14180B3",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x514910771AF9Ca656af840dff83E8264EcF986CA",
-      "name": "eth:0x514910771AF9Ca656af840dff83E8264EcF986CA",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x641B698aD1C6E503470520B0EeCb472c0589dfE6",
-      "name": "eth:0x641B698aD1C6E503470520B0EeCb472c0589dfE6",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x2e1B5a40Edc922bCE489668b11749B8eAbd67f6b",
-      "name": "eth:0x2e1B5a40Edc922bCE489668b11749B8eAbd67f6b",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x3F7b49F03375Aa588B828A5FfbAac5727fb8202d",
-      "name": "eth:0x3F7b49F03375Aa588B828A5FfbAac5727fb8202d",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xB65B6d224351cD61f856c227b2d5cFc611E9B2d8",
-      "name": "eth:0xB65B6d224351cD61f856c227b2d5cFc611E9B2d8",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xb7F0643D4ca8c296564Ce335062833e1afa3Afdb",
-      "name": "eth:0xb7F0643D4ca8c296564Ce335062833e1afa3Afdb",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x47A1dD4E277530fffb5B5f70A43CCbD542F54e17",
-      "name": "eth:0x47A1dD4E277530fffb5B5f70A43CCbD542F54e17",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xFdE996F00E42b33bdE7C640786333623aCC3f298",
-      "name": "eth:0xFdE996F00E42b33bdE7C640786333623aCC3f298",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x480496c0884D61F2f56707Adb11697F8018898c2",
-      "name": "eth:0x480496c0884D61F2f56707Adb11697F8018898c2",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x7052cB84079905400ea52B635cAb6a275fDA8823",
-      "name": "eth:0x7052cB84079905400ea52B635cAb6a275fDA8823",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x80eFDeE7F82d0F2aBF3bF29A9A85edF0B42C9e19",
-      "name": "eth:0x80eFDeE7F82d0F2aBF3bF29A9A85edF0B42C9e19",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xaD8A3E228d1f1ffff22AB1720fE6fF7f92DdA252",
-      "name": "eth:0xaD8A3E228d1f1ffff22AB1720fE6fF7f92DdA252",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
-      "name": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
-      "name": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
-      "name": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-      "name": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
+      "proxyType": "gnosis safe"
     },
     {
       "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
-      "name": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+      "name": "ActivePool (wstETH)",
       "isExternal": false,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
       "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
-      "name": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+      "name": "ActivePool (rETH)",
       "isExternal": false,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
-      "name": "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
+      "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+      "name": "ActivePool (WETH)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+      "name": "BorrowerOperations",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+      "name": "BorrowerOperations (wstETH branch)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+      "name": "BorrowerOperations (rETH branch)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x2e1B5a40Edc922bCE489668b11749B8eAbd67f6b",
+      "name": "ConfirmedTransactionModule",
       "isExternal": true,
       "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
+      "entity": null,
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0x0000000000000000000000000000000000000000",
-      "name": "eth:0x0000000000000000000000000000000000000000",
+      "address": "eth:0x5cc5ceFD034Fdc4728D487a72Ca58A410CDdCD6b",
+      "name": "DefaultPool",
       "isExternal": false,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
-      "name": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+      "address": "eth:0xD4558240d50C2E219a21c9d25afD513Bb6e5B1A0",
+      "name": "DefaultPool",
       "isExternal": false,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
       "address": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
-      "name": "eth:0xD796e1648526400386CC4d12FA05E5F11e6a22A1",
+      "name": "DefaultPool (wstETH branch)",
       "isExternal": false,
       "isGovernance": false,
       "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-      "name": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-      "name": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
-      "isExternal": false,
-      "isGovernance": false,
-      "entity": null,
-      "proxyType": null
-    },
-    {
-      "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-      "name": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-      "isExternal": true,
-      "isGovernance": false,
-      "entity": "Chainlink",
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
       "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
-      "name": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+      "name": "Chainlink rETH/ETH Price Feed",
       "isExternal": true,
       "isGovernance": false,
       "entity": "Chainlink",
-      "proxyType": null
+      "proxyType": "immutable"
     },
     {
-      "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-      "name": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+      "name": "Chainlink ETH/USD Price Feed",
       "isExternal": true,
       "isGovernance": false,
-      "entity": "Lido",
-      "proxyType": null
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
+      "name": "Chainlink stETH/USD Price Feed",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Chainlink",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x84087689B0D6a8A8f11C297e9e7f8De99f398258",
+      "name": "FixedAssetReader",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xa5224865040034A9f8E5C60e0a616c9c8A63f237",
+      "name": "FixedAssetReader",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xcC77baf5706BDf7CFA7FefD5337833e2e1fd0d8e",
+      "name": "FixedAssetReader",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x807DEf5E7d057DF05C796F4bc75C3Fe82Bd6EeE1",
+      "name": "Governance",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x3400874305E1547020fb8e80eAF1308B757171Af",
+      "name": "MetadataNFT",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x362f822dF79790C8077e61110484Fffa48F682A1",
+      "name": "MetadataNFT",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x9B36C3B16299D68c79F174df7e728E35b6AF4A12",
+      "name": "MetadataNFT",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B",
+      "name": "RETHPriceFeed",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
     },
     {
       "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-      "name": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
+      "name": "RocketPool rETH Token",
       "isExternal": true,
       "isGovernance": false,
       "entity": "RocketPool",
-      "proxyType": null
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x14d8d8011dF2b396Ed2bbC4959bb73250324F386",
+      "name": "SortedTroves",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x84eb85a8C25049255614F0536Bea8F31682e86F1",
+      "name": "SortedTroves",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xA25269E41BD072513849F2E64Ad221e84f3063F4",
+      "name": "SortedTroves",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+      "name": "StabilityPool (WETH)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+      "name": "StabilityPool (wstETH)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+      "name": "StabilityPool (rETH)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+      "name": "TroveManager",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+      "name": "TroveManager (wstETH branch)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+      "name": "TroveManager (rETH branch)",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x1A0FC0b843aFD9140267D25d4E575Cb37a838013",
+      "name": "TroveNFT",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x7ae430E25b67f19B431e1D1Dc048a5BCF24C0873",
+      "name": "TroveNFT",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x857aECeBF75f1012DC18E15020C97096aeA31b04",
+      "name": "TroveNFT",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xCC5F8102eb670c89a4a3c567C13851260303c24F",
+      "name": "WETHPriceFeed",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "name": "Wrapped Ether Token",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      "name": "Lido wstETH Token",
+      "isExternal": true,
+      "isGovernance": false,
+      "entity": "Lido",
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E",
+      "name": "WSTETHPriceFeed",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x5CcA549ca706C39D68156e5E0a72CcBC95f563d0",
+      "name": "",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x884Acfa4593a6FdbA0a9373007E48Ea9AF881C42",
+      "name": "",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0xf4a3fE99227F6060e4C1c62b557EEE050B6483E4",
+      "name": "",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "immutable"
+    },
+    {
+      "address": "eth:0x6048896546837818165748415000000000000000",
+      "name": "eth:0x6048896546837818165748415000000000000000",
+      "isExternal": false,
+      "isGovernance": false,
+      "entity": null,
+      "proxyType": "EOA"
     }
   ],
   "resources": [

--- a/packages/defiscan-frontend/scripts/compile-data.ts
+++ b/packages/defiscan-frontend/scripts/compile-data.ts
@@ -115,14 +115,14 @@ function main() {
     const fundsDataPath = join(DATA_DIR, slug, 'funds-data.json')
     if (existsSync(fundsDataPath) && review.funds) {
       const fundsData: FundsData = JSON.parse(readFileSync(fundsDataPath, 'utf8'))
-      // Build case-insensitive lookup with eth: prefix normalization
+      // Build case-insensitive lookup with chain prefix normalization
       const fundsLookup = new Map<string, FundsData['contracts'][string]>()
       for (const [addr, data] of Object.entries(fundsData.contracts ?? {})) {
-        fundsLookup.set(addr.replace(/^eth:/i, '').toLowerCase(), data)
+        fundsLookup.set(addr.toLowerCase(), data)
       }
       let patched = 0
       for (const fund of review.funds) {
-        const normalizedAddr = fund.address.replace(/^eth:/i, '').toLowerCase()
+        const normalizedAddr = fund.address.toLowerCase()
         const contractFunds = fundsLookup.get(normalizedAddr)
         if (!contractFunds) continue
         if (contractFunds.balances) {
@@ -201,7 +201,7 @@ function main() {
     // For each dependency, sum capital of admins whose functions use this dependency
     // This avoids attributing the entire protocol TVL to every dependency
     for (const dep of review.dependencies) {
-      const key = dep.address.toLowerCase()
+      const key = dep.address.toLowerCase() // normalized for deduplication across protocols
       // Compute capital controlled by admins that call through this dependency
       const depContractAddresses = new Set(dep.functions.map((f) => f.contractAddress.toLowerCase()))
       let depCapital = 0

--- a/packages/defiscan-frontend/scripts/compile-data.ts
+++ b/packages/defiscan-frontend/scripts/compile-data.ts
@@ -5,6 +5,11 @@ import { fileURLToPath } from 'url'
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
+/** Strip chain prefix and lowercase for consistent address comparison */
+function stripChainPrefix(a: string): string {
+  return a.replace(/^[a-z0-9]+:/i, '').toLowerCase()
+}
+
 interface CompiledReview {
   metadata: {
     protocolName: string
@@ -118,11 +123,11 @@ function main() {
       // Build case-insensitive lookup with chain prefix normalization
       const fundsLookup = new Map<string, FundsData['contracts'][string]>()
       for (const [addr, data] of Object.entries(fundsData.contracts ?? {})) {
-        fundsLookup.set(addr.toLowerCase(), data)
+        fundsLookup.set(stripChainPrefix(addr), data)
       }
       let patched = 0
       for (const fund of review.funds) {
-        const normalizedAddr = fund.address.toLowerCase()
+        const normalizedAddr = stripChainPrefix(fund.address)
         const contractFunds = fundsLookup.get(normalizedAddr)
         if (!contractFunds) continue
         if (contractFunds.balances) {
@@ -201,13 +206,13 @@ function main() {
     // For each dependency, sum capital of admins whose functions use this dependency
     // This avoids attributing the entire protocol TVL to every dependency
     for (const dep of review.dependencies) {
-      const key = dep.address.toLowerCase() // normalized for deduplication across protocols
+      const key = stripChainPrefix(dep.address) // normalized for deduplication across protocols
       // Compute capital controlled by admins that call through this dependency
-      const depContractAddresses = new Set(dep.functions.map((f) => f.contractAddress.toLowerCase()))
+      const depContractAddresses = new Set(dep.functions.map((f) => stripChainPrefix(f.contractAddress)))
       let depCapital = 0
       for (const admin of review.admins) {
         const usesThisDep = admin.functions.some(
-          (f) => depContractAddresses.has(f.contractAddress.toLowerCase()),
+          (f) => depContractAddresses.has(stripChainPrefix(f.contractAddress)),
         )
         if (usesThisDep) {
           depCapital += admin.totalDirectCapital

--- a/packages/defiscan-frontend/src/pages/review/views/explorer/ContractsTab.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/explorer/ContractsTab.tsx
@@ -6,6 +6,7 @@ import type {
   CompiledContract,
   CompiledFunction,
 } from '../../../../types'
+import { addressesEqual } from '../../../../utils/address'
 
 interface ContractsTabProps {
   review: CompiledReview
@@ -212,7 +213,7 @@ export function ContractsTab({ review }: ContractsTabProps) {
                 contract={contract}
                 fnCount={fnCountByContract.get(contract.address.toLowerCase()) ?? 0}
                 functions={functions.filter(
-                  (f) => f.contractAddress === contract.address,
+                  (f) => addressesEqual(f.contractAddress, contract.address),
                 )}
                 adminsByFunction={adminsByFunction}
               />

--- a/packages/defiscan-frontend/src/pages/review/views/explorer/OverviewTab.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/explorer/OverviewTab.tsx
@@ -87,7 +87,7 @@ export function OverviewTab({ review }: OverviewTabProps) {
         <MetricBox
           label="Admins"
           value={String(humanAdmins.length)}
-          sublabel={`controlling ${totals.permissionedFunctionCount} functions`}
+          sublabel={humanAdmins.length > 0 ? `controlling ${totals.permissionedFunctionCount} functions` : 'having control'}
         />
         <MetricBox
           label="Dependencies"

--- a/packages/defiscan-frontend/src/utils/address.ts
+++ b/packages/defiscan-frontend/src/utils/address.ts
@@ -1,0 +1,7 @@
+/**
+ * Case-insensitive comparison of two addresses.
+ * Handles chain-prefixed addresses (e.g. "eth:0xAbC...").
+ */
+export function addressesEqual(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase()
+}

--- a/packages/defiscan-frontend/src/utils/format.ts
+++ b/packages/defiscan-frontend/src/utils/format.ts
@@ -12,13 +12,32 @@ export function formatUsdValue(value: number): string {
   return `$${value.toFixed(2)}`
 }
 
+/**
+ * Strip the chain prefix from an address.
+ * Works with any chain prefix (eth:, arb1:, base:, etc.).
+ */
+export function stripChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(colonIdx + 1)
+  }
+  return address
+}
+
+/**
+ * Normalize an address for use as a lookup key (lowercase).
+ */
+export function normalizeForLookup(address: string): string {
+  return address.toLowerCase()
+}
+
 export function truncateAddress(address: string): string {
-  const raw = address.startsWith('eth:') ? address.slice(4) : address
+  const raw = stripChainPrefix(address)
   if (raw.length <= 10) return raw
   return `${raw.slice(0, 6)}...${raw.slice(-4)}`
 }
 
 export function etherscanUrl(address: string): string {
-  const raw = address.startsWith('eth:') ? address.slice(4) : address
+  const raw = stripChainPrefix(address)
   return `https://etherscan.io/address/${raw}`
 }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/addressUtils.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/addressUtils.ts
@@ -1,0 +1,172 @@
+import { EthereumAddress } from '@l2beat/shared-pure'
+
+/**
+ * Address utility functions for DeFiDisco.
+ *
+ * All internal addresses use the chain-prefixed format "chain:0xChecksummed".
+ * These helpers ensure addresses are always normalized on ingestion and
+ * compared without ad-hoc toLowerCase() calls scattered through the codebase.
+ */
+
+// ---------------------------------------------------------------------------
+// Core: normalize a chain-prefixed address to checksummed form
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a chain-prefixed address (e.g. "eth:0xabc...") so that:
+ *  - the chain prefix is preserved as-is (lowercase by convention)
+ *  - the hex address part is ERC-55 checksummed
+ *
+ * If the address has no chain prefix it is returned with "eth:" prepended
+ * (legacy compatibility). If the hex part is invalid the input is returned
+ * unchanged so callers don't crash on non-address strings.
+ */
+export function normalizeChainAddress(raw: string): string {
+  const colonIdx = raw.indexOf(':')
+
+  let chain: string
+  let hex: string
+
+  if (colonIdx !== -1 && !raw.startsWith('0x')) {
+    chain = raw.slice(0, colonIdx)
+    hex = raw.slice(colonIdx + 1)
+  } else {
+    // No chain prefix – treat as ethereum
+    chain = 'eth'
+    hex = raw
+  }
+
+  if (!hex.startsWith('0x') || hex.length !== 42) {
+    return raw // not an address, return as-is
+  }
+
+  try {
+    const checksummed = EthereumAddress(hex)
+    return `${chain}:${checksummed}`
+  } catch {
+    return raw
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Comparison helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compare two chain-prefixed addresses for equality.
+ * Handles mixed casing and optional chain prefix gracefully.
+ */
+export function addressesEqual(a: string, b: string): boolean {
+  return normalizeChainAddress(a) === normalizeChainAddress(b)
+}
+
+/**
+ * Strip the chain prefix from an address.
+ * Works with any chain prefix (eth:, arb1:, base:, etc.).
+ */
+export function stripChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(colonIdx + 1)
+  }
+  return address
+}
+
+/**
+ * Get only the chain prefix from a chain-specific address.
+ * Returns 'eth' as default if no prefix is found.
+ */
+export function getChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(0, colonIdx)
+  }
+  return 'eth'
+}
+
+/**
+ * Ensure an address has a chain prefix.
+ * If it already has one, normalizes the checksumming.
+ * If it doesn't, prepends 'eth:' by default.
+ */
+export function ensureChainPrefix(
+  address: string,
+  chain = 'eth',
+): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return normalizeChainAddress(address)
+  }
+  return normalizeChainAddress(`${chain}:${address}`)
+}
+
+/**
+ * Check if a string looks like a chain-prefixed address.
+ */
+export function isChainAddress(value: string): boolean {
+  const colonIdx = value.indexOf(':')
+  if (colonIdx === -1 || value.startsWith('0x')) return false
+  const hex = value.slice(colonIdx + 1)
+  return hex.startsWith('0x') && hex.length === 42
+}
+
+// ---------------------------------------------------------------------------
+// Collection helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a case-insensitive lookup Set from an array of addresses.
+ * All entries are normalized so lookups don't need toLowerCase().
+ */
+export function buildAddressSet(addresses: string[]): Set<string> {
+  return new Set(addresses.map(normalizeChainAddress))
+}
+
+/**
+ * Check if an address is in a normalized address set.
+ */
+export function isInAddressSet(address: string, set: Set<string>): boolean {
+  return set.has(normalizeChainAddress(address))
+}
+
+/**
+ * Build a Map keyed by normalized addresses.
+ */
+export function buildAddressMap<T>(
+  entries: Array<[string, T]>,
+): Map<string, T> {
+  const map = new Map<string, T>()
+  for (const [addr, value] of entries) {
+    map.set(normalizeChainAddress(addr), value)
+  }
+  return map
+}
+
+/**
+ * Look up a value in an address-keyed Map using normalized comparison.
+ */
+export function getFromAddressMap<T>(
+  map: Map<string, T>,
+  address: string,
+): T | undefined {
+  return map.get(normalizeChainAddress(address))
+}
+
+/**
+ * Look up a value in a plain object keyed by addresses.
+ * Tries the normalized form first, then falls back to scanning all keys.
+ */
+export function getFromAddressRecord<T>(
+  record: Record<string, T>,
+  address: string,
+): T | undefined {
+  const normalized = normalizeChainAddress(address)
+  if (normalized in record) return record[normalized]
+  // Fallback: scan keys (handles legacy data with non-checksummed keys)
+  for (const key of Object.keys(record)) {
+    if (normalizeChainAddress(key) === normalized) {
+      return record[key]
+    }
+  }
+  return undefined
+}

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/addressUtils.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/addressUtils.ts
@@ -89,10 +89,7 @@ export function getChainPrefix(address: string): string {
  * If it already has one, normalizes the checksumming.
  * If it doesn't, prepends 'eth:' by default.
  */
-export function ensureChainPrefix(
-  address: string,
-  chain = 'eth',
-): string {
+export function ensureChainPrefix(address: string, chain = 'eth'): string {
   const colonIdx = address.indexOf(':')
   if (colonIdx !== -1 && !address.startsWith('0x')) {
     return normalizeChainAddress(address)

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -7,6 +7,14 @@ import { spawn } from 'child_process'
 import * as fs from 'fs'
 import * as path from 'path'
 import {
+  addressesEqual,
+  buildAddressSet,
+  isChainAddress,
+  isInAddressSet,
+  normalizeChainAddress,
+  stripChainPrefix,
+} from './addressUtils'
+import {
   createHeuristicEngine,
   type HeuristicContext,
   parseVariableAssignments,
@@ -472,7 +480,7 @@ function getSlithirCacheFilePath(
   contractAddress: string,
 ): string {
   // Use the address (without eth: prefix) as filename
-  const cleanAddress = contractAddress.replace(/^eth:/i, '')
+  const cleanAddress = stripChainPrefix(contractAddress)
   return path.join(
     getSlithirCacheFolderPath(paths, project),
     `${cleanAddress}.json`,
@@ -521,7 +529,7 @@ function getContractSourceHash(
   slitherAddress: string,
 ): string | undefined {
   const entry = discovered.entries.find(
-    (e) => e.address.toLowerCase() === entryAddress.toLowerCase(),
+    (e) => addressesEqual(e.address, entryAddress),
   )
 
   if (!entry?.sourceHashes || entry.sourceHashes.length === 0) {
@@ -531,7 +539,7 @@ function getContractSourceHash(
   // For proxies (entryAddress !== slitherAddress), use only the implementation hash
   // to avoid cache thrashing when two proxies share one implementation.
   // sourceHashes order: [proxy, implementation] — last element is the implementation.
-  if (entryAddress.toLowerCase() !== slitherAddress.toLowerCase()) {
+  if (!addressesEqual(entryAddress, slitherAddress)) {
     return entry.sourceHashes[entry.sourceHashes.length - 1]
   }
 
@@ -564,10 +572,10 @@ function getContractsToAnalyze(
 ): ContractToAnalyze[] {
   // Load contract tags to identify external contracts
   const tags = getContractTags(paths, project)
-  const externalAddresses = new Set(
+  const externalAddresses = buildAddressSet(
     tags.tags
       .filter((tag) => tag.isExternal)
-      .map((tag) => tag.contractAddress.toLowerCase()),
+      .map((tag) => tag.contractAddress),
   )
 
   const contracts: ContractToAnalyze[] = []
@@ -576,8 +584,7 @@ function getContractsToAnalyze(
     if (entry.type !== 'Contract') continue
 
     // Skip external contracts
-    const normalizedAddress = entry.address.toLowerCase()
-    if (externalAddresses.has(normalizedAddress)) continue
+    if (isInAddressSet(entry.address, externalAddresses)) continue
 
     const displayName = entry.name || 'Unknown'
     const implNames = entry.implementationNames
@@ -590,7 +597,7 @@ function getContractsToAnalyze(
       // Get implementation address from values.$implementation
       const implValue = entry.values?.$implementation
 
-      if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
+      if (typeof implValue === 'string' && isChainAddress(implValue)) {
         // Proxy contract — analyze the implementation
         const implAddress = implValue as typeof entry.address
         const implName = implNames?.[implAddress] ?? displayName
@@ -636,12 +643,12 @@ function getContractsToAnalyze(
  * Handles flat strings and one-level-deep object fields (e.g., oracle structs
  * with an `aggregator` address alongside non-address fields like `stalenessThreshold`).
  */
-export function extractEthAddresses(value: unknown): string[] {
-  if (typeof value === 'string' && value.startsWith('eth:')) return [value]
+export function extractChainAddresses(value: unknown): string[] {
+  if (typeof value === 'string' && isChainAddress(value)) return [value]
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
     const addresses: string[] = []
     for (const v of Object.values(value)) {
-      if (typeof v === 'string' && v.startsWith('eth:')) {
+      if (typeof v === 'string' && isChainAddress(v)) {
         addresses.push(v)
       }
     }
@@ -649,6 +656,9 @@ export function extractEthAddresses(value: unknown): string[] {
   }
   return []
 }
+
+/** @deprecated Use extractChainAddresses instead */
+export const extractEthAddresses = extractChainAddresses
 
 /**
  * Resolve storage variable to actual contract address using discovered.json
@@ -661,7 +671,7 @@ function resolveStorageVariable(
   // Find the contract in discovered data
   const contract = discovered.entries.find(
     (e) =>
-      e.address.toLowerCase() === contractAddress.toLowerCase() &&
+      addressesEqual(e.address, contractAddress) &&
       e.type === 'Contract',
   )
 
@@ -672,10 +682,10 @@ function resolveStorageVariable(
   // Look up the storage variable in contract values
   const value = contract.values[storageVariable]
 
-  if (typeof value === 'string' && value.startsWith('eth:')) {
+  if (typeof value === 'string' && isChainAddress(value)) {
     // Find the name of the resolved contract
     const resolvedContract = discovered.entries.find(
-      (e) => e.address.toLowerCase() === value.toLowerCase(),
+      (e) => addressesEqual(e.address, value),
     )
     return {
       address: value,
@@ -685,11 +695,11 @@ function resolveStorageVariable(
 
   // Handle nested objects (e.g., oracle structs like { aggregator: "eth:0x...", decimals: 8 }).
   // Only deterministic if exactly one address is found (unambiguous).
-  const addresses = extractEthAddresses(value)
+  const addresses = extractChainAddresses(value)
   if (addresses.length === 1) {
     const addr = addresses[0]!
     const resolvedContract = discovered.entries.find(
-      (e) => e.address.toLowerCase() === addr.toLowerCase(),
+      (e) => addressesEqual(e.address, addr),
     )
     return {
       address: addr,
@@ -1187,7 +1197,7 @@ async function runSlitherOnContract(
     }
 
     // Clean address - remove eth: prefix
-    const cleanAddress = address.replace(/^eth:/i, '')
+    const cleanAddress = stripChainPrefix(address)
 
     onProgress?.(`Running slither on ${cleanAddress}...`)
 
@@ -1311,7 +1321,7 @@ export function traverseWithPaths(
   while (queue.length > 0) {
     const { contract, function: func, pathIsViewOnly, path } = queue.shift()!
 
-    const visitKey = `${contract.toLowerCase()}:${func}`
+    const visitKey = `${normalizeChainAddress(contract)}:${func}`
     if (visited.has(visitKey)) continue
     visited.add(visitKey)
 
@@ -1394,19 +1404,15 @@ export function findContractGraph(
   const direct = callGraphData.contracts[contract]
   if (direct) return direct
   const entry = Object.entries(callGraphData.contracts).find(
-    ([addr]) => addr.toLowerCase() === contract.toLowerCase(),
+    ([addr]) => addressesEqual(addr, contract),
   )
   return entry ? entry[1] : undefined
 }
 
 export function buildExternalAddressSet(tags: ContractTag[]): Set<string> {
-  const set = new Set<string>()
-  for (const tag of tags) {
-    if (tag.isExternal) {
-      set.add(tag.contractAddress.toLowerCase())
-    }
-  }
-  return set
+  return buildAddressSet(
+    tags.filter((tag) => tag.isExternal).map((tag) => tag.contractAddress),
+  )
 }
 
 export function buildTagsByAddress(
@@ -1414,7 +1420,7 @@ export function buildTagsByAddress(
 ): Map<string, ContractTag> {
   const map = new Map<string, ContractTag>()
   for (const tag of tags) {
-    map.set(tag.contractAddress.toLowerCase(), tag)
+    map.set(normalizeChainAddress(tag.contractAddress), tag)
   }
   return map
 }
@@ -1423,32 +1429,22 @@ export function isExternalAddress(
   address: string,
   externalAddresses: Set<string>,
 ): boolean {
-  const normalized = address.toLowerCase()
-  if (externalAddresses.has(normalized)) return true
-  if (externalAddresses.has(normalized.replace('eth:', ''))) return true
-  if (externalAddresses.has(`eth:${normalized}`)) return true
-  return false
+  return isInAddressSet(address, externalAddresses)
 }
 
 export function findTag(
   tagsByAddress: Map<string, ContractTag>,
   address: string,
 ): ContractTag | undefined {
-  const normalized = address.toLowerCase()
-  return (
-    tagsByAddress.get(normalized) ??
-    tagsByAddress.get(normalized.replace('eth:', '')) ??
-    tagsByAddress.get(`eth:${normalized}`)
-  )
+  return tagsByAddress.get(normalizeChainAddress(address))
 }
 
 export function getCallGraphContractName(
   callGraphData: ApiCallGraphResponse,
   address: string,
 ): string | undefined {
-  const normalizedAddress = address.toLowerCase()
   const entry = Object.entries(callGraphData.contracts).find(
-    ([key]) => key.toLowerCase() === normalizedAddress,
+    ([key]) => addressesEqual(key, address),
   )
   return entry?.[1]?.name
 }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraph.ts
@@ -528,8 +528,8 @@ function getContractSourceHash(
   entryAddress: string,
   slitherAddress: string,
 ): string | undefined {
-  const entry = discovered.entries.find(
-    (e) => addressesEqual(e.address, entryAddress),
+  const entry = discovered.entries.find((e) =>
+    addressesEqual(e.address, entryAddress),
   )
 
   if (!entry?.sourceHashes || entry.sourceHashes.length === 0) {
@@ -573,9 +573,7 @@ function getContractsToAnalyze(
   // Load contract tags to identify external contracts
   const tags = getContractTags(paths, project)
   const externalAddresses = buildAddressSet(
-    tags.tags
-      .filter((tag) => tag.isExternal)
-      .map((tag) => tag.contractAddress),
+    tags.tags.filter((tag) => tag.isExternal).map((tag) => tag.contractAddress),
   )
 
   const contracts: ContractToAnalyze[] = []
@@ -670,9 +668,7 @@ function resolveStorageVariable(
 ): { address: string | undefined; name: string | undefined } {
   // Find the contract in discovered data
   const contract = discovered.entries.find(
-    (e) =>
-      addressesEqual(e.address, contractAddress) &&
-      e.type === 'Contract',
+    (e) => addressesEqual(e.address, contractAddress) && e.type === 'Contract',
   )
 
   if (!contract || !('values' in contract) || !contract.values) {
@@ -684,8 +680,8 @@ function resolveStorageVariable(
 
   if (typeof value === 'string' && isChainAddress(value)) {
     // Find the name of the resolved contract
-    const resolvedContract = discovered.entries.find(
-      (e) => addressesEqual(e.address, value),
+    const resolvedContract = discovered.entries.find((e) =>
+      addressesEqual(e.address, value),
     )
     return {
       address: value,
@@ -698,8 +694,8 @@ function resolveStorageVariable(
   const addresses = extractChainAddresses(value)
   if (addresses.length === 1) {
     const addr = addresses[0]!
-    const resolvedContract = discovered.entries.find(
-      (e) => addressesEqual(e.address, addr),
+    const resolvedContract = discovered.entries.find((e) =>
+      addressesEqual(e.address, addr),
     )
     return {
       address: addr,
@@ -1403,8 +1399,8 @@ export function findContractGraph(
 ) {
   const direct = callGraphData.contracts[contract]
   if (direct) return direct
-  const entry = Object.entries(callGraphData.contracts).find(
-    ([addr]) => addressesEqual(addr, contract),
+  const entry = Object.entries(callGraphData.contracts).find(([addr]) =>
+    addressesEqual(addr, contract),
   )
   return entry ? entry[1] : undefined
 }
@@ -1443,8 +1439,8 @@ export function getCallGraphContractName(
   callGraphData: ApiCallGraphResponse,
   address: string,
 ): string | undefined {
-  const entry = Object.entries(callGraphData.contracts).find(
-    ([key]) => addressesEqual(key, address),
+  const entry = Object.entries(callGraphData.contracts).find(([key]) =>
+    addressesEqual(key, address),
   )
   return entry?.[1]?.name
 }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -1,5 +1,6 @@
 import type { DiscoveryOutput } from '@l2beat/discovery'
-import { extractEthAddresses } from './callGraph'
+import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+import { extractChainAddresses } from './callGraph'
 import type { ExternalCall, ResolutionCandidate } from './types'
 
 // =============================================================================
@@ -49,7 +50,7 @@ function contractHasFunction(
 ): boolean {
   const abiAddresses = [entry.address]
   const implValue = entry.values?.$implementation
-  if (typeof implValue === 'string' && implValue.startsWith('eth:')) {
+  if (typeof implValue === 'string' && isChainAddress(implValue)) {
     abiAddresses.push(implValue as typeof entry.address)
   }
 
@@ -92,7 +93,7 @@ class VariableChainHeuristic implements ResolutionHeuristic {
     // Look up the caller contract's values first
     const contract = discovered.entries.find(
       (e) =>
-        e.address.toLowerCase() === callerContractAddress.toLowerCase() &&
+        addressesEqual(e.address, callerContractAddress) &&
         e.type === 'Contract',
     )
 
@@ -115,9 +116,9 @@ class VariableChainHeuristic implements ResolutionHeuristic {
 
     const value = contract.values[resolvedVar]
 
-    if (typeof value === 'string' && value.startsWith('eth:')) {
+    if (typeof value === 'string' && isChainAddress(value)) {
       const resolvedContract = discovered.entries.find(
-        (e) => e.address.toLowerCase() === value.toLowerCase(),
+        (e) => addressesEqual(e.address, value),
       )
 
       return {
@@ -133,12 +134,12 @@ class VariableChainHeuristic implements ResolutionHeuristic {
 
     // Handle nested objects (e.g., oracle structs like { aggregator: "eth:0x...", decimals: 8 })
     // Filter to addresses that actually have the called function in their ABI
-    const addresses = extractEthAddresses(value)
+    const addresses = extractChainAddresses(value)
     if (addresses.length > 0) {
       const validMatches = addresses
         .map((addr) => {
           const entry = discovered.entries.find(
-            (e) => e.address.toLowerCase() === addr.toLowerCase(),
+            (e) => addressesEqual(e.address, addr),
           )
           return { address: addr, contractName: entry?.name, entry }
         })
@@ -350,7 +351,7 @@ class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
     // Find the caller contract's values
     const callerContract = discovered.entries.find(
       (e) =>
-        e.address.toLowerCase() === callerContractAddress.toLowerCase() &&
+        addressesEqual(e.address, callerContractAddress) &&
         e.type === 'Contract',
     )
 
@@ -365,8 +366,8 @@ class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
     // Collect all eth: addresses from the caller's values (one level deep into objects)
     const valueAddresses = new Set<string>()
     for (const value of Object.values(callerContract.values)) {
-      for (const addr of extractEthAddresses(value)) {
-        valueAddresses.add(addr.toLowerCase())
+      for (const addr of extractChainAddresses(value)) {
+        valueAddresses.add(normalizeChainAddress(addr))
       }
     }
 
@@ -380,7 +381,7 @@ class DiscoveredValuesScanHeuristic implements ResolutionHeuristic {
 
     for (const entry of discovered.entries) {
       if (entry.type !== 'Contract') continue
-      if (!valueAddresses.has(entry.address.toLowerCase())) continue
+      if (!valueAddresses.has(normalizeChainAddress(entry.address))) continue
 
       if (contractHasFunction(discovered, entry, functionName)) {
         matches.push({

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphHeuristics.ts
@@ -1,5 +1,9 @@
 import type { DiscoveryOutput } from '@l2beat/discovery'
-import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+import {
+  addressesEqual,
+  isChainAddress,
+  normalizeChainAddress,
+} from './addressUtils'
 import { extractChainAddresses } from './callGraph'
 import type { ExternalCall, ResolutionCandidate } from './types'
 
@@ -117,8 +121,8 @@ class VariableChainHeuristic implements ResolutionHeuristic {
     const value = contract.values[resolvedVar]
 
     if (typeof value === 'string' && isChainAddress(value)) {
-      const resolvedContract = discovered.entries.find(
-        (e) => addressesEqual(e.address, value),
+      const resolvedContract = discovered.entries.find((e) =>
+        addressesEqual(e.address, value),
       )
 
       return {
@@ -138,8 +142,8 @@ class VariableChainHeuristic implements ResolutionHeuristic {
     if (addresses.length > 0) {
       const validMatches = addresses
         .map((addr) => {
-          const entry = discovered.entries.find(
-            (e) => addressesEqual(e.address, addr),
+          const entry = discovered.entries.find((e) =>
+            addressesEqual(e.address, addr),
           )
           return { address: addr, contractName: entry?.name, entry }
         })

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphTraversal.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphTraversal.ts
@@ -74,7 +74,10 @@ export class CallGraphTraverser {
         // Try case-insensitive lookup
         const contractGraphEntry = Object.entries(
           this.callGraphData.contracts,
-        ).find(([addr]) => normalizeChainAddress(addr) === normalizeChainAddress(contract))
+        ).find(
+          ([addr]) =>
+            normalizeChainAddress(addr) === normalizeChainAddress(contract),
+        )
         if (!contractGraphEntry) continue
         // Use the found contract graph
         const [, foundGraph] = contractGraphEntry

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphTraversal.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/callGraphTraversal.ts
@@ -1,3 +1,4 @@
+import { normalizeChainAddress } from './addressUtils'
 import type {
   ApiCallGraphResponse,
   CallGraphTraversalResult,
@@ -63,7 +64,7 @@ export class CallGraphTraverser {
       const { contract, function: func, pathIsViewOnly } = queue.shift()!
 
       // Create visit key for cycle detection
-      const visitKey = `${contract.toLowerCase()}:${func}`
+      const visitKey = `${normalizeChainAddress(contract)}:${func}`
       if (visited.has(visitKey)) continue
       visited.add(visitKey)
 
@@ -73,7 +74,7 @@ export class CallGraphTraverser {
         // Try case-insensitive lookup
         const contractGraphEntry = Object.entries(
           this.callGraphData.contracts,
-        ).find(([addr]) => addr.toLowerCase() === contract.toLowerCase())
+        ).find(([addr]) => normalizeChainAddress(addr) === normalizeChainAddress(contract))
         if (!contractGraphEntry) continue
         // Use the found contract graph
         const [, foundGraph] = contractGraphEntry

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
@@ -211,8 +211,8 @@ export class CapitalAnalysisCalculator {
       // Check if we have call graph data for this contract
       const hasCallGraphData =
         this.callGraphData.contracts[func.contractAddress] !== undefined ||
-        Object.keys(this.callGraphData.contracts).some(
-          (addr) => addressesEqual(addr, func.contractAddress),
+        Object.keys(this.callGraphData.contracts).some((addr) =>
+          addressesEqual(addr, func.contractAddress),
         )
 
       if (!hasCallGraphData) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
@@ -1,3 +1,4 @@
+import { addressesEqual, normalizeChainAddress } from './addressUtils'
 import { CallGraphTraverser } from './callGraphTraversal'
 import type {
   AdminDetail,
@@ -45,10 +46,10 @@ export class CapitalAnalysisCalculator {
     functionName: string,
   ): boolean {
     // Case-insensitive lookup for the contract
-    const normalizedAddress = contractAddress.toLowerCase()
+    const normalizedAddress = normalizeChainAddress(contractAddress)
     const contractEntry = Object.entries(
       this.functionsData.contracts ?? {},
-    ).find(([key]) => key.toLowerCase() === normalizedAddress)
+    ).find(([key]) => normalizeChainAddress(key) === normalizedAddress)
 
     if (!contractEntry) return false
     const contractFunctions = contractEntry[1]
@@ -89,9 +90,9 @@ export class CapitalAnalysisCalculator {
     if (!this.fundsData?.contracts) return 0
 
     // Case-insensitive lookup
-    const normalizedAddress = contractAddress.toLowerCase()
+    const normalizedAddress = normalizeChainAddress(contractAddress)
     const fundsEntry = Object.entries(this.fundsData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddress,
+      ([key]) => normalizeChainAddress(key) === normalizedAddress,
     )
 
     if (!fundsEntry) return 0
@@ -111,9 +112,9 @@ export class CapitalAnalysisCalculator {
   getContractTokenValue(contractAddress: string): number {
     if (!this.fundsData?.contracts) return 0
 
-    const normalizedAddress = contractAddress.toLowerCase()
+    const normalizedAddress = normalizeChainAddress(contractAddress)
     const fundsEntry = Object.entries(this.fundsData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddress,
+      ([key]) => normalizeChainAddress(key) === normalizedAddress,
     )
 
     if (!fundsEntry) return 0
@@ -147,7 +148,7 @@ export class CapitalAnalysisCalculator {
 
     for (const [addr, data] of traversalResult.reachableContracts) {
       // Skip self-reference (the starting contract)
-      if (addr.toLowerCase() === contractAddress.toLowerCase()) continue
+      if (addressesEqual(addr, contractAddress)) continue
 
       const fundsUsd = this.getContractFunds(addr)
       const tokenValueUsd = this.getContractTokenValue(addr)
@@ -201,7 +202,7 @@ export class CapitalAnalysisCalculator {
     const functionsWithCapital: FunctionCapitalAnalysis[] = []
 
     // Track unique contracts to avoid double-counting
-    // Key: contract address (lowercase), Value: whether funds are at risk
+    // Key: contract address (normalized), Value: whether funds are at risk
     const contractsAtRisk = new Map<string, boolean>()
     const directContracts = new Set<string>()
 
@@ -211,12 +212,12 @@ export class CapitalAnalysisCalculator {
       const hasCallGraphData =
         this.callGraphData.contracts[func.contractAddress] !== undefined ||
         Object.keys(this.callGraphData.contracts).some(
-          (addr) => addr.toLowerCase() === func.contractAddress.toLowerCase(),
+          (addr) => addressesEqual(addr, func.contractAddress),
         )
 
       if (!hasCallGraphData) {
         // No call graph data - just track direct capital
-        directContracts.add(func.contractAddress.toLowerCase())
+        directContracts.add(normalizeChainAddress(func.contractAddress))
         continue
       }
 
@@ -230,11 +231,11 @@ export class CapitalAnalysisCalculator {
       functionsWithCapital.push(analysis)
 
       // Track direct contracts (always counted since the permissioned function has impact)
-      directContracts.add(func.contractAddress.toLowerCase())
+      directContracts.add(normalizeChainAddress(func.contractAddress))
 
       // Track reachable contracts - only mark as at risk if fundsAtRisk is true
       for (const reachable of analysis.reachableContracts) {
-        const addr = reachable.contractAddress.toLowerCase()
+        const addr = normalizeChainAddress(reachable.contractAddress)
         const existingRisk = contractsAtRisk.get(addr)
         // If any path marks it as at risk, it stays at risk
         if (existingRisk === true || reachable.fundsAtRisk) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/contractTags.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/contractTags.ts
@@ -1,6 +1,7 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
+import { addressesEqual, ensureChainPrefix } from './addressUtils'
 import type {
   ApiContractTagsResponse,
   ApiContractTagsUpdateRequest,
@@ -39,11 +40,8 @@ export function updateContractTag(
 ): void {
   const tagsPath = getContractTagsPath(paths, project)
 
-  // Ensure eth: prefix, preserve original case
-  const addressWithPrefix = updateRequest.contractAddress.startsWith('eth:')
-    ? updateRequest.contractAddress
-    : `eth:${updateRequest.contractAddress}`
-  const normalizedForLookup = addressWithPrefix.toLowerCase()
+  // Normalize address: ensure chain prefix and checksummed format
+  const normalizedAddress = ensureChainPrefix(updateRequest.contractAddress)
 
   // Load existing contract tags
   let contractTags: ContractTag[] = []
@@ -57,15 +55,10 @@ export function updateContractTag(
     }
   }
 
-  // Find existing tag for the same contract (case-insensitive comparison)
-  const existingTagIndex = contractTags.findIndex((tag) => {
-    const existingNormalized = (
-      tag.contractAddress.startsWith('eth:')
-        ? tag.contractAddress
-        : `eth:${tag.contractAddress}`
-    ).toLowerCase()
-    return existingNormalized === normalizedForLookup
-  })
+  // Find existing tag for the same contract (chain-aware comparison)
+  const existingTagIndex = contractTags.findIndex((tag) =>
+    addressesEqual(ensureChainPrefix(tag.contractAddress), normalizedAddress),
+  )
 
   // Determine the new values for all tag fields
   const existingTag =
@@ -97,7 +90,7 @@ export function updateContractTag(
   if (hasAnyTagData) {
     // Create or update tag entry
     const newTag: ContractTag = {
-      contractAddress: existingTag?.contractAddress ?? addressWithPrefix,
+      contractAddress: existingTag?.contractAddress ?? normalizedAddress,
       isExternal: newIsExternal,
       isGovernance: newIsGovernance || undefined, // Only store if true
       entity: newEntity || undefined,

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/contractTags.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/contractTags.ts
@@ -72,6 +72,8 @@ export function updateContractTag(
   const newIsToken = updateRequest.isToken ?? existingTag?.isToken ?? false
   const newIsGovernance =
     updateRequest.isGovernance ?? existingTag?.isGovernance ?? false
+  const newExcludeFromReview =
+    updateRequest.excludeFromReview ?? existingTag?.excludeFromReview ?? false
   const newEntity =
     updateRequest.entity !== undefined
       ? updateRequest.entity === null
@@ -85,7 +87,8 @@ export function updateContractTag(
     newIsGovernance ||
     newFetchBalances ||
     newFetchPositions ||
-    newIsToken
+    newIsToken ||
+    newExcludeFromReview
 
   if (hasAnyTagData) {
     // Create or update tag entry
@@ -97,6 +100,7 @@ export function updateContractTag(
       fetchBalances: newFetchBalances || undefined, // Only store if true
       fetchPositions: newFetchPositions || undefined, // Only store if true
       isToken: newIsToken || undefined, // Only store if true
+      excludeFromReview: newExcludeFromReview || undefined, // Only store if true
       timestamp: new Date().toISOString(),
     }
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/enhancedTraversal.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/enhancedTraversal.ts
@@ -532,7 +532,10 @@ function deduplicateTerminals(
   const result: TraversalTerminal[] = []
   for (const terminal of terminals) {
     const chainSig = terminal.chain
-      .map((s) => `${normalizeChainAddress(s.contractAddress)}:${s.functionName ?? ''}`)
+      .map(
+        (s) =>
+          `${normalizeChainAddress(s.contractAddress)}:${s.functionName ?? ''}`,
+      )
       .join('→')
     const key = `${normalizeChainAddress(terminal.address)}|${chainSig}`
     if (seen.has(key)) continue

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/enhancedTraversal.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/enhancedTraversal.ts
@@ -6,6 +6,7 @@ import type {
 import * as fs from 'fs'
 import * as path from 'path'
 import { getProject } from '../getProject'
+import { normalizeChainAddress } from './addressUtils'
 import { getCallGraphData } from './callGraph'
 import {
   extractAddressesFromResolvedOwners,
@@ -118,7 +119,7 @@ function buildEnhancedGraph(
           }
         }
         if (errors.length > 0) {
-          const key = `${contractAddr.toLowerCase()}:${func.functionName}`
+          const key = `${normalizeChainAddress(contractAddr)}:${func.functionName}`
           constructionErrors.set(key, errors)
         }
 
@@ -150,7 +151,7 @@ function buildIndices(edges: EnhancedEdge[]): EnhancedGraph {
   const backwardIndex = new Map<string, EnhancedEdge[]>()
 
   for (const edge of edges) {
-    const fwdKey = edge.sourceContract.toLowerCase()
+    const fwdKey = normalizeChainAddress(edge.sourceContract)
     let fwdList = forwardIndex.get(fwdKey)
     if (!fwdList) {
       fwdList = []
@@ -158,7 +159,7 @@ function buildIndices(edges: EnhancedEdge[]): EnhancedGraph {
     }
     fwdList.push(edge)
 
-    const bwdKey = edge.targetContract.toLowerCase()
+    const bwdKey = normalizeChainAddress(edge.targetContract)
     let bwdList = backwardIndex.get(bwdKey)
     if (!bwdList) {
       bwdList = []
@@ -223,7 +224,7 @@ function traverse(
     return { terminals: [], errors: [], depthLimitReached: true }
   }
 
-  const visitKey = `${contractAddress.toLowerCase()}:${functionName ?? '*'}`
+  const visitKey = `${normalizeChainAddress(contractAddress)}:${functionName ?? '*'}`
 
   // Check memoization cache FIRST — reuse previous results with adjusted chain prefix.
   // Safe because cached results are fully computed (no risk of infinite loop).
@@ -401,7 +402,7 @@ function groupEdgesBySource(
 ): { sourceContract: string; edges: EnhancedEdge[] }[] {
   const groups = new Map<string, EnhancedEdge[]>()
   for (const edge of edges) {
-    const key = edge.sourceContract.toLowerCase()
+    const key = normalizeChainAddress(edge.sourceContract)
     let list = groups.get(key)
     if (!list) {
       list = []
@@ -420,7 +421,7 @@ function lookupBackwardEdges(
   ctx: TraversalContext,
   contractAddress: string,
 ): EnhancedEdge[] {
-  const normalized = contractAddress.toLowerCase()
+  const normalized = normalizeChainAddress(contractAddress)
 
   // Direct match
   const direct = ctx.graph.backwardIndex.get(normalized)
@@ -429,7 +430,7 @@ function lookupBackwardEdges(
   // impl → proxy fallback
   const proxyAddr = ctx.implToProxyMap.get(normalized)
   if (proxyAddr) {
-    const via = ctx.graph.backwardIndex.get(proxyAddr.toLowerCase())
+    const via = ctx.graph.backwardIndex.get(normalizeChainAddress(proxyAddr))
     if (via && via.length > 0) return via
   }
 
@@ -437,7 +438,7 @@ function lookupBackwardEdges(
   const implAddrs = ctx.proxyToImplsMap.get(normalized)
   if (implAddrs) {
     for (const implAddr of implAddrs) {
-      const via = ctx.graph.backwardIndex.get(implAddr.toLowerCase())
+      const via = ctx.graph.backwardIndex.get(normalizeChainAddress(implAddr))
       if (via && via.length > 0) return via
     }
   }
@@ -451,9 +452,9 @@ function findContractFunctions(
   contractAddress: string,
 ) {
   if (!functionsData.contracts) return undefined
-  const normalized = contractAddress.toLowerCase()
+  const normalized = normalizeChainAddress(contractAddress)
   const entry = Object.entries(functionsData.contracts).find(
-    ([key]) => key.toLowerCase() === normalized,
+    ([key]) => normalizeChainAddress(key) === normalized,
   )
   return entry ? entry[1] : undefined
 }
@@ -467,7 +468,7 @@ function findContractFunctionsWithMapping(
   let result = findContractFunctions(ctx.functionsData, address)
   if (result) return result
 
-  const normalized = address.toLowerCase()
+  const normalized = normalizeChainAddress(address)
 
   // impl → proxy fallback
   const proxyAddr = ctx.implToProxyMap.get(normalized)
@@ -505,9 +506,9 @@ function lookupType(
 ): ApiAddressType {
   const exact = typeMap.get(address)
   if (exact) return exact
-  const normalized = address.toLowerCase()
+  const normalized = normalizeChainAddress(address)
   for (const [key, value] of typeMap) {
-    if (key.toLowerCase() === normalized) return value
+    if (normalizeChainAddress(key) === normalized) return value
   }
   return 'Unknown'
 }
@@ -516,9 +517,9 @@ function lookupType(
 function lookupName(nameMap: Map<string, string>, address: string): string {
   const exact = nameMap.get(address)
   if (exact) return exact
-  const normalized = address.toLowerCase()
+  const normalized = normalizeChainAddress(address)
   for (const [key, value] of nameMap) {
-    if (key.toLowerCase() === normalized) return value
+    if (normalizeChainAddress(key) === normalized) return value
   }
   return address
 }
@@ -531,9 +532,9 @@ function deduplicateTerminals(
   const result: TraversalTerminal[] = []
   for (const terminal of terminals) {
     const chainSig = terminal.chain
-      .map((s) => `${s.contractAddress.toLowerCase()}:${s.functionName ?? ''}`)
+      .map((s) => `${normalizeChainAddress(s.contractAddress)}:${s.functionName ?? ''}`)
       .join('→')
-    const key = `${terminal.address.toLowerCase()}|${chainSig}`
+    const key = `${normalizeChainAddress(terminal.address)}|${chainSig}`
     if (seen.has(key)) continue
     seen.add(key)
     result.push(terminal)
@@ -611,12 +612,12 @@ export function resolveEnhancedTraversal(
     ]
     allContracts.forEach((contract: any) => {
       if (contract.implementationNames) {
-        const proxyAddr = contract.address.toLowerCase()
+        const proxyAddr = normalizeChainAddress(contract.address)
         const impls: string[] = []
         for (const implAddr of Object.keys(contract.implementationNames)) {
-          const implLower = implAddr.toLowerCase()
-          if (implLower !== proxyAddr) {
-            implToProxyMap.set(implLower, contract.address)
+          const implNormalized = normalizeChainAddress(implAddr)
+          if (implNormalized !== proxyAddr) {
+            implToProxyMap.set(implNormalized, contract.address)
             impls.push(implAddr)
           }
         }
@@ -679,7 +680,7 @@ export function resolveEnhancedTraversal(
         const terminals = deduplicateTerminals(result.terminals)
 
         // Merge construction errors for this function
-        const errorKey = `${contractAddress.toLowerCase()}:${func.functionName}`
+        const errorKey = `${normalizeChainAddress(contractAddress)}:${func.functionName}`
         const buildErrors = constructionErrors.get(errorKey) ?? []
         const allErrors = [
           ...new Set([

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/functionAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/functionAnalysis.ts
@@ -1,4 +1,5 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
+import { addressesEqual, normalizeChainAddress } from './addressUtils'
 import {
   buildExternalAddressSet,
   buildTagsByAddress,
@@ -117,7 +118,7 @@ function computeImpact(
 
   for (const [addr, data] of traversalResult.reachableContracts) {
     // Skip self-reference
-    if (addr.toLowerCase() === startContractAddress.toLowerCase()) continue
+    if (addressesEqual(addr, startContractAddress)) continue
 
     const fundsUsd = getContractFunds(fundsData, addr)
     const tokenValueUsd = getContractTokenValue(fundsData, addr)
@@ -186,12 +187,12 @@ function computeDependencies(
   // 1. Auto-detected: external contracts reachable via call graph
   for (const [addr, data] of traversalResult.reachableContracts) {
     // Skip self-reference
-    if (addr.toLowerCase() === startContractAddress.toLowerCase()) continue
+    if (addressesEqual(addr, startContractAddress)) continue
 
     // Only include external contracts
     if (!isExternalAddress(addr, externalAddresses)) continue
 
-    const normalized = addr.toLowerCase()
+    const normalized = normalizeChainAddress(addr)
     if (seenAddresses.has(normalized)) continue
     seenAddresses.add(normalized)
 
@@ -216,7 +217,7 @@ function computeDependencies(
   // 2. Manual dependencies (from functions.json)
   if (manualDeps) {
     for (const dep of manualDeps) {
-      const normalized = dep.contractAddress.toLowerCase()
+      const normalized = normalizeChainAddress(dep.contractAddress)
       if (seenAddresses.has(normalized)) continue
       seenAddresses.add(normalized)
 
@@ -249,9 +250,9 @@ function getContractFunds(
   contractAddress: string,
 ): number {
   if (!fundsData?.contracts) return 0
-  const normalizedAddress = contractAddress.toLowerCase()
+  const normalizedAddress = normalizeChainAddress(contractAddress)
   const fundsEntry = Object.entries(fundsData.contracts).find(
-    ([key]) => key.toLowerCase() === normalizedAddress,
+    ([key]) => normalizeChainAddress(key) === normalizedAddress,
   )
   if (!fundsEntry) return 0
   const funds = fundsEntry[1]
@@ -265,9 +266,9 @@ function getContractTokenValue(
   contractAddress: string,
 ): number {
   if (!fundsData?.contracts) return 0
-  const normalizedAddress = contractAddress.toLowerCase()
+  const normalizedAddress = normalizeChainAddress(contractAddress)
   const fundsEntry = Object.entries(fundsData.contracts).find(
-    ([key]) => key.toLowerCase() === normalizedAddress,
+    ([key]) => normalizeChainAddress(key) === normalizedAddress,
   )
   if (!fundsEntry) return 0
   return fundsEntry[1].tokenInfo?.tokenValue ?? 0
@@ -279,9 +280,9 @@ function isFunctionPermissioned(
   functionName: string,
 ): boolean {
   if (!functionsData.contracts) return false
-  const normalizedAddress = contractAddress.toLowerCase()
+  const normalizedAddress = normalizeChainAddress(contractAddress)
   const contractEntry = Object.entries(functionsData.contracts).find(
-    ([key]) => key.toLowerCase() === normalizedAddress,
+    ([key]) => normalizeChainAddress(key) === normalizedAddress,
   )
   if (!contractEntry) return false
   const func = contractEntry[1].functions.find(

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/functions.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/functions.ts
@@ -1,6 +1,7 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
+import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
 import { DiscoveredDataAccess, resolvePathExpression } from './ownerResolution'
 import type {
   ApiFunctionsResponse,
@@ -117,7 +118,7 @@ export function updateFunction(
 
   // Get or create contract entry (case-insensitive key lookup, preserve original case)
   const existingKey = Object.keys(userContracts).find(
-    (k) => k.toLowerCase() === contractAddress.toLowerCase(),
+    (k) => normalizeChainAddress(k) === normalizeChainAddress(contractAddress),
   )
   if (!existingKey) {
     userContracts[contractAddress] = { functions: [] }
@@ -250,7 +251,7 @@ export function deleteContractFunctions(
   // Remove the contract entry (case-insensitive key lookup)
   const keyToDelete =
     Object.keys(userContracts).find(
-      (k) => k.toLowerCase() === contractAddress.toLowerCase(),
+      (k) => normalizeChainAddress(k) === normalizeChainAddress(contractAddress),
     ) ?? contractAddress
   delete userContracts[keyToDelete]
 
@@ -372,7 +373,7 @@ function mergeContractFunctions(
   // Build case-insensitive lookup for user contracts
   const userLookup = new Map<string, ContractFunctions>()
   for (const [addr, contract] of Object.entries(userContracts)) {
-    userLookup.set(addr.toLowerCase(), contract)
+    userLookup.set(normalizeChainAddress(addr), contract)
   }
 
   // Track which discovered addresses we've processed (lowercase)
@@ -382,7 +383,7 @@ function mergeContractFunctions(
   for (const [contractAddress, discoveredContract] of Object.entries(
     discoveredContracts,
   )) {
-    const normalizedAddr = contractAddress.toLowerCase()
+    const normalizedAddr = normalizeChainAddress(contractAddress)
     discoveredAddrsLower.add(normalizedAddr)
     const userContract = userLookup.get(normalizedAddr)
 
@@ -416,7 +417,7 @@ function mergeContractFunctions(
 
   // Add user-only contracts (contracts that have user functions but no discovered data)
   for (const [contractAddress, userContract] of Object.entries(userContracts)) {
-    if (!discoveredAddrsLower.has(contractAddress.toLowerCase())) {
+    if (!discoveredAddrsLower.has(normalizeChainAddress(contractAddress))) {
       result[contractAddress] = { functions: [...userContract.functions] }
     }
   }
@@ -595,7 +596,7 @@ function extractAddressesFromValue(value: any, addresses: string[]): void {
   if (!value) return
 
   // If it's an address-like string
-  if (typeof value === 'string' && value.match(/^(eth:)?0x[a-fA-F0-9]{40}$/)) {
+  if (typeof value === 'string' && (isChainAddress(value) || /^0x[a-fA-F0-9]{40}$/.test(value))) {
     addresses.push(value)
     return
   }
@@ -647,7 +648,7 @@ export function resolveDelayFromDiscovered(
     const contractEntry = discovered.entries.find(
       (entry: any) =>
         entry.type === 'Contract' &&
-        entry.address.toLowerCase() === delayRef.contractAddress.toLowerCase(),
+        addressesEqual(entry.address, delayRef.contractAddress),
     )
 
     if (!contractEntry) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/functions.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/functions.ts
@@ -1,7 +1,11 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
-import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+import {
+  addressesEqual,
+  isChainAddress,
+  normalizeChainAddress,
+} from './addressUtils'
 import { DiscoveredDataAccess, resolvePathExpression } from './ownerResolution'
 import type {
   ApiFunctionsResponse,
@@ -251,7 +255,8 @@ export function deleteContractFunctions(
   // Remove the contract entry (case-insensitive key lookup)
   const keyToDelete =
     Object.keys(userContracts).find(
-      (k) => normalizeChainAddress(k) === normalizeChainAddress(contractAddress),
+      (k) =>
+        normalizeChainAddress(k) === normalizeChainAddress(contractAddress),
     ) ?? contractAddress
   delete userContracts[keyToDelete]
 
@@ -596,7 +601,10 @@ function extractAddressesFromValue(value: any, addresses: string[]): void {
   if (!value) return
 
   // If it's an address-like string
-  if (typeof value === 'string' && (isChainAddress(value) || /^0x[a-fA-F0-9]{40}$/.test(value))) {
+  if (
+    typeof value === 'string' &&
+    (isChainAddress(value) || /^0x[a-fA-F0-9]{40}$/.test(value))
+  ) {
     addresses.push(value)
     return
   }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/fundsData.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/fundsData.ts
@@ -1,6 +1,7 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
+import { addressesEqual, stripChainPrefix } from './addressUtils'
 import { getContractTags } from './contractTags'
 import type {
   ApiFundsDataResponse,
@@ -138,7 +139,7 @@ export async function fetchFundsForContract(
   let positionsCached = false
 
   // Normalize address - remove eth: prefix for API calls
-  const cleanAddress = contractAddress.replace(/^eth:/i, '')
+  const cleanAddress = stripChainPrefix(contractAddress)
   const forceRefreshParam = options.forceRefresh ? '&force_refresh=true' : ''
 
   try {
@@ -282,7 +283,7 @@ export async function fetchFundsForContract(
       if (options.discoveredData?.entries) {
         const contract = options.discoveredData.entries.find(
           (c: any) =>
-            c.address?.toLowerCase() === contractAddress.toLowerCase(),
+            c.address && addressesEqual(c.address, contractAddress),
         )
         if (contract?.values) {
           if (contract.values.totalSupply != null)
@@ -457,7 +458,7 @@ export async function fetchFundsForSingleContract(
 ): Promise<ApiFundsDataResponse> {
   const tags = getContractTags(paths, project)
   const tag = tags.tags.find(
-    (t) => t.contractAddress.toLowerCase() === contractAddress.toLowerCase(),
+    (t) => addressesEqual(t.contractAddress, contractAddress),
   )
 
   if (!tag || (!tag.fetchBalances && !tag.fetchPositions && !tag.isToken)) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/fundsData.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/fundsData.ts
@@ -282,8 +282,7 @@ export async function fetchFundsForContract(
       // discovered.json entries is a flat array of contracts with values
       if (options.discoveredData?.entries) {
         const contract = options.discoveredData.entries.find(
-          (c: any) =>
-            c.address && addressesEqual(c.address, contractAddress),
+          (c: any) => c.address && addressesEqual(c.address, contractAddress),
         )
         if (contract?.values) {
           if (contract.values.totalSupply != null)
@@ -457,8 +456,8 @@ export async function fetchFundsForSingleContract(
   forceRefresh = false,
 ): Promise<ApiFundsDataResponse> {
   const tags = getContractTags(paths, project)
-  const tag = tags.tags.find(
-    (t) => addressesEqual(t.contractAddress, contractAddress),
+  const tag = tags.tags.find((t) =>
+    addressesEqual(t.contractAddress, contractAddress),
   )
 
   if (!tag || (!tag.fetchBalances && !tag.fetchPositions && !tag.isToken)) {

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/ownerResolution.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/ownerResolution.ts
@@ -14,7 +14,11 @@
  *   "$self" → current contract itself is the owner
  */
 
-import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+import {
+  addressesEqual,
+  isChainAddress,
+  normalizeChainAddress,
+} from './addressUtils'
 
 // =============================================================================
 // Types
@@ -355,8 +359,8 @@ export class DiscoveredDataAccess implements IContractDataAccess {
       (entry: any) =>
         entry.type === 'Contract' &&
         entry.implementationNames &&
-        Object.keys(entry.implementationNames).some(
-          (implAddr: string) => addressesEqual(implAddr, normalized),
+        Object.keys(entry.implementationNames).some((implAddr: string) =>
+          addressesEqual(implAddr, normalized),
         ),
     )
     if (proxy) return proxy

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/ownerResolution.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/ownerResolution.ts
@@ -14,6 +14,8 @@
  *   "$self" → current contract itself is the owner
  */
 
+import { addressesEqual, isChainAddress, normalizeChainAddress } from './addressUtils'
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -121,7 +123,7 @@ export function parseValuePath(path: string): PathSegment[] {
  */
 export function extractAddresses(value: any, path: string): string[] {
   // Single string address
-  if (typeof value === 'string' && value.startsWith('eth:')) {
+  if (typeof value === 'string' && isChainAddress(value)) {
     return [value]
   }
 
@@ -129,7 +131,7 @@ export function extractAddresses(value: any, path: string): string[] {
   if (Array.isArray(value)) {
     const addresses: string[] = []
     for (const element of value) {
-      if (typeof element === 'string' && element.startsWith('eth:')) {
+      if (typeof element === 'string' && isChainAddress(element)) {
         addresses.push(element)
       } else if (typeof element === 'object' && element !== null) {
         // Recursively extract from object elements
@@ -146,7 +148,7 @@ export function extractAddresses(value: any, path: string): string[] {
     const addresses: string[] = []
     for (const key in value) {
       const prop = value[key]
-      if (typeof prop === 'string' && prop.startsWith('eth:')) {
+      if (typeof prop === 'string' && isChainAddress(prop)) {
         addresses.push(prop)
       } else if (typeof prop === 'object' && prop !== null) {
         // Recursively extract from nested objects/arrays
@@ -289,13 +291,13 @@ export function resolvePathExpression(
       if (
         !targetContractAddress ||
         typeof targetContractAddress !== 'string' ||
-        !targetContractAddress.startsWith('eth:')
+        !isChainAddress(targetContractAddress)
       ) {
         throw new Error(
           `Field "${fieldName}" not found or is not an address in current contract`,
         )
       }
-    } else if (contractRef.startsWith('eth:')) {
+    } else if (isChainAddress(contractRef)) {
       // Absolute contract address
       targetContractAddress = contractRef
     } else {
@@ -337,12 +339,12 @@ export class DiscoveredDataAccess implements IContractDataAccess {
       throw new Error('No entries found in discovered data')
     }
 
-    const normalized = address.toLowerCase()
+    const normalized = normalizeChainAddress(address)
 
     // Direct lookup by address
     const contract = this.discovered.entries.find(
       (entry: any) =>
-        entry.type === 'Contract' && entry.address.toLowerCase() === normalized,
+        entry.type === 'Contract' && addressesEqual(entry.address, normalized),
     )
     if (contract) return contract
 
@@ -354,7 +356,7 @@ export class DiscoveredDataAccess implements IContractDataAccess {
         entry.type === 'Contract' &&
         entry.implementationNames &&
         Object.keys(entry.implementationNames).some(
-          (implAddr: string) => implAddr.toLowerCase() === normalized,
+          (implAddr: string) => addressesEqual(implAddr, normalized),
         ),
     )
     if (proxy) return proxy
@@ -379,7 +381,7 @@ export class DiscoveredDataAccess implements IContractDataAccess {
     }
 
     // Handle string addresses (most common case)
-    if (typeof value === 'string' && value.startsWith('eth:')) {
+    if (typeof value === 'string' && isChainAddress(value)) {
       return value
     }
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -280,7 +280,7 @@ export class ReviewCompiler {
           if (membersField?.value?.type === 'array') {
             for (const v of membersField.value.values ?? []) {
               if (v.type === 'address') {
-                multisigSigners.add(v.address.toLowerCase())
+                multisigSigners.add(normalizeChainAddress(v.address))
               }
             }
           }
@@ -291,7 +291,7 @@ export class ReviewCompiler {
       const adminAddresses = new Set<string>()
       if (v2Score.inventory.admins.breakdown) {
         for (const admin of v2Score.inventory.admins.breakdown) {
-          adminAddresses.add(admin.adminAddress.toLowerCase())
+          adminAddresses.add(normalizeChainAddress(admin.adminAddress))
         }
       }
 
@@ -299,19 +299,18 @@ export class ReviewCompiler {
       const excludedAddresses = new Set<string>()
       for (const tag of contractTags.tags ?? []) {
         if (tag.excludeFromReview) {
-          const norm = tag.contractAddress.replace(/^eth:/i, '').toLowerCase()
-          excludedAddresses.add(norm)
+          excludedAddresses.add(normalizeChainAddress(tag.contractAddress))
         }
       }
 
       // Filter out EOAs that are multisig signers (unless also admins) and excluded contracts
       const discoveryEntries = allProjectContracts.filter((e) => {
-        const norm = e.address.replace(/^eth:/i, '').toLowerCase()
+        const norm = normalizeChainAddress(e.address)
         if (excludedAddresses.has(norm)) return false
         if (
           e.type === 'EOA' &&
-          multisigSigners.has(e.address.toLowerCase()) &&
-          !adminAddresses.has(e.address.toLowerCase())
+          multisigSigners.has(norm) &&
+          !adminAddresses.has(norm)
         )
           return false
         return true
@@ -579,26 +578,20 @@ export class ReviewCompiler {
     ]) {
       for (const [addr, desc] of Object.entries(section ?? {})) {
         if (desc?.name) {
-          configNameMap.set(addr.toLowerCase(), desc.name)
+          configNameMap.set(normalizeChainAddress(addr), desc.name)
         }
       }
     }
 
     const contracts: CompiledContract[] = []
     for (const entry of discoveryEntries) {
-      const addrNorm = entry.address.replace(/^eth:/i, '').toLowerCase()
+      const addrNorm = normalizeChainAddress(entry.address)
       const tag = tagsByAddress.get(addrNorm)
 
       // Resolve name: review-config override > cleaned getProject name > address
-      let name =
-        configNameMap.get(entry.address.toLowerCase()) ??
-        entry.name ??
-        entry.address
+      let name = configNameMap.get(addrNorm) ?? entry.name ?? entry.address
       // Clean up multisig names: "5/8 63% Safe" → "5/8 Multisig"
-      if (
-        entry.proxyType === 'gnosis safe' &&
-        !configNameMap.has(entry.address.toLowerCase())
-      ) {
+      if (entry.proxyType === 'gnosis safe' && !configNameMap.has(addrNorm)) {
         name = name
           .replace(/\s+\d+%/, '') // remove percentage
           .replace(/\b(GnosisSafe|Safe)\b/, 'Multisig') // replace Safe/GnosisSafe with Multisig

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -282,10 +282,7 @@ export class ReviewCompiler {
       ApiContractTagsResponse['tags'][number]
     >()
     for (const tag of contractTags.tags ?? []) {
-      tagsByAddress.set(
-        normalizeChainAddress(tag.contractAddress),
-        tag,
-      )
+      tagsByAddress.set(normalizeChainAddress(tag.contractAddress), tag)
     }
 
     // Case-insensitive lookup for funds data with eth: prefix normalization
@@ -298,10 +295,11 @@ export class ReviewCompiler {
     const admins: CompiledAdmin[] = []
     if (v2Score.inventory.admins.breakdown) {
       for (const admin of v2Score.inventory.admins.breakdown) {
-        const desc = getFromAddressRecord(reviewConfig.admins, admin.adminAddress)
-        const tag = tagsByAddress.get(
-          normalizeChainAddress(admin.adminAddress),
+        const desc = getFromAddressRecord(
+          reviewConfig.admins,
+          admin.adminAddress,
         )
+        const tag = tagsByAddress.get(normalizeChainAddress(admin.adminAddress))
 
         const withCapital = admin as AdminDetailWithCapital
         const hasCapital = 'totalDirectCapital' in withCapital
@@ -358,7 +356,10 @@ export class ReviewCompiler {
     if (v2Score.inventory.admins.breakdown) {
       for (const admin of v2Score.inventory.admins.breakdown) {
         for (const fn of admin.functions) {
-          contractNameMap.set(normalizeChainAddress(fn.contractAddress), fn.contractName)
+          contractNameMap.set(
+            normalizeChainAddress(fn.contractAddress),
+            fn.contractName,
+          )
         }
       }
     }
@@ -446,9 +447,7 @@ export class ReviewCompiler {
     // Build fund holders from funds data + review config descriptions
     const funds: CompiledFundHolder[] = []
     for (const [address, desc] of Object.entries(reviewConfig.funds ?? {})) {
-      const contractFunds = fundsLookup.get(
-        normalizeChainAddress(address),
-      )
+      const contractFunds = fundsLookup.get(normalizeChainAddress(address))
 
       funds.push({
         address,

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -266,27 +266,6 @@ export class ReviewCompiler {
         }
       }
 
-      // Collect multisig signer addresses from gnosis safe contracts
-      const multisigSigners = new Set<string>()
-      for (const entry of projectData.entries) {
-        for (const contract of [
-          ...(entry.initialContracts ?? []),
-          ...(entry.discoveredContracts ?? []),
-        ]) {
-          if (contract.proxyType !== 'gnosis safe') continue
-          const membersField = contract.fields?.find(
-            (f) => f.name === '$members',
-          )
-          if (membersField?.value?.type === 'array') {
-            for (const v of membersField.value.values ?? []) {
-              if (v.type === 'address') {
-                multisigSigners.add(normalizeChainAddress(v.address))
-              }
-            }
-          }
-        }
-      }
-
       // Collect admin addresses from v2 scoring
       const adminAddresses = new Set<string>()
       if (v2Score.inventory.admins.breakdown) {
@@ -303,16 +282,11 @@ export class ReviewCompiler {
         }
       }
 
-      // Filter out EOAs that are multisig signers (unless also admins) and excluded contracts
+      // Filter out non-admin EOAs and excluded contracts
       const discoveryEntries = allProjectContracts.filter((e) => {
         const norm = normalizeChainAddress(e.address)
         if (excludedAddresses.has(norm)) return false
-        if (
-          e.type === 'EOA' &&
-          multisigSigners.has(norm) &&
-          !adminAddresses.has(norm)
-        )
-          return false
+        if (e.type === 'EOA' && !adminAddresses.has(norm)) return false
         return true
       })
 
@@ -555,16 +529,25 @@ export class ReviewCompiler {
       })
     }
 
-    // Build functions from v2 scoring breakdown
+    // Build functions from human admin function lists only (EOA, EOAPermissioned,
+    // Multisig, Timelock, or governance-tagged). Contracts that are permission
+    // owners but not "real" admins are excluded.
+    const HUMAN_ADMIN_TYPES = new Set(['EOA', 'EOAPermissioned', 'Multisig', 'Timelock'])
     const functions: CompiledFunction[] = []
-    if (v2Score.inventory.functions.breakdown) {
-      for (const func of v2Score.inventory.functions.breakdown) {
-        functions.push({
-          contractAddress: func.contractAddress,
-          contractName: func.contractName,
-          functionName: func.functionName,
-          impact: func.impact,
-        })
+    const seenFunctions = new Set<string>()
+    for (const admin of admins) {
+      if (!HUMAN_ADMIN_TYPES.has(admin.adminType) && !admin.isGovernance) continue
+      for (const func of admin.functions) {
+        const key = `${func.contractAddress}:${func.functionName}`
+        if (!seenFunctions.has(key)) {
+          seenFunctions.add(key)
+          functions.push({
+            contractAddress: func.contractAddress,
+            contractName: func.contractName,
+            functionName: func.functionName,
+            impact: func.impact,
+          })
+        }
       }
     }
 
@@ -623,8 +606,8 @@ export class ReviewCompiler {
 
       totals: {
         contractCount: v2Score.inventory.contracts.inventory,
-        permissionedFunctionCount: v2Score.inventory.functions.inventory,
-        scoredFunctionCount: v2Score.inventory.functions.breakdown?.length ?? 0,
+        permissionedFunctionCount: functions.length,
+        scoredFunctionCount: functions.length,
         adminCount: v2Score.inventory.admins.inventory,
         dependencyCount: v2Score.inventory.dependencies.inventory,
         totalCapitalAtRisk: v2Score.inventory.admins.totalCapitalAtRisk ?? 0,

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -16,6 +16,11 @@ import type {
 import { computeFunctionAnalysis } from './functionAnalysis'
 import { getFundsData } from './fundsData'
 import { getContractTags } from './contractTags'
+import {
+  normalizeChainAddress,
+  addressesEqual,
+  getFromAddressRecord,
+} from './addressUtils'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -278,7 +283,7 @@ export class ReviewCompiler {
     >()
     for (const tag of contractTags.tags ?? []) {
       tagsByAddress.set(
-        tag.contractAddress.replace(/^eth:/i, '').toLowerCase(),
+        normalizeChainAddress(tag.contractAddress),
         tag,
       )
     }
@@ -286,18 +291,16 @@ export class ReviewCompiler {
     // Case-insensitive lookup for funds data with eth: prefix normalization
     const fundsLookup = new Map<string, ContractFundsData>()
     for (const [addr, data] of Object.entries(fundsData.contracts ?? {})) {
-      fundsLookup.set(addr.replace(/^eth:/i, '').toLowerCase(), data)
+      fundsLookup.set(normalizeChainAddress(addr), data)
     }
 
     // Build admins from v2 scoring breakdown
     const admins: CompiledAdmin[] = []
     if (v2Score.inventory.admins.breakdown) {
       for (const admin of v2Score.inventory.admins.breakdown) {
-        const desc =
-          reviewConfig.admins[admin.adminAddress] ??
-          reviewConfig.admins[admin.adminAddress.toLowerCase()]
+        const desc = getFromAddressRecord(reviewConfig.admins, admin.adminAddress)
         const tag = tagsByAddress.get(
-          admin.adminAddress.replace(/^eth:/i, '').toLowerCase(),
+          normalizeChainAddress(admin.adminAddress),
         )
 
         const withCapital = admin as AdminDetailWithCapital
@@ -355,7 +358,7 @@ export class ReviewCompiler {
     if (v2Score.inventory.admins.breakdown) {
       for (const admin of v2Score.inventory.admins.breakdown) {
         for (const fn of admin.functions) {
-          contractNameMap.set(fn.contractAddress.toLowerCase(), fn.contractName)
+          contractNameMap.set(normalizeChainAddress(fn.contractAddress), fn.contractName)
         }
       }
     }
@@ -383,7 +386,7 @@ export class ReviewCompiler {
     )) {
       for (const [funcName, analysis] of Object.entries(contractFuncs)) {
         for (const dep of analysis.dependencies.entries) {
-          const key = dep.contractAddress.toLowerCase()
+          const key = normalizeChainAddress(dep.contractAddress)
           let existing = depMap.get(key)
           if (!existing) {
             existing = {
@@ -404,14 +407,14 @@ export class ReviewCompiler {
           // Add caller function (deduplicate)
           const alreadyAdded = existing.functions.some(
             (f) =>
-              f.contractAddress.toLowerCase() === contractAddr.toLowerCase() &&
+              addressesEqual(f.contractAddress, contractAddr) &&
               f.functionName === funcName,
           )
           if (!alreadyAdded) {
             existing.functions.push({
               contractAddress: contractAddr,
               contractName:
-                contractNameMap.get(contractAddr.toLowerCase()) ??
+                contractNameMap.get(normalizeChainAddress(contractAddr)) ??
                 'Unknown Contract',
               functionName: funcName,
               viewOnlyPath: dep.viewOnlyPath,
@@ -424,9 +427,7 @@ export class ReviewCompiler {
     // Build final CompiledDependency[] with review-config descriptions
     const dependencies: CompiledDependency[] = []
     for (const dep of depMap.values()) {
-      const desc =
-        reviewConfig.dependencies[dep.address] ??
-        reviewConfig.dependencies[dep.address.toLowerCase()]
+      const desc = getFromAddressRecord(reviewConfig.dependencies, dep.address)
 
       dependencies.push({
         address: dep.address,
@@ -446,7 +447,7 @@ export class ReviewCompiler {
     const funds: CompiledFundHolder[] = []
     for (const [address, desc] of Object.entries(reviewConfig.funds ?? {})) {
       const contractFunds = fundsLookup.get(
-        address.replace(/^eth:/i, '').toLowerCase(),
+        normalizeChainAddress(address),
       )
 
       funds.push({
@@ -609,14 +610,14 @@ export class ReviewCompiler {
           return this.resolveBreakdownPath(root, remainingPath)
         }
       } else if (dataPath.startsWith('fundsdata.')) {
-        // Lowercase contract address keys for case-insensitive matching
+        // Normalize contract address keys for case-insensitive matching
         const fundsData = { ...sources.fundsData }
         if (fundsData.contracts) {
-          const lowered: Record<string, any> = {}
+          const normalized: Record<string, any> = {}
           for (const [k, v] of Object.entries(fundsData.contracts)) {
-            lowered[k.toLowerCase()] = v
+            normalized[normalizeChainAddress(k)] = v
           }
-          fundsData.contracts = lowered as any
+          fundsData.contracts = normalized as any
         }
         root = fundsData
         remainingPath = dataPath.slice('fundsdata.'.length)
@@ -642,7 +643,7 @@ export class ReviewCompiler {
     if (!Array.isArray(breakdown)) return null
 
     const admin = breakdown.find(
-      (a: any) => a.adminAddress?.toLowerCase() === address.toLowerCase(),
+      (a: any) => a.adminAddress && addressesEqual(a.adminAddress, address),
     )
     if (!admin) return null
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -21,6 +21,7 @@ import {
   addressesEqual,
   getFromAddressRecord,
 } from './addressUtils'
+import { getProject } from '../getProject'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -233,7 +234,90 @@ export class ReviewCompiler {
       // 5. Compute function analysis (rich dependency data with viewOnlyPath)
       const functionAnalysis = computeFunctionAnalysis(this.paths, project)
 
-      // 6. Build the compiled review
+      // 6. Load project data for contract names (applies config name overrides + multisig formatting)
+      const projectData = getProject(configReader, templateService, project)
+
+      // Build flat list of contracts with names from getProject
+      const allProjectContracts: {
+        name: string
+        address: string
+        type: string
+        proxyType?: string
+      }[] = []
+      for (const entry of projectData.entries) {
+        for (const contract of [
+          ...(entry.initialContracts ?? []),
+          ...(entry.discoveredContracts ?? []),
+        ]) {
+          allProjectContracts.push({
+            name: contract.name ?? contract.address,
+            address: contract.address,
+            type: contract.type,
+            proxyType: contract.proxyType,
+          })
+        }
+        for (const eoa of entry.eoas ?? []) {
+          allProjectContracts.push({
+            name: eoa.address,
+            address: eoa.address,
+            type: 'EOA',
+            proxyType: 'EOA',
+          })
+        }
+      }
+
+      // Collect multisig signer addresses from gnosis safe contracts
+      const multisigSigners = new Set<string>()
+      for (const entry of projectData.entries) {
+        for (const contract of [
+          ...(entry.initialContracts ?? []),
+          ...(entry.discoveredContracts ?? []),
+        ]) {
+          if (contract.proxyType !== 'gnosis safe') continue
+          const membersField = contract.fields?.find(
+            (f) => f.name === '$members',
+          )
+          if (membersField?.value?.type === 'array') {
+            for (const v of membersField.value.values ?? []) {
+              if (v.type === 'address') {
+                multisigSigners.add(v.address.toLowerCase())
+              }
+            }
+          }
+        }
+      }
+
+      // Collect admin addresses from v2 scoring
+      const adminAddresses = new Set<string>()
+      if (v2Score.inventory.admins.breakdown) {
+        for (const admin of v2Score.inventory.admins.breakdown) {
+          adminAddresses.add(admin.adminAddress.toLowerCase())
+        }
+      }
+
+      // Build excluded address set from contract tags
+      const excludedAddresses = new Set<string>()
+      for (const tag of contractTags.tags ?? []) {
+        if (tag.excludeFromReview) {
+          const norm = tag.contractAddress.replace(/^eth:/i, '').toLowerCase()
+          excludedAddresses.add(norm)
+        }
+      }
+
+      // Filter out EOAs that are multisig signers (unless also admins) and excluded contracts
+      const discoveryEntries = allProjectContracts.filter((e) => {
+        const norm = e.address.replace(/^eth:/i, '').toLowerCase()
+        if (excludedAddresses.has(norm)) return false
+        if (
+          e.type === 'EOA' &&
+          multisigSigners.has(e.address.toLowerCase()) &&
+          !adminAddresses.has(e.address.toLowerCase())
+        )
+          return false
+        return true
+      })
+
+      // 7. Build the compiled review
       const compiled = this.buildCompiledReview(
         project,
         reviewConfig,
@@ -241,6 +325,7 @@ export class ReviewCompiler {
         fundsData,
         contractTags,
         functionAnalysis,
+        discoveryEntries,
       )
 
       // 7. Resolve template variables in all description fields
@@ -276,6 +361,7 @@ export class ReviewCompiler {
     fundsData: ApiFundsDataResponse,
     contractTags: ApiContractTagsResponse,
     functionAnalysis: ApiFunctionAnalysisResponse,
+    discoveryEntries: { name?: string; address: string; proxyType?: string }[],
   ): CompiledReview {
     const tagsByAddress = new Map<
       string,
@@ -483,16 +569,48 @@ export class ReviewCompiler {
       }
     }
 
-    // Build contracts list (stub — uses tag data)
+    // Build contracts list from discovery entries, enriched with tag data
+    // Build review-config name lookup (admins, dependencies, funds all have name overrides)
+    const configNameMap = new Map<string, string>()
+    for (const section of [
+      reviewConfig.admins,
+      reviewConfig.dependencies,
+      reviewConfig.funds,
+    ]) {
+      for (const [addr, desc] of Object.entries(section ?? {})) {
+        if (desc?.name) {
+          configNameMap.set(addr.toLowerCase(), desc.name)
+        }
+      }
+    }
+
     const contracts: CompiledContract[] = []
-    for (const tag of contractTags.tags ?? []) {
+    for (const entry of discoveryEntries) {
+      const addrNorm = entry.address.replace(/^eth:/i, '').toLowerCase()
+      const tag = tagsByAddress.get(addrNorm)
+
+      // Resolve name: review-config override > cleaned getProject name > address
+      let name =
+        configNameMap.get(entry.address.toLowerCase()) ??
+        entry.name ??
+        entry.address
+      // Clean up multisig names: "5/8 63% Safe" → "5/8 Multisig"
+      if (
+        entry.proxyType === 'gnosis safe' &&
+        !configNameMap.has(entry.address.toLowerCase())
+      ) {
+        name = name
+          .replace(/\s+\d+%/, '') // remove percentage
+          .replace(/\b(GnosisSafe|Safe)\b/, 'Multisig') // replace Safe/GnosisSafe with Multisig
+      }
+
       contracts.push({
-        address: tag.contractAddress,
-        name: tag.contractAddress, // Name resolved from discovery if available
-        isExternal: tag.isExternal ?? false,
-        isGovernance: tag.isGovernance ?? false,
-        entity: tag.entity ?? null,
-        proxyType: null,
+        address: entry.address,
+        name,
+        isExternal: tag?.isExternal ?? false,
+        isGovernance: tag?.isGovernance ?? false,
+        entity: tag?.entity ?? null,
+        proxyType: entry.proxyType ?? null,
       })
     }
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewConfig.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewConfig.ts
@@ -1,6 +1,7 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
 import * as fs from 'fs'
 import * as path from 'path'
+import { ensureChainPrefix } from './addressUtils'
 import type {
   ApiReviewConfigResponse,
   ApiUpdateEntityDescriptionRequest,
@@ -66,9 +67,7 @@ export function updateEntityDescription(
     throw new Error('No review config exists for this project')
   }
 
-  const normalizedAddress = request.address.startsWith('eth:')
-    ? request.address
-    : `eth:${request.address}`
+  const normalizedAddress = ensureChainPrefix(request.address)
 
   const section = config[request.section]
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/types.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/types.ts
@@ -407,6 +407,7 @@ export interface ContractTag {
   fetchBalances?: boolean
   fetchPositions?: boolean
   isToken?: boolean
+  excludeFromReview?: boolean
   timestamp: string
 }
 
@@ -418,6 +419,7 @@ export interface ApiContractTagsUpdateRequest {
   fetchBalances?: boolean
   fetchPositions?: boolean
   isToken?: boolean
+  excludeFromReview?: boolean
 }
 
 // Funds data types

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
@@ -381,7 +381,10 @@ class AdminInventoryModule {
           normalizeChainAddress(eoa.address),
           eoa.name || 'Unknown EOA',
         )
-        contractTypeMap.set(normalizeChainAddress(eoa.address), eoa.type || 'EOA')
+        contractTypeMap.set(
+          normalizeChainAddress(eoa.address),
+          eoa.type || 'EOA',
+        )
       })
     })
 

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
@@ -5,6 +5,11 @@ import type {
 } from '@l2beat/discovery'
 import { getProject } from '../getProject'
 import {
+  addressesEqual,
+  normalizeChainAddress,
+  stripChainPrefix,
+} from './addressUtils'
+import {
   buildExternalAddressSet,
   buildTagsByAddress,
   findTag,
@@ -150,8 +155,8 @@ class FunctionInventoryModule {
   private getContractName(projectData: any, contractAddress: string): string {
     if (!projectData?.entries) return contractAddress
 
-    // Normalize address for comparison (remove eth: prefix, lowercase for case-insensitive match)
-    const normalizedAddress = contractAddress.replace('eth:', '').toLowerCase()
+    // Normalize address for comparison (remove eth: prefix, checksummed for case-insensitive match)
+    const normalizedAddress = stripChainPrefix(contractAddress)
 
     for (const entry of projectData.entries) {
       // Check both initialContracts and discoveredContracts
@@ -161,8 +166,8 @@ class FunctionInventoryModule {
       ]
 
       for (const contract of contracts) {
-        const entryAddress = contract.address.replace('eth:', '').toLowerCase()
-        if (entryAddress === normalizedAddress) {
+        const entryAddress = stripChainPrefix(contract.address)
+        if (addressesEqual(entryAddress, normalizedAddress)) {
           return contract.name || contractAddress
         }
       }
@@ -181,7 +186,7 @@ class DependencyInventoryModule {
   name = 'dependencies'
 
   calculate(data: ScoringData): DependencyModuleScore {
-    // Build contract name lookup map (lowercase keys for case-insensitive lookup)
+    // Build contract name lookup map (normalized keys for case-insensitive lookup)
     const contractNameMap = new Map<string, string>()
     data.projectData.entries?.forEach((entry: any) => {
       const allContracts = [
@@ -190,7 +195,7 @@ class DependencyInventoryModule {
       ]
       allContracts.forEach((contract: any) => {
         contractNameMap.set(
-          contract.address.toLowerCase(),
+          normalizeChainAddress(contract.address),
           contract.name || 'Unknown Contract',
         )
       })
@@ -220,7 +225,7 @@ class DependencyInventoryModule {
 
             // 1. Auto-detected: external contracts reachable via call graph
             for (const [addr] of traversalResult.reachableContracts) {
-              if (addr.toLowerCase() === contractAddress.toLowerCase()) continue
+              if (addressesEqual(addr, contractAddress)) continue
               if (!isExternalAddress(addr, externalAddresses)) continue
 
               this.addDependency(
@@ -273,7 +278,7 @@ class DependencyInventoryModule {
     callerContractAddress: string,
     callerFunctionName: string,
   ) {
-    const normalizedDep = depAddress.toLowerCase()
+    const normalizedDep = normalizeChainAddress(depAddress)
 
     // Get or create dependency entry
     if (!dependenciesMap.has(normalizedDep)) {
@@ -300,7 +305,7 @@ class DependencyInventoryModule {
       depData.functions.push({
         contractAddress: callerContractAddress,
         contractName:
-          contractNameMap.get(callerContractAddress.toLowerCase()) ||
+          contractNameMap.get(normalizeChainAddress(callerContractAddress)) ||
           'Unknown Contract',
         functionName: callerFunctionName,
         impact: 'critical' as Impact,
@@ -322,8 +327,8 @@ function mapAdminType(
   normalizedAddress: string,
   proxyTypeMap: Map<string, string>,
 ): ApiAddressType {
-  // Strip eth: prefix for zero address comparison
-  const bareAddress = normalizedAddress.replace(/^eth:/i, '')
+  // Strip chain prefix for zero address comparison
+  const bareAddress = stripChainPrefix(normalizedAddress)
   if (bareAddress === ZERO_ADDRESS) {
     return 'Revoked'
   }
@@ -351,7 +356,7 @@ class AdminInventoryModule {
   name = 'admins'
 
   calculate(data: ScoringData): AdminModuleScore {
-    // Build contract name, type, and proxy type lookup maps (lowercase keys for case-insensitive lookup)
+    // Build contract name, type, and proxy type lookup maps (normalized keys for case-insensitive lookup)
     const contractNameMap = new Map<string, string>()
     const contractTypeMap = new Map<string, ApiAddressType>()
     const proxyTypeMap = new Map<string, string>()
@@ -362,7 +367,7 @@ class AdminInventoryModule {
         ...(entry.discoveredContracts || []),
       ]
       allContracts.forEach((contract: any) => {
-        const addr = contract.address.toLowerCase()
+        const addr = normalizeChainAddress(contract.address)
         contractNameMap.set(addr, contract.name || 'Unknown Contract')
         contractTypeMap.set(addr, contract.type || 'Contract')
         if (contract.proxyType) {
@@ -373,10 +378,10 @@ class AdminInventoryModule {
       // Also add EOAs
       entry.eoas?.forEach((eoa: any) => {
         contractNameMap.set(
-          eoa.address.toLowerCase(),
+          normalizeChainAddress(eoa.address),
           eoa.name || 'Unknown EOA',
         )
-        contractTypeMap.set(eoa.address.toLowerCase(), eoa.type || 'EOA')
+        contractTypeMap.set(normalizeChainAddress(eoa.address), eoa.type || 'EOA')
       })
     })
 
@@ -420,7 +425,7 @@ class AdminInventoryModule {
 
             // Process each admin address
             adminAddresses.forEach((adminAddr: string) => {
-              const normalizedAdmin = adminAddr.toLowerCase()
+              const normalizedAdmin = normalizeChainAddress(adminAddr)
               // Get or create admin entry
               if (!adminsMap.has(adminAddr)) {
                 const rawType =
@@ -444,7 +449,7 @@ class AdminInventoryModule {
               admin.functions.push({
                 contractAddress,
                 contractName:
-                  contractNameMap.get(contractAddress.toLowerCase()) ||
+                  contractNameMap.get(normalizeChainAddress(contractAddress)) ||
                   'Unknown Contract',
                 functionName: func.functionName,
                 impact: 'critical' as Impact,
@@ -489,7 +494,7 @@ class AdminInventoryModule {
       for (const admin of adminsWithCapital) {
         // Direct contracts (all functions, including those without call graph)
         for (const func of admin.functions) {
-          const addr = func.contractAddress.toLowerCase()
+          const addr = normalizeChainAddress(func.contractAddress)
           if (!contractCapitalMap.has(addr)) {
             contractCapitalMap.set(addr, {
               funds: capitalCalculator.getContractFunds(addr),
@@ -501,7 +506,7 @@ class AdminInventoryModule {
         for (const funcAnalysis of admin.functionsWithCapital) {
           for (const rc of funcAnalysis.reachableContracts) {
             if (!rc.fundsAtRisk) continue
-            const addr = rc.contractAddress.toLowerCase()
+            const addr = normalizeChainAddress(rc.contractAddress)
             if (!contractCapitalMap.has(addr)) {
               contractCapitalMap.set(addr, {
                 funds: rc.fundsUsd,

--- a/packages/protocolbeat/src/api/types.ts
+++ b/packages/protocolbeat/src/api/types.ts
@@ -488,6 +488,7 @@ export interface ContractTag {
   fetchBalances?: boolean
   fetchPositions?: boolean
   isToken?: boolean
+  excludeFromReview?: boolean
   timestamp: string
 }
 
@@ -499,6 +500,7 @@ export interface ApiContractTagsUpdateRequest {
   fetchBalances?: boolean
   fetchPositions?: boolean
   isToken?: boolean
+  excludeFromReview?: boolean
 }
 
 // V2 Scoring types

--- a/packages/protocolbeat/src/apps/discovery/defidisco/CallGraphPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/CallGraphPanel.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { getCallGraphData, getCode } from '../../../api/api'
 import type { ContractCallGraph, ExternalCall } from '../../../api/types'
+import { stripChainPrefix } from './addressUtils'
 import { useCodeStore } from '../../../components/editor/store'
 import { useMultiViewStore } from '../multi-view/store'
 import { usePanelStore } from '../store/panel-store'
@@ -308,7 +309,7 @@ function ContractSection({
             {contract.name}
           </span>
           <span className="text-coffee-400 text-xs">
-            {contract.address.replace('eth:', '').slice(0, 10)}...
+            {stripChainPrefix(contract.address).slice(0, 10)}...
           </span>
         </div>
         <span className={`text-xs ${getStatusColor()}`}>{getStatusText()}</span>

--- a/packages/protocolbeat/src/apps/discovery/defidisco/DeFiScanPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/DeFiScanPanel.tsx
@@ -8,6 +8,7 @@ import { V2ScoringSection } from '../../../defidisco/V2ScoringSection'
 import { usePanelStore } from '../store/panel-store'
 import { FundsSection } from './FundsSection'
 import { formatUsdValue } from '../../../defidisco/scoringShared'
+import { addressesEqual, normalizeForLookup, stripChainPrefix } from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { resolvePathExpression, UIContractDataAccess } from './ownerResolution'
 import { ProxyTypeTag } from './ProxyTypeTag'
@@ -52,13 +53,9 @@ export function DeFiScanPanel() {
     contracts: Object.fromEntries(
       Object.entries(functions.contracts || {}).filter(
         ([contractAddress, _]) => {
-          // Normalize address format - remove 'eth:' prefix and convert to lowercase
-          const normalizedAddress = contractAddress
-            .replace('eth:', '')
-            .toLowerCase()
           const tag = contractTags.tags.find(
             (tag: any) =>
-              tag.contractAddress.toLowerCase() === normalizedAddress,
+              addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(contractAddress)),
           )
           return tag?.isExternal !== true
         },
@@ -162,10 +159,8 @@ function StatusOfReviewSection({
 
   allContracts.forEach((contract) => {
     // Check if contract is explicitly marked as external in contract tags
-    // Both contracts and tags use 'eth:0x...' format - just normalize to lowercase
-    const contractAddr = contract.address.toLowerCase()
     const tag = contractTags.tags.find(
-      (tag: any) => tag.contractAddress.toLowerCase() === contractAddr,
+      (tag: any) => addressesEqual(tag.contractAddress, contract.address),
     )
     const isExternal = tag?.isExternal === true
 
@@ -199,9 +194,8 @@ function StatusOfReviewSection({
   // Check for external EOAs and adjust counts
   let externalEoas = 0
   allEoas.forEach((eoa) => {
-    const eoaAddress = eoa.address.replace('eth:', '').toLowerCase()
     const tag = contractTags.tags.find(
-      (tag: any) => tag.contractAddress?.toLowerCase() === eoaAddress,
+      (tag: any) => addressesEqual(stripChainPrefix(tag.contractAddress ?? ''), stripChainPrefix(eoa.address)),
     )
     if (tag?.isExternal === true) {
       externalEoas++
@@ -331,7 +325,7 @@ function getContractDisplayName(contract: {
   address: string
   name: string
 }): string {
-  const shortAddress = contract.address.replace('eth:', '').slice(0, 10)
+  const shortAddress = stripChainPrefix(contract.address).slice(0, 10)
   return `${contract.name} (${shortAddress}...)`
 }
 
@@ -429,9 +423,9 @@ function ContractsWithPermissionsTable({
   const getContractFunds = (address: string): number => {
     if (!fundsData?.contracts) return 0
     // Funds data keys may have different case, so do case-insensitive lookup
-    const normalizedAddress = address.toLowerCase()
+    const normalizedAddress = normalizeForLookup(address)
     const fundsEntry = Object.entries(fundsData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddress,
+      ([key]) => normalizeForLookup(key) === normalizedAddress,
     )
     if (!fundsEntry) return 0
     const funds = fundsEntry[1]
@@ -646,7 +640,7 @@ function ContractsWithPermissionsTable({
                     {getContractDisplayName(contract)}
                   </span>
                   <ProxyTypeTag
-                    proxyType={proxyTypeMap.get(contract.address.toLowerCase())}
+                    proxyType={proxyTypeMap.get(normalizeForLookup(contract.address))}
                   />
                   {hasFunds && (
                     <span className="text-aux-green">

--- a/packages/protocolbeat/src/apps/discovery/defidisco/DeFiScanPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/DeFiScanPanel.tsx
@@ -8,7 +8,11 @@ import { V2ScoringSection } from '../../../defidisco/V2ScoringSection'
 import { usePanelStore } from '../store/panel-store'
 import { FundsSection } from './FundsSection'
 import { formatUsdValue } from '../../../defidisco/scoringShared'
-import { addressesEqual, normalizeForLookup, stripChainPrefix } from './addressUtils'
+import {
+  addressesEqual,
+  normalizeForLookup,
+  stripChainPrefix,
+} from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { resolvePathExpression, UIContractDataAccess } from './ownerResolution'
 import { ProxyTypeTag } from './ProxyTypeTag'
@@ -53,9 +57,11 @@ export function DeFiScanPanel() {
     contracts: Object.fromEntries(
       Object.entries(functions.contracts || {}).filter(
         ([contractAddress, _]) => {
-          const tag = contractTags.tags.find(
-            (tag: any) =>
-              addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(contractAddress)),
+          const tag = contractTags.tags.find((tag: any) =>
+            addressesEqual(
+              stripChainPrefix(tag.contractAddress),
+              stripChainPrefix(contractAddress),
+            ),
           )
           return tag?.isExternal !== true
         },
@@ -159,8 +165,8 @@ function StatusOfReviewSection({
 
   allContracts.forEach((contract) => {
     // Check if contract is explicitly marked as external in contract tags
-    const tag = contractTags.tags.find(
-      (tag: any) => addressesEqual(tag.contractAddress, contract.address),
+    const tag = contractTags.tags.find((tag: any) =>
+      addressesEqual(tag.contractAddress, contract.address),
     )
     const isExternal = tag?.isExternal === true
 
@@ -194,8 +200,11 @@ function StatusOfReviewSection({
   // Check for external EOAs and adjust counts
   let externalEoas = 0
   allEoas.forEach((eoa) => {
-    const tag = contractTags.tags.find(
-      (tag: any) => addressesEqual(stripChainPrefix(tag.contractAddress ?? ''), stripChainPrefix(eoa.address)),
+    const tag = contractTags.tags.find((tag: any) =>
+      addressesEqual(
+        stripChainPrefix(tag.contractAddress ?? ''),
+        stripChainPrefix(eoa.address),
+      ),
     )
     if (tag?.isExternal === true) {
       externalEoas++
@@ -640,7 +649,9 @@ function ContractsWithPermissionsTable({
                     {getContractDisplayName(contract)}
                   </span>
                   <ProxyTypeTag
-                    proxyType={proxyTypeMap.get(normalizeForLookup(contract.address))}
+                    proxyType={proxyTypeMap.get(
+                      normalizeForLookup(contract.address),
+                    )}
                   />
                   {hasFunds && (
                     <span className="text-aux-green">

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ExcludeButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ExcludeButton.tsx
@@ -1,0 +1,46 @@
+import { useParams } from 'react-router-dom'
+import { ControlButton } from '../panel-nodes/controls/ControlButton'
+import { useStore } from '../panel-nodes/store/store'
+import { findByAddress } from './addressUtils'
+import { useContractTags, useUpdateContractTag } from './hooks/useContractTags'
+
+export function ExcludeButton() {
+  const { project } = useParams()
+  if (!project) {
+    throw new Error('Missing project!')
+  }
+
+  const selected = useStore((state) => state.selected)
+  const nodes = useStore((state) => state.nodes)
+  const updateContractTag = useUpdateContractTag(project)
+  const { data: contractTags } = useContractTags(project)
+
+  const selectedNodes = nodes.filter((node) => selected.includes(node.id))
+  const selectionExists = selected.length > 0
+
+  const hasExcludedContract = selectedNodes.some((node) => {
+    const tag = findByAddress(
+      contractTags?.tags ?? [],
+      (t) => t.contractAddress,
+      node.address,
+    )
+    return tag?.excludeFromReview
+  })
+
+  const handleToggle = async () => {
+    const newValue = !hasExcludedContract
+    const promises = selectedNodes.map((node) =>
+      updateContractTag.mutateAsync({
+        contractAddress: node.address,
+        excludeFromReview: newValue,
+      }),
+    )
+    await Promise.all(promises)
+  }
+
+  return (
+    <ControlButton disabled={!selectionExists} onClick={handleToggle}>
+      Exclude
+    </ControlButton>
+  )
+}

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ExternalButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ExternalButton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { ControlButton } from '../panel-nodes/controls/ControlButton'
 import { useStore } from '../panel-nodes/store/store'
+import { findByAddress } from './addressUtils'
 import { DependencyPropagationDialog } from './DependencyPropagationDialog'
 import { EntitySelector } from './EntitySelector'
 import {
@@ -126,13 +127,10 @@ function AttributePicker({
   // Get current entity from first selected node's tag
   const currentEntity = useMemo(() => {
     if (selectedNodes.length > 0 && selectedNodes[0]) {
-      const normalizedNodeAddress = selectedNodes[0].address
-        .toLowerCase()
-        .replace('eth:', '')
-      const tag = contractTags?.tags.find(
-        (tag) =>
-          tag.contractAddress.toLowerCase().replace('eth:', '') ===
-          normalizedNodeAddress,
+      const tag = findByAddress(
+        contractTags?.tags ?? [],
+        (t) => t.contractAddress,
+        selectedNodes[0].address,
       )
       return tag?.entity
     }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ExternalIndicator.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ExternalIndicator.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { IS_READONLY } from '../../../config/readonly'
+import { findByAddress } from './addressUtils'
 import { DependencyPropagationDialog } from './DependencyPropagationDialog'
 import { EntitySelector } from './EntitySelector'
 import { GovernanceIndicator } from './GovernanceIndicator'
@@ -30,11 +31,10 @@ export function ExternalIndicator({
   const [showEntityPicker, setShowEntityPicker] = useState(false)
 
   const currentEntity = useMemo(() => {
-    const normalizeAddress = (addr: string) =>
-      addr.toLowerCase().replace('eth:', '')
-    const normalized = normalizeAddress(address)
-    return contractTags?.tags.find(
-      (t) => normalizeAddress(t.contractAddress) === normalized,
+    return findByAddress(
+      contractTags?.tags ?? [],
+      (t) => t.contractAddress,
+      address,
     )?.entity
   }, [contractTags, address])
 

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FunctionFolder.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FunctionFolder.tsx
@@ -29,7 +29,11 @@ import {
   isZeroAddress,
   MIN_TOKEN_USD_VALUE,
 } from '../../../defidisco/scoringShared'
-import { addressesEqual, normalizeForLookup, stripChainPrefix } from './addressUtils'
+import {
+  addressesEqual,
+  normalizeForLookup,
+  stripChainPrefix,
+} from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { IconCheckFalse } from './IconCheckFalse'
 import { IconCheckTrue } from './IconCheckTrue'
@@ -84,7 +88,9 @@ function collapseChains(
   // Group by contract address sequence
   const groups = new Map<string, TraversalTerminal['chain'][]>()
   for (const chain of chains) {
-    const key = chain.map((s) => normalizeForLookup(s.contractAddress)).join('\u2192')
+    const key = chain
+      .map((s) => normalizeForLookup(s.contractAddress))
+      .join('\u2192')
     const group = groups.get(key)
     if (group) {
       group.push(chain)
@@ -578,9 +584,7 @@ export function FunctionFolder({
       // Address normalization is now handled in the backend when saving
       const contract = projectData.entries
         .flatMap((e) => [...e.initialContracts, ...e.discoveredContracts])
-        .find(
-          (c) => addressesEqual(c.address, tag.contractAddress),
-        )
+        .find((c) => addressesEqual(c.address, tag.contractAddress))
 
       if (contract) {
         contracts.push({
@@ -1471,7 +1475,10 @@ export function FunctionFolder({
                   if (!contractTags?.tags) return false
                   return contractTags.tags.some(
                     (tag) =>
-                      addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(addr)) && tag.isGovernance,
+                      addressesEqual(
+                        stripChainPrefix(tag.contractAddress),
+                        stripChainPrefix(addr),
+                      ) && tag.isGovernance,
                   )
                 }
                 const isKeyOwner = (owner: GroupedOwner) =>

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FunctionFolder.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FunctionFolder.tsx
@@ -29,6 +29,7 @@ import {
   isZeroAddress,
   MIN_TOKEN_USD_VALUE,
 } from '../../../defidisco/scoringShared'
+import { addressesEqual, normalizeForLookup, stripChainPrefix } from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { IconCheckFalse } from './IconCheckFalse'
 import { IconCheckTrue } from './IconCheckTrue'
@@ -83,7 +84,7 @@ function collapseChains(
   // Group by contract address sequence
   const groups = new Map<string, TraversalTerminal['chain'][]>()
   for (const chain of chains) {
-    const key = chain.map((s) => s.contractAddress.toLowerCase()).join('\u2192')
+    const key = chain.map((s) => normalizeForLookup(s.contractAddress)).join('\u2192')
     const group = groups.get(key)
     if (group) {
       group.push(chain)
@@ -126,7 +127,7 @@ function groupOwnersByAddress(owners: TraversalTerminal[]): GroupedOwner[] {
     }
   >()
   for (const owner of owners) {
-    const key = owner.address.toLowerCase()
+    const key = normalizeForLookup(owner.address)
     const existing = grouped.get(key)
     if (existing) {
       existing.chains.push(owner.chain)
@@ -346,9 +347,9 @@ export function FunctionFolder({
 
   const contractFunds: ContractFundsData | null = React.useMemo(() => {
     if (!fundsData?.contracts) return null
-    const normalizedAddr = contractAddress.toLowerCase()
+    const normalizedAddr = normalizeForLookup(contractAddress)
     const entry = Object.entries(fundsData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddr,
+      ([key]) => normalizeForLookup(key) === normalizedAddr,
     )
     return entry?.[1] ?? null
   }, [fundsData, contractAddress])
@@ -364,9 +365,9 @@ export function FunctionFolder({
     React.useMemo(() => {
       if (!traversalData?.contracts) return null
       // Case-insensitive lookup — functions.json keys may differ in case from project data
-      const normalizedAddr = contractAddress.toLowerCase()
+      const normalizedAddr = normalizeForLookup(contractAddress)
       const contractEntry = Object.entries(traversalData.contracts).find(
-        ([key]) => key.toLowerCase() === normalizedAddr,
+        ([key]) => normalizeForLookup(key) === normalizedAddr,
       )
       return contractEntry?.[1]?.[functionName] ?? null
     }, [traversalData, contractAddress, functionName])
@@ -380,9 +381,9 @@ export function FunctionFolder({
 
   const functionAnalysis: FunctionAnalysis | null = React.useMemo(() => {
     if (!analysisData?.contracts) return null
-    const normalizedAddr = contractAddress.toLowerCase()
+    const normalizedAddr = normalizeForLookup(contractAddress)
     const contractEntry = Object.entries(analysisData.contracts).find(
-      ([key]) => key.toLowerCase() === normalizedAddr,
+      ([key]) => normalizeForLookup(key) === normalizedAddr,
     )
     return contractEntry?.[1]?.[functionName] ?? null
   }, [analysisData, contractAddress, functionName])
@@ -578,7 +579,7 @@ export function FunctionFolder({
       const contract = projectData.entries
         .flatMap((e) => [...e.initialContracts, ...e.discoveredContracts])
         .find(
-          (c) => c.address.toLowerCase() === tag.contractAddress.toLowerCase(),
+          (c) => addressesEqual(c.address, tag.contractAddress),
         )
 
       if (contract) {
@@ -1468,11 +1469,9 @@ export function FunctionFolder({
                 )
                 const isGovernanceAddress = (addr: string) => {
                   if (!contractTags?.tags) return false
-                  const norm = addr.toLowerCase().replace('eth:', '')
                   return contractTags.tags.some(
                     (tag) =>
-                      tag.contractAddress.toLowerCase().replace('eth:', '') ===
-                        norm && tag.isGovernance,
+                      addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(addr)) && tag.isGovernance,
                   )
                 }
                 const isKeyOwner = (owner: GroupedOwner) =>

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FundsSection.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FundsSection.tsx
@@ -11,6 +11,7 @@ import {
   formatUsdValue,
   MIN_TOKEN_USD_VALUE,
 } from '../../../defidisco/scoringShared'
+import { normalizeForLookup, stripChainPrefix } from './addressUtils'
 import { useContractTags } from './hooks/useContractTags'
 import { ProxyTypeTag } from './ProxyTypeTag'
 import { buildProxyTypeMap } from './proxyTypeUtils'
@@ -48,7 +49,7 @@ function ContractFundsRow({
     (fundsData.balances?.totalUsdValue ?? 0) +
     (fundsData.positions?.totalUsdValue ?? 0)
 
-  const shortAddress = contractAddress.replace('eth:', '').slice(0, 10) + '...'
+  const shortAddress = stripChainPrefix(contractAddress).slice(0, 10) + '...'
   const displayName = contractName || shortAddress
 
   const handleSelectClick = (e: React.MouseEvent) => {
@@ -187,7 +188,7 @@ function TokenContractRow({
   const [isExpanded, setIsExpanded] = useState(false)
   const tokenInfo = fundsData.tokenInfo
 
-  const shortAddress = contractAddress.replace('eth:', '').slice(0, 10) + '...'
+  const shortAddress = stripChainPrefix(contractAddress).slice(0, 10) + '...'
   const displayName = contractName || shortAddress
 
   const handleSelectClick = (e: React.MouseEvent) => {
@@ -442,7 +443,7 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
     projectData.entries.forEach((entry: any) => {
       ;[...entry.initialContracts, ...entry.discoveredContracts].forEach(
         (c: any) => {
-          map.set(c.address.toLowerCase(), c.name)
+          map.set(normalizeForLookup(c.address), c.name)
         },
       )
     })
@@ -461,12 +462,7 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
     if (contractTags?.tags) {
       for (const tag of contractTags.tags) {
         if (tag.isToken) {
-          const normalized = tag.contractAddress
-            .toLowerCase()
-            .startsWith('eth:')
-            ? tag.contractAddress.toLowerCase()
-            : `eth:${tag.contractAddress.toLowerCase()}`
-          set.add(normalized)
+          set.add(normalizeForLookup(tag.contractAddress))
         }
       }
     }
@@ -479,7 +475,7 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
     const fundsEntries: [string, ContractFundsData][] = []
     if (fundsData?.contracts) {
       for (const [address, data] of Object.entries(fundsData.contracts)) {
-        if (tokenAddressSet.has(address.toLowerCase())) {
+        if (tokenAddressSet.has(normalizeForLookup(address))) {
           tokenEntries.push([address, data])
         } else {
           fundsEntries.push([address, data])
@@ -669,8 +665,8 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
                       key={address}
                       contractAddress={address}
                       fundsData={data}
-                      contractName={contractNameMap.get(address.toLowerCase())}
-                      proxyType={proxyTypeMap.get(address.toLowerCase())}
+                      contractName={contractNameMap.get(normalizeForLookup(address))}
+                      proxyType={proxyTypeMap.get(normalizeForLookup(address))}
                       onSelect={() => usePanelStore.getState().select(address)}
                     />
                   ))}
@@ -690,8 +686,8 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
                       key={address}
                       contractAddress={address}
                       fundsData={data}
-                      contractName={contractNameMap.get(address.toLowerCase())}
-                      proxyType={proxyTypeMap.get(address.toLowerCase())}
+                      contractName={contractNameMap.get(normalizeForLookup(address))}
+                      proxyType={proxyTypeMap.get(normalizeForLookup(address))}
                       onSelect={() => usePanelStore.getState().select(address)}
                     />
                   ))}

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FundsSection.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FundsSection.tsx
@@ -665,7 +665,9 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
                       key={address}
                       contractAddress={address}
                       fundsData={data}
-                      contractName={contractNameMap.get(normalizeForLookup(address))}
+                      contractName={contractNameMap.get(
+                        normalizeForLookup(address),
+                      )}
                       proxyType={proxyTypeMap.get(normalizeForLookup(address))}
                       onSelect={() => usePanelStore.getState().select(address)}
                     />
@@ -686,7 +688,9 @@ export function FundsSection({ project, projectData }: FundsSectionProps) {
                       key={address}
                       contractAddress={address}
                       fundsData={data}
-                      contractName={contractNameMap.get(normalizeForLookup(address))}
+                      contractName={contractNameMap.get(
+                        normalizeForLookup(address),
+                      )}
                       proxyType={proxyTypeMap.get(normalizeForLookup(address))}
                       onSelect={() => usePanelStore.getState().select(address)}
                     />

--- a/packages/protocolbeat/src/apps/discovery/defidisco/FundsTagsButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/FundsTagsButton.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { ControlButton } from '../panel-nodes/controls/ControlButton'
 import { useStore } from '../panel-nodes/store/store'
+import { findByAddress } from './addressUtils'
 import { useContractTags, useUpdateContractTag } from './hooks/useContractTags'
 
 export function FundsTagsButton() {
@@ -24,13 +25,10 @@ export function FundsTagsButton() {
   // Get current funds settings for first selected node
   const getCurrentSettings = () => {
     if (selectedNodes.length > 0 && selectedNodes[0]) {
-      const normalizedNodeAddress = selectedNodes[0].address
-        .toLowerCase()
-        .replace('eth:', '')
-      const tag = contractTags?.tags.find(
-        (tag) =>
-          tag.contractAddress.toLowerCase().replace('eth:', '') ===
-          normalizedNodeAddress,
+      const tag = findByAddress(
+        contractTags?.tags ?? [],
+        (t) => t.contractAddress,
+        selectedNodes[0].address,
       )
       return {
         fetchBalances: tag?.fetchBalances ?? false,
@@ -111,11 +109,10 @@ export function FundsTagsButton() {
 
   // Count selected nodes that have funds fetching enabled
   const fundsEnabledCount = selectedNodes.filter((node) => {
-    const normalizedNodeAddress = node.address.toLowerCase().replace('eth:', '')
-    const tag = contractTags?.tags.find(
-      (tag) =>
-        tag.contractAddress.toLowerCase().replace('eth:', '') ===
-        normalizedNodeAddress,
+    const tag = findByAddress(
+      contractTags?.tags ?? [],
+      (t) => t.contractAddress,
+      node.address,
     )
     return tag?.fetchBalances || tag?.fetchPositions || tag?.isToken
   }).length

--- a/packages/protocolbeat/src/apps/discovery/defidisco/GovernanceButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/GovernanceButton.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 import { ControlButton } from '../panel-nodes/controls/ControlButton'
 import { useStore } from '../panel-nodes/store/store'
+import { findByAddress } from './addressUtils'
 import { useContractTags, useUpdateContractTag } from './hooks/useContractTags'
 
 export function GovernanceButton() {
@@ -18,12 +19,12 @@ export function GovernanceButton() {
   const selectionExists = selected.length > 0
 
   const hasGovernanceContract = selectedNodes.some((node) => {
-    const normalizedNodeAddress = node.address.toLowerCase().replace('eth:', '')
-    return contractTags?.tags.some(
-      (tag) =>
-        tag.contractAddress.toLowerCase().replace('eth:', '') ===
-          normalizedNodeAddress && tag.isGovernance,
+    const tag = findByAddress(
+      contractTags?.tags ?? [],
+      (t) => t.contractAddress,
+      node.address,
     )
+    return tag?.isGovernance
   })
 
   const handleToggle = async () => {

--- a/packages/protocolbeat/src/apps/discovery/defidisco/GovernanceIndicator.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/GovernanceIndicator.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom'
 import { IS_READONLY } from '../../../config/readonly'
+import { findByAddress } from './addressUtils'
 import { useContractTags, useUpdateContractTag } from './hooks/useContractTags'
 
 export function GovernanceIndicator({ address }: { address: string }) {
@@ -9,11 +10,10 @@ export function GovernanceIndicator({ address }: { address: string }) {
   const { data: contractTags } = useContractTags(project)
   const updateContractTag = useUpdateContractTag(project)
 
-  const normalizeAddress = (addr: string) =>
-    addr.toLowerCase().replace('eth:', '')
-
-  const tag = contractTags?.tags.find(
-    (t) => normalizeAddress(t.contractAddress) === normalizeAddress(address),
+  const tag = findByAddress(
+    contractTags?.tags ?? [],
+    (t) => t.contractAddress,
+    address,
   )
   const isGovernance = tag?.isGovernance ?? false
 

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ListItemExternalDeps.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ListItemExternalDeps.tsx
@@ -7,6 +7,7 @@ import { IconChevronDown } from '../../../icons/IconChevronDown'
 import { IconChevronRight } from '../../../icons/IconChevronRight'
 import { IconFolder } from '../../../icons/IconFolder'
 import { IconFolderOpened } from '../../../icons/IconFolderOpened'
+import { addressesEqual, stripChainPrefix } from './addressUtils'
 import { usePanelStore } from '../store/panel-store'
 import { AddressEntry } from './AddressEntry'
 
@@ -184,9 +185,8 @@ function getEntity(
   contractTags: ApiContractTagsResponse | undefined,
 ): string | undefined {
   if (!contractTags?.tags) return undefined
-  const normalized = address.toLowerCase().replace('eth:', '')
   return contractTags.tags.find(
     (tag) =>
-      tag.contractAddress.toLowerCase().replace('eth:', '') === normalized,
+      addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(address)),
   )?.entity
 }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ListItemExternalDeps.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ListItemExternalDeps.tsx
@@ -185,8 +185,10 @@ function getEntity(
   contractTags: ApiContractTagsResponse | undefined,
 ): string | undefined {
   if (!contractTags?.tags) return undefined
-  return contractTags.tags.find(
-    (tag) =>
-      addressesEqual(stripChainPrefix(tag.contractAddress), stripChainPrefix(address)),
+  return contractTags.tags.find((tag) =>
+    addressesEqual(
+      stripChainPrefix(tag.contractAddress),
+      stripChainPrefix(address),
+    ),
   )?.entity
 }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/NodeControlExtensions.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/NodeControlExtensions.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { ExcludeButton } from './ExcludeButton'
 import { ExternalButton } from './ExternalButton'
 import { FundsTagsButton } from './FundsTagsButton'
 import { GovernanceButton } from './GovernanceButton'
@@ -8,6 +9,7 @@ export function NodeControlExtensions() {
     <>
       <ExternalButton />
       <GovernanceButton />
+      <ExcludeButton />
       <FundsTagsButton />
     </>
   )

--- a/packages/protocolbeat/src/apps/discovery/defidisco/PermissionsDisplay.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/PermissionsDisplay.tsx
@@ -15,6 +15,7 @@ import type {
 } from '../../../api/types'
 import { useCodeStore } from '../../../components/editor/store'
 import { partition } from '../../../utils/partition'
+import { addressesEqual, normalizeForLookup } from './addressUtils'
 import { useMultiViewStore } from '../multi-view/store'
 import { Folder } from '../panel-values/Folder'
 import { usePanelStore } from '../store/panel-store'
@@ -107,16 +108,16 @@ export function PermissionsDisplay({
 
   // Get functions for the specific contracts we're displaying (case-insensitive lookup)
   const getFunctionsForContract = (contractAddress: string) => {
-    const normalizedAddr = contractAddress.toLowerCase()
+    const normalizedAddr = normalizeForLookup(contractAddress)
     const matchingKey = Object.keys(functionsData?.contracts || {}).find(
-      (k) => k.toLowerCase() === normalizedAddr,
+      (k) => normalizeForLookup(k) === normalizedAddr,
     )
     const contractFunctions =
       (matchingKey
         ? functionsData?.contracts?.[matchingKey]?.functions
         : undefined) || []
     const localFunctionsForContract = localFunctions.filter(
-      (o) => o.contractAddress.toLowerCase() === normalizedAddr,
+      (o) => addressesEqual(o.contractAddress, contractAddress),
     )
 
     // Map contract functions to include contractAddress (functions in contracts don't have it)

--- a/packages/protocolbeat/src/apps/discovery/defidisco/PermissionsDisplay.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/PermissionsDisplay.tsx
@@ -116,8 +116,8 @@ export function PermissionsDisplay({
       (matchingKey
         ? functionsData?.contracts?.[matchingKey]?.functions
         : undefined) || []
-    const localFunctionsForContract = localFunctions.filter(
-      (o) => addressesEqual(o.contractAddress, contractAddress),
+    const localFunctionsForContract = localFunctions.filter((o) =>
+      addressesEqual(o.contractAddress, contractAddress),
     )
 
     // Map contract functions to include contractAddress (functions in contracts don't have it)

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ResultsSection.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ResultsSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { ApiAddressType, OwnerDefinition } from '../../../api/types'
+import { stripChainPrefix } from './addressUtils'
 
 interface ResultsSectionProps {
   projectData: any
@@ -168,19 +169,19 @@ function calculateUpgradeabilityStats(
   projectData.entries?.forEach((entry: any) => {
     // Add initial contracts
     entry.initialContracts?.forEach((contract: any) => {
-      const normalizedAddr = contract.address.replace('eth:', '').toLowerCase()
+      const normalizedAddr = stripChainPrefix(contract.address).toLowerCase()
       addressTypeMap.set(normalizedAddr, contract.type)
     })
 
     // Add discovered contracts
     entry.discoveredContracts?.forEach((contract: any) => {
-      const normalizedAddr = contract.address.replace('eth:', '').toLowerCase()
+      const normalizedAddr = stripChainPrefix(contract.address).toLowerCase()
       addressTypeMap.set(normalizedAddr, contract.type)
     })
 
     // Add EOAs
     entry.eoas?.forEach((eoa: any) => {
-      const normalizedAddr = eoa.address.replace('eth:', '').toLowerCase()
+      const normalizedAddr = stripChainPrefix(eoa.address).toLowerCase()
       addressTypeMap.set(normalizedAddr, eoa.type || 'EOA')
     })
   })
@@ -226,7 +227,7 @@ function calculateUpgradeabilityStats(
               )
 
               ownerAddresses.forEach((address) => {
-                const normalizedAddr = address.replace('eth:', '').toLowerCase()
+                const normalizedAddr = stripChainPrefix(address).toLowerCase()
                 const addressType = addressTypeMap.get(normalizedAddr)
 
                 if (addressType) {

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ReviewDescriptionsEditor.tsx
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ReviewDescriptionsEditor.tsx
@@ -7,6 +7,7 @@ import type {
   ReviewProjectType,
 } from '../../../api/types'
 import { ReviewResourcesEditor } from './ReviewResourcesEditor'
+import { ensureChainPrefix } from './addressUtils'
 
 const PROTOCOL_TYPES: ReviewProjectType[] = [
   'stablecoin',
@@ -57,9 +58,7 @@ export function ReviewDescriptionsEditor({
       // Optimistically update localConfig
       onUpdateConfig((prev) => {
         const sectionData = { ...prev[section] }
-        const normalizedAddress = address.startsWith('eth:')
-          ? address
-          : `eth:${address}`
+        const normalizedAddress = ensureChainPrefix(address)
         if (!description && !name) {
           delete sectionData[normalizedAddress]
         } else {

--- a/packages/protocolbeat/src/apps/discovery/defidisco/addressUtils.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/addressUtils.ts
@@ -1,0 +1,97 @@
+/**
+ * Address utility functions for DeFiDisco frontend.
+ *
+ * All internal addresses use the chain-prefixed format "chain:0xChecksummed".
+ * The backend is responsible for checksumming; the frontend uses these helpers
+ * for consistent prefix handling and comparisons.
+ */
+
+/**
+ * Strip the chain prefix from an address.
+ * Works with any chain prefix (eth:, arb1:, base:, etc.).
+ */
+export function stripChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(colonIdx + 1)
+  }
+  return address
+}
+
+/**
+ * Get the chain prefix from a chain-specific address.
+ * Returns 'eth' as default if no prefix is found.
+ */
+export function getChainPrefix(address: string): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address.slice(0, colonIdx)
+  }
+  return 'eth'
+}
+
+/**
+ * Ensure an address has a chain prefix.
+ * If it already has one, returns as-is.
+ * If it doesn't, prepends 'eth:' by default.
+ */
+export function ensureChainPrefix(address: string, chain = 'eth'): string {
+  const colonIdx = address.indexOf(':')
+  if (colonIdx !== -1 && !address.startsWith('0x')) {
+    return address
+  }
+  return `${chain}:${address}`
+}
+
+/**
+ * Compare two addresses for equality, case-insensitively.
+ * Handles addresses with or without chain prefix.
+ */
+export function addressesEqual(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+/**
+ * Normalize an address for use as a lookup key.
+ * Lowercases and ensures chain prefix consistency.
+ *
+ * NOTE: On the backend, addresses should be checksummed at ingestion.
+ * This frontend normalizer is for display/comparison only.
+ */
+export function normalizeForLookup(address: string): string {
+  return ensureChainPrefix(address).toLowerCase()
+}
+
+/**
+ * Check if a string looks like a chain-prefixed address.
+ */
+export function isChainAddress(value: string): boolean {
+  const colonIdx = value.indexOf(':')
+  if (colonIdx === -1 || value.startsWith('0x')) return false
+  const hex = value.slice(colonIdx + 1)
+  return hex.startsWith('0x') && hex.length === 42
+}
+
+/**
+ * Shorten an address for display: "0x1234...abcd"
+ * Handles chain-prefixed addresses by stripping the prefix first.
+ */
+export function shortenAddress(address: string, chars = 4): string {
+  const hex = stripChainPrefix(address)
+  if (hex.length <= chars * 2 + 2) return hex
+  return `${hex.slice(0, chars + 2)}...${hex.slice(-chars)}`
+}
+
+/**
+ * Find a value in an array by matching an address field.
+ */
+export function findByAddress<T>(
+  items: T[],
+  getAddress: (item: T) => string,
+  targetAddress: string,
+): T | undefined {
+  const normalizedTarget = normalizeForLookup(targetAddress)
+  return items.find(
+    (item) => normalizeForLookup(getAddress(item)) === normalizedTarget,
+  )
+}

--- a/packages/protocolbeat/src/apps/discovery/defidisco/addressUtils.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/addressUtils.ts
@@ -48,7 +48,7 @@ export function ensureChainPrefix(address: string, chain = 'eth'): string {
  * Handles addresses with or without chain prefix.
  */
 export function addressesEqual(a: string, b: string): boolean {
-  return a.toLowerCase() === b.toLowerCase()
+  return normalizeForLookup(a) === normalizeForLookup(b)
 }
 
 /**

--- a/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useContractTags.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useContractTags.ts
@@ -3,6 +3,7 @@ import { getContractTags, updateContractTag } from '../../../../api/api'
 import type { ApiContractTagsUpdateRequest } from '../../../../api/types'
 import type { OklchColor } from '../../panel-nodes/view/colors/oklch'
 import oklchColors from '../../../../oklchColors.json'
+import { findByAddress } from '../addressUtils'
 
 export function useContractTags(project: string) {
   return useQuery({
@@ -37,16 +38,9 @@ export function useIsContractExternal(
   const { data: contractTags } = useContractTags(project)
 
   // Normalize both addresses for comparison (handle eth: prefix)
-  const normalizeAddress = (addr: string) => {
-    return addr.toLowerCase().replace('eth:', '')
-  }
-
-  const normalizedNodeAddress = normalizeAddress(contractAddress)
-
-  const tag = contractTags?.tags.find((tag) => {
-    const normalizedTagAddress = normalizeAddress(tag.contractAddress)
-    return normalizedTagAddress === normalizedNodeAddress
-  })
+  const tag = contractTags?.tags
+    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    : undefined
 
   return tag?.isExternal ?? false
 }
@@ -57,16 +51,9 @@ export function useIsContractGovernance(
 ) {
   const { data: contractTags } = useContractTags(project)
 
-  const normalizeAddress = (addr: string) => {
-    return addr.toLowerCase().replace('eth:', '')
-  }
-
-  const normalizedNodeAddress = normalizeAddress(contractAddress)
-
-  const tag = contractTags?.tags.find((tag) => {
-    const normalizedTagAddress = normalizeAddress(tag.contractAddress)
-    return normalizedTagAddress === normalizedNodeAddress
-  })
+  const tag = contractTags?.tags
+    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    : undefined
 
   return tag?.isGovernance ?? false
 }
@@ -89,13 +76,9 @@ export function useContractTagColor(
 ): { color: OklchColor; isDark: boolean } | undefined {
   const { data: contractTags } = useContractTags(project)
 
-  const normalizeAddress = (addr: string) =>
-    addr.toLowerCase().replace('eth:', '')
-  const normalizedAddress = normalizeAddress(contractAddress)
-
-  const tag = contractTags?.tags.find(
-    (t) => normalizeAddress(t.contractAddress) === normalizedAddress,
-  )
+  const tag = contractTags?.tags
+    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    : undefined
 
   if (tag?.isExternal) return { color: oklchColors.aux.orange, isDark: false }
   if (tag?.isGovernance) return { color: oklchColors.aux.green, isDark: false }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useContractTags.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useContractTags.ts
@@ -39,7 +39,11 @@ export function useIsContractExternal(
 
   // Normalize both addresses for comparison (handle eth: prefix)
   const tag = contractTags?.tags
-    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    ? findByAddress(
+        contractTags.tags,
+        (t) => t.contractAddress,
+        contractAddress,
+      )
     : undefined
 
   return tag?.isExternal ?? false
@@ -52,7 +56,11 @@ export function useIsContractGovernance(
   const { data: contractTags } = useContractTags(project)
 
   const tag = contractTags?.tags
-    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    ? findByAddress(
+        contractTags.tags,
+        (t) => t.contractAddress,
+        contractAddress,
+      )
     : undefined
 
   return tag?.isGovernance ?? false
@@ -77,7 +85,11 @@ export function useContractTagColor(
   const { data: contractTags } = useContractTags(project)
 
   const tag = contractTags?.tags
-    ? findByAddress(contractTags.tags, (t) => t.contractAddress, contractAddress)
+    ? findByAddress(
+        contractTags.tags,
+        (t) => t.contractAddress,
+        contractAddress,
+      )
     : undefined
 
   if (tag?.isExternal) return { color: oklchColors.aux.orange, isDark: false }

--- a/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useExternalToggle.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useExternalToggle.ts
@@ -6,6 +6,7 @@ import type {
   AffectedFunction,
   ExternalContract,
 } from '../DependencyPropagationDialog'
+import { addressesEqual, normalizeForLookup } from '../addressUtils'
 import { useContractTags, useUpdateContractTag } from './useContractTags'
 
 export interface ExternalToggleTarget {
@@ -55,11 +56,10 @@ export function useExternalToggle(
 
   // Check if any of the targets are external
   const hasExternalContract = targets.some((target) => {
-    const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
+    const normalized = normalizeForLookup(target.address)
     const tag = contractTags?.tags.find(
       (tag) =>
-        tag.contractAddress.toLowerCase().replace('eth:', '') ===
-        normalizedAddress,
+        normalizeForLookup(tag.contractAddress) === normalized,
     )
     return tag?.isExternal ?? false
   })
@@ -76,13 +76,9 @@ export function useExternalToggle(
   // Helper function to get contract name from address
   const getContractName = (address: string): string => {
     const allContracts = getAllContracts()
-    const normalizedAddress = address.toLowerCase().replace('eth:', '')
-    const contract = allContracts.find((c) => {
-      const normalizedContractAddress = c.address
-        .toLowerCase()
-        .replace('eth:', '')
-      return normalizedContractAddress === normalizedAddress
-    })
+    const contract = allContracts.find((c) =>
+      addressesEqual(c.address, address),
+    )
     return contract?.name || address.slice(0, 10) + '...'
   }
 
@@ -99,13 +95,9 @@ export function useExternalToggle(
 
     // Map targets to external contracts, using the actual contract address from project data (with prefix)
     const externalContractsList: ExternalContract[] = targets.map((target) => {
-      const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
-      const contract = allContracts.find((c) => {
-        const normalizedContractAddress = c.address
-          .toLowerCase()
-          .replace('eth:', '')
-        return normalizedContractAddress === normalizedAddress
-      })
+      const contract = allContracts.find((c) =>
+        addressesEqual(c.address, target.address),
+      )
       // Use the contract's actual address (with prefix) or fallback to target address
       return {
         address: contract?.address || target.address,
@@ -117,27 +109,21 @@ export function useExternalToggle(
 
     // Create a set of target addresses for quick lookup (these are all being marked external)
     const targetAddresses = new Set(
-      targets.map((t) => t.address.toLowerCase().replace('eth:', '')),
+      targets.map((t) => normalizeForLookup(t.address)),
     )
 
     // For each external contract, find referencing contracts
     for (const target of targets) {
-      const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
-      const extContract = allContracts.find((c) => {
-        const normalizedContractAddress = c.address
-          .toLowerCase()
-          .replace('eth:', '')
-        return normalizedContractAddress === normalizedAddress
-      })
+      const extContract = allContracts.find((c) =>
+        addressesEqual(c.address, target.address),
+      )
 
       if (!extContract?.referencedBy) continue
 
       // Filter to only internal contracts
       for (const ref of extContract.referencedBy) {
         // Check if the referencing contract is one of the targets being marked external
-        const normalizedRefAddress = ref.address
-          .toLowerCase()
-          .replace('eth:', '')
+        const normalizedRefAddress = normalizeForLookup(ref.address)
         if (targetAddresses.has(normalizedRefAddress)) {
           continue // Skip contracts being marked external in this batch
         }
@@ -145,8 +131,7 @@ export function useExternalToggle(
         // Check if the referencing contract is already external
         const refTag = contractTags.tags.find(
           (tag) =>
-            tag.contractAddress.toLowerCase().replace('eth:', '') ===
-            normalizedRefAddress,
+            normalizeForLookup(tag.contractAddress) === normalizedRefAddress,
         )
 
         if (refTag?.isExternal) continue // Skip already external contracts
@@ -155,12 +140,9 @@ export function useExternalToggle(
         const allFunctionNames = new Set<string>()
 
         // Find the contract data to get ABIs
-        const refContractData = allContracts.find((c) => {
-          const normalizedContractAddr = c.address
-            .toLowerCase()
-            .replace('eth:', '')
-          return normalizedContractAddr === normalizedRefAddress
-        })
+        const refContractData = allContracts.find((c) =>
+          addressesEqual(c.address, ref.address),
+        )
 
         if (refContractData?.abis) {
           for (const abi of refContractData.abis) {
@@ -218,13 +200,9 @@ export function useExternalToggle(
 
     // Map targets to external contracts, using the actual contract address from project data (with prefix)
     const externalContractsList: ExternalContract[] = targets.map((target) => {
-      const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
-      const contract = allContracts.find((c) => {
-        const normalizedContractAddress = c.address
-          .toLowerCase()
-          .replace('eth:', '')
-        return normalizedContractAddress === normalizedAddress
-      })
+      const contract = allContracts.find((c) =>
+        addressesEqual(c.address, target.address),
+      )
       return {
         address: contract?.address || target.address,
         name: target.name || getContractName(target.address),
@@ -235,26 +213,20 @@ export function useExternalToggle(
 
     // Create a set of target addresses for quick lookup
     const targetAddresses = new Set(
-      targets.map((t) => t.address.toLowerCase().replace('eth:', '')),
+      targets.map((t) => normalizeForLookup(t.address)),
     )
 
     // Use referencedBy from project data to find referencing contracts (same as add analysis)
     for (const target of targets) {
-      const normalizedAddress = target.address.toLowerCase().replace('eth:', '')
-      const extContract = allContracts.find((c) => {
-        const normalizedContractAddress = c.address
-          .toLowerCase()
-          .replace('eth:', '')
-        return normalizedContractAddress === normalizedAddress
-      })
+      const extContract = allContracts.find((c) =>
+        addressesEqual(c.address, target.address),
+      )
 
       if (!extContract?.referencedBy) continue
 
       for (const ref of extContract.referencedBy) {
         // Skip contracts being marked internal in this batch
-        const normalizedRefAddress = ref.address
-          .toLowerCase()
-          .replace('eth:', '')
+        const normalizedRefAddress = normalizeForLookup(ref.address)
         if (targetAddresses.has(normalizedRefAddress)) {
           continue
         }
@@ -262,19 +234,15 @@ export function useExternalToggle(
         // Skip already-external contracts (they wouldn't have dependencies on this one)
         const refTag = contractTags.tags.find(
           (tag) =>
-            tag.contractAddress.toLowerCase().replace('eth:', '') ===
-            normalizedRefAddress,
+            normalizeForLookup(tag.contractAddress) === normalizedRefAddress,
         )
         if (refTag?.isExternal) continue
 
         // Get ALL write functions for this contract from ABIs
         const allFunctionNames = new Set<string>()
-        const refContractData = allContracts.find((c) => {
-          const normalizedContractAddr = c.address
-            .toLowerCase()
-            .replace('eth:', '')
-          return normalizedContractAddr === normalizedRefAddress
-        })
+        const refContractData = allContracts.find((c) =>
+          addressesEqual(c.address, ref.address),
+        )
 
         if (refContractData?.abis) {
           for (const abi of refContractData.abis) {
@@ -387,8 +355,7 @@ export function useExternalToggle(
       .filter(
         (ext) =>
           !currentDependencies.some(
-            (dep) =>
-              dep.contractAddress.toLowerCase() === ext.address.toLowerCase(),
+            (dep) => addressesEqual(dep.contractAddress, ext.address),
           ),
       )
       .map((ext) => ({ contractAddress: ext.address }))
@@ -418,11 +385,10 @@ export function useExternalToggle(
     }
 
     // Remove specified external contracts from dependencies
-    const externalAddresses = externalContracts.map((ext) =>
-      ext.address.toLowerCase(),
-    )
     const newDependencies = currentFunc.dependencies.filter(
-      (dep) => !externalAddresses.includes(dep.contractAddress.toLowerCase()),
+      (dep) => !externalContracts.some((ext) =>
+        addressesEqual(dep.contractAddress, ext.address),
+      ),
     )
 
     // Update function with filtered dependencies
@@ -535,13 +501,10 @@ export function useExternalToggle(
   // Get initial entity from first target's tag
   const initialEntity = (() => {
     if (targets.length === 0) return undefined
-    const normalizedAddress = targets[0].address
-      .toLowerCase()
-      .replace('eth:', '')
+    const normalized = normalizeForLookup(targets[0].address)
     const tag = contractTags?.tags.find(
       (tag) =>
-        tag.contractAddress.toLowerCase().replace('eth:', '') ===
-        normalizedAddress,
+        normalizeForLookup(tag.contractAddress) === normalized,
     )
     return tag?.entity
   })()

--- a/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useExternalToggle.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/hooks/useExternalToggle.ts
@@ -58,8 +58,7 @@ export function useExternalToggle(
   const hasExternalContract = targets.some((target) => {
     const normalized = normalizeForLookup(target.address)
     const tag = contractTags?.tags.find(
-      (tag) =>
-        normalizeForLookup(tag.contractAddress) === normalized,
+      (tag) => normalizeForLookup(tag.contractAddress) === normalized,
     )
     return tag?.isExternal ?? false
   })
@@ -354,8 +353,8 @@ export function useExternalToggle(
     const newDependencies = externalContracts
       .filter(
         (ext) =>
-          !currentDependencies.some(
-            (dep) => addressesEqual(dep.contractAddress, ext.address),
+          !currentDependencies.some((dep) =>
+            addressesEqual(dep.contractAddress, ext.address),
           ),
       )
       .map((ext) => ({ contractAddress: ext.address }))
@@ -386,9 +385,10 @@ export function useExternalToggle(
 
     // Remove specified external contracts from dependencies
     const newDependencies = currentFunc.dependencies.filter(
-      (dep) => !externalContracts.some((ext) =>
-        addressesEqual(dep.contractAddress, ext.address),
-      ),
+      (dep) =>
+        !externalContracts.some((ext) =>
+          addressesEqual(dep.contractAddress, ext.address),
+        ),
     )
 
     // Update function with filtered dependencies
@@ -503,8 +503,7 @@ export function useExternalToggle(
     if (targets.length === 0) return undefined
     const normalized = normalizeForLookup(targets[0].address)
     const tag = contractTags?.tags.find(
-      (tag) =>
-        normalizeForLookup(tag.contractAddress) === normalized,
+      (tag) => normalizeForLookup(tag.contractAddress) === normalized,
     )
     return tag?.entity
   })()

--- a/packages/protocolbeat/src/apps/discovery/defidisco/ownerResolution.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/ownerResolution.ts
@@ -1,3 +1,5 @@
+import { isChainAddress } from './addressUtils'
+
 /**
  * Shared owner resolution logic for DeFiDisco
  *
@@ -119,7 +121,7 @@ export function parseValuePath(path: string): PathSegment[] {
  */
 export function extractAddresses(value: any, path: string): string[] {
   // Single string address
-  if (typeof value === 'string' && value.startsWith('eth:')) {
+  if (typeof value === 'string' && isChainAddress(value)) {
     return [value]
   }
 
@@ -127,7 +129,7 @@ export function extractAddresses(value: any, path: string): string[] {
   if (Array.isArray(value)) {
     const addresses: string[] = []
     for (const element of value) {
-      if (typeof element === 'string' && element.startsWith('eth:')) {
+      if (typeof element === 'string' && isChainAddress(element)) {
         addresses.push(element)
       } else if (typeof element === 'object' && element !== null) {
         // Recursively extract from object elements
@@ -144,7 +146,7 @@ export function extractAddresses(value: any, path: string): string[] {
     const addresses: string[] = []
     for (const key in value) {
       const prop = value[key]
-      if (typeof prop === 'string' && prop.startsWith('eth:')) {
+      if (typeof prop === 'string' && isChainAddress(prop)) {
         addresses.push(prop)
       } else if (typeof prop === 'object' && prop !== null) {
         // Recursively extract from nested objects/arrays
@@ -287,13 +289,13 @@ export function resolvePathExpression(
       if (
         !targetContractAddress ||
         typeof targetContractAddress !== 'string' ||
-        !targetContractAddress.startsWith('eth:')
+        !isChainAddress(targetContractAddress)
       ) {
         throw new Error(
           `Field "${fieldName}" not found or is not an address in current contract`,
         )
       }
-    } else if (contractRef.startsWith('eth:')) {
+    } else if (isChainAddress(contractRef)) {
       // Absolute contract address
       targetContractAddress = contractRef
     } else {
@@ -465,7 +467,7 @@ export class DiscoveredDataAccess implements IContractDataAccess {
     }
 
     // Handle string addresses (most common case)
-    if (typeof value === 'string' && value.startsWith('eth:')) {
+    if (typeof value === 'string' && isChainAddress(value)) {
       return value
     }
 

--- a/packages/protocolbeat/src/apps/discovery/defidisco/proxyTypeUtils.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/proxyTypeUtils.ts
@@ -1,3 +1,5 @@
+import { normalizeForLookup } from './addressUtils'
+
 /**
  * Builds a map of contract address -> proxyType for O(1) lookups
  * @param projectData - The project data containing entries with contracts
@@ -18,7 +20,7 @@ export function buildProxyTypeMap(projectData: any): Map<string, string> {
 
     allContracts.forEach((contract: any) => {
       if (contract.proxyType) {
-        map.set(contract.address.toLowerCase(), contract.proxyType)
+        map.set(normalizeForLookup(contract.address), contract.proxyType)
       }
     })
   })

--- a/packages/protocolbeat/src/apps/discovery/defidisco/reviewDataSources.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/reviewDataSources.ts
@@ -87,9 +87,7 @@ function isExternalContract(
   if (!contractTags) return false
   const normalized = normalizeForLookup(address)
   return contractTags.tags.some(
-    (t) =>
-      normalizeForLookup(t.contractAddress) === normalized &&
-      t.isExternal,
+    (t) => normalizeForLookup(t.contractAddress) === normalized && t.isExternal,
   )
 }
 
@@ -100,9 +98,7 @@ function isTokenContract(
   if (!contractTags) return false
   const normalized = normalizeForLookup(address)
   return contractTags.tags.some(
-    (t) =>
-      normalizeForLookup(t.contractAddress) === normalized &&
-      t.isToken,
+    (t) => normalizeForLookup(t.contractAddress) === normalized && t.isToken,
   )
 }
 
@@ -482,7 +478,8 @@ const permissionedFunctionsSource: DataSourceDefinition = {
 
         items.push({
           contractName:
-            contractNameMap.get(normalizeForLookup(addr)) ?? shortenAddress(addr),
+            contractNameMap.get(normalizeForLookup(addr)) ??
+            shortenAddress(addr),
           contractAddress: addr,
           functionName: func.functionName,
           score: func.score ?? 'unscored',

--- a/packages/protocolbeat/src/apps/discovery/defidisco/reviewDataSources.ts
+++ b/packages/protocolbeat/src/apps/discovery/defidisco/reviewDataSources.ts
@@ -9,6 +9,7 @@ import type {
   DataColumnFormat,
   DataTableColumn,
 } from '../../../api/types'
+import { normalizeForLookup, stripChainPrefix } from './addressUtils'
 
 // ============================================================================
 // Types
@@ -84,10 +85,10 @@ function isExternalContract(
   contractTags?: ApiContractTagsResponse,
 ): boolean {
   if (!contractTags) return false
-  const normalized = address.replace(/^eth:/, '').toLowerCase()
+  const normalized = normalizeForLookup(address)
   return contractTags.tags.some(
     (t) =>
-      t.contractAddress.replace(/^eth:/, '').toLowerCase() === normalized &&
+      normalizeForLookup(t.contractAddress) === normalized &&
       t.isExternal,
   )
 }
@@ -97,10 +98,10 @@ function isTokenContract(
   contractTags?: ApiContractTagsResponse,
 ): boolean {
   if (!contractTags) return false
-  const normalized = address.replace(/^eth:/, '').toLowerCase()
+  const normalized = normalizeForLookup(address)
   return contractTags.tags.some(
     (t) =>
-      t.contractAddress.replace(/^eth:/, '').toLowerCase() === normalized &&
+      normalizeForLookup(t.contractAddress) === normalized &&
       t.isToken,
   )
 }
@@ -110,7 +111,7 @@ function hasCapitalData(admin: AdminDetail): admin is AdminDetailWithCapital {
 }
 
 function shortenAddress(address: string): string {
-  const addr = address.replace(/^eth:/, '')
+  const addr = stripChainPrefix(address)
   if (addr.length <= 12) return addr
   return `${addr.slice(0, 6)}...${addr.slice(-4)}`
 }
@@ -398,7 +399,7 @@ const fundsContractBalancesSource: DataSourceDefinition = {
       })
       .map(([addr, cfd]) => ({
         contractName:
-          contractNameMap.get(addr.toLowerCase()) ?? shortenAddress(addr),
+          contractNameMap.get(normalizeForLookup(addr)) ?? shortenAddress(addr),
         address: addr,
         balancesTotal: cfd.balances?.totalUsdValue ?? 0,
         positionsTotal: cfd.positions?.totalUsdValue ?? 0,
@@ -481,7 +482,7 @@ const permissionedFunctionsSource: DataSourceDefinition = {
 
         items.push({
           contractName:
-            contractNameMap.get(addr.toLowerCase()) ?? shortenAddress(addr),
+            contractNameMap.get(normalizeForLookup(addr)) ?? shortenAddress(addr),
           contractAddress: addr,
           functionName: func.functionName,
           score: func.score ?? 'unscored',
@@ -512,7 +513,7 @@ function buildContractNameMap(
   if (!entry) return map
   for (const c of [...entry.initialContracts, ...entry.discoveredContracts]) {
     if (c.name) {
-      map.set(c.address.toLowerCase(), c.name)
+      map.set(normalizeForLookup(c.address), c.name)
     }
   }
   return map

--- a/packages/protocolbeat/src/apps/discovery/panel-list/ListPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-list/ListPanel.tsx
@@ -12,6 +12,7 @@ import { IconChevronRight } from '../../../icons/IconChevronRight'
 import { IconFolder } from '../../../icons/IconFolder'
 import { IconFolderOpened } from '../../../icons/IconFolderOpened'
 import { toShortenedAddress } from '../../../utils/toShortenedAddress'
+import { addressesEqual } from '../defidisco/addressUtils'
 import { useContractTags } from '../defidisco/hooks/useContractTags'
 import { ListItemExternalDeps } from '../defidisco/ListItemExternalDeps'
 import { useGlobalSettingsStore } from '../store/global-settings-store'
@@ -57,11 +58,9 @@ function ListItemChain(props: { entry: ApiProjectChain; first: boolean }) {
 
   const isExternal = (address: string) => {
     if (!contractTags?.tags) return false
-    const normalized = address.toLowerCase().replace('eth:', '')
     return contractTags.tags.some(
       (tag) =>
-        tag.isExternal &&
-        tag.contractAddress.toLowerCase().replace('eth:', '') === normalized,
+        tag.isExternal && addressesEqual(tag.contractAddress, address),
     )
   }
 

--- a/packages/protocolbeat/src/defidisco/AdminsInventoryBreakdown.tsx
+++ b/packages/protocolbeat/src/defidisco/AdminsInventoryBreakdown.tsx
@@ -6,6 +6,10 @@ import type { AdminModuleScore } from '../api/types'
 import { useContractTags } from '../apps/discovery/defidisco/hooks/useContractTags'
 import { buildProxyTypeMap } from '../apps/discovery/defidisco/proxyTypeUtils'
 import {
+  addressesEqual,
+  normalizeForLookup,
+} from '../apps/discovery/defidisco/addressUtils'
+import {
   computeDeduplicatedCapital,
   formatUsdValue,
   hasCapitalData,
@@ -47,8 +51,8 @@ export function AdminsInventoryBreakdown({
     if (!contractTags?.tags) return false
     return contractTags.tags.some(
       (tag) =>
-        tag.contractAddress.toLowerCase() ===
-          admin.adminAddress.toLowerCase() && tag.isExternal,
+        addressesEqual(tag.contractAddress, admin.adminAddress) &&
+        tag.isExternal,
     )
   }
 
@@ -56,8 +60,8 @@ export function AdminsInventoryBreakdown({
     if (!contractTags?.tags) return false
     return contractTags.tags.some(
       (tag) =>
-        tag.contractAddress.toLowerCase() ===
-          admin.adminAddress.toLowerCase() && tag.isGovernance,
+        addressesEqual(tag.contractAddress, admin.adminAddress) &&
+        tag.isGovernance,
     )
   }
 
@@ -154,7 +158,7 @@ export function AdminsInventoryBreakdown({
               <OwnerSection
                 key={admin.adminAddress}
                 admin={admin}
-                proxyType={proxyTypeMap.get(admin.adminAddress.toLowerCase())}
+                proxyType={proxyTypeMap.get(normalizeForLookup(admin.adminAddress))}
                 isGovernance={isGovernanceOwner(admin)}
               />
             ))}

--- a/packages/protocolbeat/src/defidisco/DependencyInventoryBreakdown.tsx
+++ b/packages/protocolbeat/src/defidisco/DependencyInventoryBreakdown.tsx
@@ -7,6 +7,10 @@ import type {
   DependencyDetail,
   DependencyModuleScore,
 } from '../api/types'
+import {
+  addressesEqual,
+  normalizeForLookup,
+} from '../apps/discovery/defidisco/addressUtils'
 import { useContractTags } from '../apps/discovery/defidisco/hooks/useContractTags'
 import { buildProxyTypeMap } from '../apps/discovery/defidisco/proxyTypeUtils'
 import { usePanelStore } from '../apps/discovery/store/panel-store'
@@ -160,15 +164,15 @@ export function DependencyInventoryBreakdown({
     return adminScore.breakdown.filter((admin) => {
       return contractTags.tags.some(
         (tag) =>
-          tag.contractAddress.toLowerCase() ===
-            admin.adminAddress.toLowerCase() && tag.isExternal,
+          addressesEqual(tag.contractAddress, admin.adminAddress) &&
+          tag.isExternal,
       )
     })
   }, [adminScore, contractTags])
 
   // Filter immutable/revoked external owners based on toggle
   const isImmutableOrRevoked = (admin: any) =>
-    proxyTypeMap.get(admin.adminAddress.toLowerCase()) === 'immutable' ||
+    proxyTypeMap.get(normalizeForLookup(admin.adminAddress)) === 'immutable' ||
     isZeroAddress(admin.adminAddress)
 
   const displayedExternalOwners = useMemo(() => {
@@ -300,7 +304,7 @@ export function DependencyInventoryBreakdown({
               <OwnerSection
                 key={admin.adminAddress}
                 admin={admin}
-                proxyType={proxyTypeMap.get(admin.adminAddress.toLowerCase())}
+                proxyType={proxyTypeMap.get(normalizeForLookup(admin.adminAddress))}
               />
             ))}
           </>

--- a/packages/protocolbeat/src/defidisco/scoringShared.tsx
+++ b/packages/protocolbeat/src/defidisco/scoringShared.tsx
@@ -8,6 +8,7 @@ import type {
   ApiAddressType,
   FunctionCapitalAnalysis,
 } from '../api/types'
+import { stripChainPrefix } from '../apps/discovery/defidisco/addressUtils'
 import { ProxyTypeTag } from '../apps/discovery/defidisco/ProxyTypeTag'
 import { usePanelStore } from '../apps/discovery/store/panel-store'
 
@@ -59,7 +60,7 @@ export function hasCapitalData(admin: any): admin is AdminDetailWithCapital {
 }
 
 export function isZeroAddress(address: string): boolean {
-  const normalized = address.toLowerCase().replace('eth:', '')
+  const normalized = stripChainPrefix(address).toLowerCase()
   return normalized === '0x0000000000000000000000000000000000000000'
 }
 


### PR DESCRIPTION
- Replace stub contracts list in compiler with getProject() data for proper contract names (config aliases, multisig threshold formatting)
- Include all discovered contracts, not just tagged ones
- Filter out multisig signer EOAs (unless they're also admins)
- Clean up multisig display names: remove percentage, use "Multisig"
- Use review-config name overrides when available
- Add excludeFromReview tag with UI toggle (ExcludeButton) for researchers to hide irrelevant contracts from compiled output
- Populate proxyType field from discovery data