### PR TITLE
Fix dependencies impact on funds and compilation

### DIFF
--- a/docs/developers/features/call-graph-analysis.md
+++ b/docs/developers/features/call-graph-analysis.md
@@ -94,8 +94,10 @@ Exported from `callGraph.ts`, used by `functionAnalysis.ts` and `v2Scoring.ts`:
 
 ### Function Analysis (`functionAnalysis.ts`)
 
-- **Impact** (permissioned only): Forward BFS via call graph, filters contracts with funds. Includes `callPath: CallPathStep[]` (shortest path)
+- **ABI-driven iteration**: Iterates ALL write functions from `discovered.json` ABIs (same set shown in the UI's permissions section), not just entries in `functions.json`. This ensures dependency detection covers every write function visible in the UI.
+- **Impact** (permissioned functions or functions with dependencies): Forward BFS via call graph, filters contracts with funds. Includes `callPath: CallPathStep[]` (shortest path)
 - **Dependencies** (all functions): Auto-detected external contracts (BFS + `isExternal` tag) merged with manual deps from `functions.json`. `isAutoDetected` flag distinguishes them
+- **Pre-loaded data**: Accepts optional `FunctionAnalysisPreloadedData` to avoid redundant file I/O when callers (e.g., `v2Scoring.ts`, `reviewCompiler.ts`) have already loaded functions, call graph, funds, or contract tags data
 - Response: `ApiFunctionAnalysisResponse` — `contracts[address][functionName] -> FunctionAnalysis`
 
 ### Key Types (in both backend and frontend `types.ts`)

--- a/docs/developers/features/scoring-and-review.md
+++ b/docs/developers/features/scoring-and-review.md
@@ -168,4 +168,6 @@ Protocol links (frontends, docs, GitHub, X, source code, other) stored as `resou
 - **Output**: `compiled-review.json` written to `packages/defiscan-frontend/public/data/<slug>/`
 - **Guard Conditions**: Requires `review-config.json` and `call-graph-data.json`; skips if either is missing
 - **Template Variables**: `{{variableName}}` resolved at compile time via `dataKeys` map
-- **TypeScript interfaces**: `CompiledReview`, `CompiledAdmin`, `CompiledDependency`, `CompiledFundHolder`, `CompiledFunction`, `CompiledContract`
+- **TypeScript interfaces**: `CompiledReview`, `CompiledAdmin`, `CompiledDependency`, `CompiledDependencyFunction`, `CompiledFundHolder`, `CompiledFunction`, `CompiledContract`
+- **Dependency funds**: Each `CompiledDependency` includes `totalFundsAtRisk` and `totalTokenValueAtRisk` (pre-computed, deduplicated across functions). Each `CompiledDependencyFunction` includes `directFundsUsd`, `directTokenValueUsd`, and `reachableContracts[]` with per-contract funds. These are computed server-side in the compiler, not client-side.
+- **Frontend subset**: `defiscan-frontend/scripts/compile-data.ts` uses a minimal subset of `CompiledReview` (not imported) for index aggregation — keep in sync when adding fields

--- a/packages/config/src/projects/liquity-v1/contract-tags.json
+++ b/packages/config/src/projects/liquity-v1/contract-tags.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "lastModified": "2026-03-10T08:33:12.258Z",
+  "lastModified": "2026-03-10T14:03:38.034Z",
   "tags": [
     {
       "contractAddress": "eth:0x5f4ec3df9cbd43714fe2740f5e3616155c5b8419",
@@ -28,7 +28,8 @@
     {
       "contractAddress": "eth:0x21f73d42eb58ba49ddb685dc29d3bf5c0f0373ca",
       "isExternal": true,
-      "timestamp": "2026-03-02T12:26:45.736Z"
+      "entity": "Chainlink",
+      "timestamp": "2026-03-10T14:03:38.034Z"
     },
     {
       "contractAddress": "eth:0x66017d22b0f8556afdd19fc67041899eb65a21bb",

--- a/packages/config/src/projects/liquity-v1/functions.json
+++ b/packages/config/src/projects/liquity-v1/functions.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "lastModified": "2026-03-04T12:51:12.035Z",
+  "lastModified": "2026-03-10T14:05:55.202Z",
   "contracts": {
     "eth:0x4c517d4e2c851ca76d7ec94b805269df0f2201de": {
       "functions": [
@@ -103,6 +103,16 @@
           "completedBy": {
             "author": "yvesboutellier",
             "date": "2026-03-04T12:50:19.560Z"
+          }
+        },
+        {
+          "functionName": "openTrove",
+          "isPermissioned": false,
+          "score": "unscored",
+          "timestamp": "2026-03-10T14:05:55.202Z",
+          "lastChangedBy": {
+            "author": "unknown",
+            "date": "2026-03-10T14:05:55.202Z"
           }
         }
       ]

--- a/packages/defiscan-frontend/public/data/Steakhouse-USDC/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/Steakhouse-USDC/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-10T10:29:36.396Z",
+  "compiledAt": "2026-03-10T14:27:58.842Z",
   "project": "Steakhouse-USDC",
   "metadata": {
     "protocolName": "Steakhouse USDC",
@@ -15,7 +15,7 @@
     "permissionedFunctionCount": 16,
     "scoredFunctionCount": 0,
     "adminCount": 7,
-    "dependencyCount": 8,
+    "dependencyCount": 9,
     "totalCapitalAtRisk": 169519102.78369424,
     "totalTokenValueAtRisk": 0,
     "totalTokenValue": 0
@@ -738,52 +738,100 @@
   ],
   "dependencies": [
     {
-      "address": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
-      "name": "Morpho Blue",
-      "description": "Core lending protocol where all vault deposits are allocated. The vault supplies USDC to various lending markets on Morpho Blue, making it the fundamental dependency for capital deployment, yield generation, and withdrawal operations. All vault positions and reallocations interact directly with Morpho Blue.",
-      "entity": "Morpho",
+      "address": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
+      "name": "GnosisSafe",
+      "description": "",
+      "entity": "Chainlink",
       "isAutoDetected": true,
       "viewOnlyPath": false,
       "calledFunctions": [
-        "idToMarketParams",
-        "market",
-        "extSloads",
-        "withdraw",
-        "supply",
-        "accrueInterest"
+        "isValidSignature"
       ],
       "functions": [
         {
-          "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
-          "contractName": "MetaMorpho",
-          "functionName": "setFee",
-          "viewOnlyPath": true
+          "contractAddress": "eth:0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD",
+          "contractName": "Unknown Contract",
+          "functionName": "checkNSignatures",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         },
         {
-          "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
-          "contractName": "MetaMorpho",
-          "functionName": "setFeeRecipient",
-          "viewOnlyPath": true
+          "contractAddress": "eth:0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD",
+          "contractName": "Unknown Contract",
+          "functionName": "checkSignatures",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         },
         {
-          "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
-          "contractName": "MetaMorpho",
-          "functionName": "submitCap",
-          "viewOnlyPath": true
+          "contractAddress": "eth:0x0A0e559bc3b0950a7e448F0d4894db195b9cf8DD",
+          "contractName": "Unknown Contract",
+          "functionName": "execTransaction",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         },
         {
-          "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
-          "contractName": "MetaMorpho",
-          "functionName": "updateWithdrawQueue",
-          "viewOnlyPath": true
+          "contractAddress": "eth:0x255c7705e8BB334DfCae438197f7C4297988085a",
+          "contractName": "Unknown Contract",
+          "functionName": "checkNSignatures",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         },
         {
-          "contractAddress": "eth:0xbeef01735c132ada46aa9aa4c54623caa92a64cb",
-          "contractName": "MetaMorpho",
-          "functionName": "reallocate",
-          "viewOnlyPath": false
+          "contractAddress": "eth:0x255c7705e8BB334DfCae438197f7C4297988085a",
+          "contractName": "Unknown Contract",
+          "functionName": "checkSignatures",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0x255c7705e8BB334DfCae438197f7C4297988085a",
+          "contractName": "Unknown Contract",
+          "functionName": "execTransaction",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0x827e86072B06674a077f592A531dcE4590aDeCdB",
+          "contractName": "Unknown Contract",
+          "functionName": "checkNSignatures",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0x827e86072B06674a077f592A531dcE4590aDeCdB",
+          "contractName": "Unknown Contract",
+          "functionName": "checkSignatures",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0x827e86072B06674a077f592A531dcE4590aDeCdB",
+          "contractName": "Unknown Contract",
+          "functionName": "execTransaction",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         }
-      ]
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
     },
     {
       "address": "eth:0x86392dc19c0b719886221c78ab11eb8cf5c52812",
@@ -795,12 +843,17 @@
       "calledFunctions": [],
       "functions": [
         {
-          "contractAddress": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+          "contractAddress": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
           "contractName": "Unknown Contract",
           "functionName": "liquidate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         }
-      ]
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
     },
     {
       "address": "eth:0x986b5e1e1755e3c2440e960477f25201b0a8bbd4",
@@ -812,12 +865,17 @@
       "calledFunctions": [],
       "functions": [
         {
-          "contractAddress": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+          "contractAddress": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
           "contractName": "Unknown Contract",
           "functionName": "liquidate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         }
-      ]
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
     },
     {
       "address": "eth:0xc0053f3fbccd593758258334dfce24c2a9a673ad",
@@ -829,12 +887,17 @@
       "calledFunctions": [],
       "functions": [
         {
-          "contractAddress": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+          "contractAddress": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
           "contractName": "Unknown Contract",
           "functionName": "liquidate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         }
-      ]
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
     },
     {
       "address": "eth:0x8fffffd4afb6115b954bd326cbe7b4ba576818f6",
@@ -846,12 +909,17 @@
       "calledFunctions": [],
       "functions": [
         {
-          "contractAddress": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+          "contractAddress": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
           "contractName": "Unknown Contract",
           "functionName": "liquidate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         }
-      ]
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
     },
     {
       "address": "eth:0xf4030086522a5beea4988f8ca5b36dbc97bee88c",
@@ -863,12 +931,17 @@
       "calledFunctions": [],
       "functions": [
         {
-          "contractAddress": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+          "contractAddress": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
           "contractName": "Unknown Contract",
           "functionName": "liquidate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         }
-      ]
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
     },
     {
       "address": "eth:0xfdfd9c85ad200c506cf9e21f1fd8dd01932fbb23",
@@ -880,12 +953,17 @@
       "calledFunctions": [],
       "functions": [
         {
-          "contractAddress": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+          "contractAddress": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
           "contractName": "Unknown Contract",
           "functionName": "liquidate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         }
-      ]
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
     },
     {
       "address": "eth:0x4f67e4d9bd67efa28236013288737d39aef48e79",
@@ -897,12 +975,127 @@
       "calledFunctions": [],
       "functions": [
         {
-          "contractAddress": "eth:0xbbbbbbbbbb9cc5e90e3b3af64bdaf62c37eeffcb",
+          "contractAddress": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
           "contractName": "Unknown Contract",
           "functionName": "liquidate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
         }
-      ]
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
+    },
+    {
+      "address": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+      "name": "Morpho Blue",
+      "description": "Core lending protocol where all vault deposits are allocated. The vault supplies USDC to various lending markets on Morpho Blue, making it the fundamental dependency for capital deployment, yield generation, and withdrawal operations. All vault positions and reallocations interact directly with Morpho Blue.",
+      "entity": "Morpho",
+      "isAutoDetected": true,
+      "viewOnlyPath": false,
+      "calledFunctions": [
+        "market",
+        "extSloads",
+        "idToMarketParams",
+        "accrueInterest",
+        "supply",
+        "withdraw"
+      ],
+      "functions": [
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "acceptCap",
+          "viewOnlyPath": true,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "deposit",
+          "viewOnlyPath": false,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "mint",
+          "viewOnlyPath": false,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "reallocate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "redeem",
+          "viewOnlyPath": false,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "setFee",
+          "viewOnlyPath": true,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "setFeeRecipient",
+          "viewOnlyPath": true,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "submitCap",
+          "viewOnlyPath": true,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "updateWithdrawQueue",
+          "viewOnlyPath": true,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB",
+          "contractName": "MetaMorpho",
+          "functionName": "withdraw",
+          "viewOnlyPath": false,
+          "directFundsUsd": 169519102.78369424,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        }
+      ],
+      "totalFundsAtRisk": 169519102.78369424,
+      "totalTokenValueAtRisk": 0
     }
   ],
   "funds": [

--- a/packages/defiscan-frontend/public/data/index.json
+++ b/packages/defiscan-frontend/public/data/index.json
@@ -75,49 +75,13 @@
     {
       "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
       "name": "Chainlink ETH/USD Price Feed",
-      "entity": null,
-      "totalFundsAtRisk": 266964315.50836384,
+      "entity": "Chainlink",
+      "totalFundsAtRisk": 91354642.20883462,
       "protocols": [
         {
           "slug": "liquity-v1",
           "name": "Liquity V1"
         },
-        {
-          "slug": "liquity-v2",
-          "name": "Liquity V2"
-        }
-      ]
-    },
-    {
-      "address": "eth:0xAd430500ECDa11E38C9bCB08a702274b94641112",
-      "name": "Tellor Price Feed",
-      "entity": "Tellor",
-      "totalFundsAtRisk": 175609673.29952922,
-      "protocols": [
-        {
-          "slug": "liquity-v1",
-          "name": "Liquity V1"
-        }
-      ]
-    },
-    {
-      "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
-      "name": "Chainlink stETH/USD Price Feed",
-      "entity": "Chainlink",
-      "totalFundsAtRisk": 91354642.20883462,
-      "protocols": [
-        {
-          "slug": "liquity-v2",
-          "name": "Liquity V2"
-        }
-      ]
-    },
-    {
-      "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
-      "name": "Lido wstETH Token",
-      "entity": "Lido",
-      "totalFundsAtRisk": 91354642.20883462,
-      "protocols": [
         {
           "slug": "liquity-v2",
           "name": "Liquity V2"
@@ -140,6 +104,30 @@
       "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
       "name": "RocketPool rETH Token",
       "entity": "RocketPool",
+      "totalFundsAtRisk": 91354642.20883462,
+      "protocols": [
+        {
+          "slug": "liquity-v2",
+          "name": "Liquity V2"
+        }
+      ]
+    },
+    {
+      "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
+      "name": "Chainlink stETH/USD Price Feed",
+      "entity": "Chainlink",
+      "totalFundsAtRisk": 91354642.20883462,
+      "protocols": [
+        {
+          "slug": "liquity-v2",
+          "name": "Liquity V2"
+        }
+      ]
+    },
+    {
+      "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
+      "name": "Lido wstETH Token",
+      "entity": "Lido",
       "totalFundsAtRisk": 91354642.20883462,
       "protocols": [
         {
@@ -229,6 +217,30 @@
         {
           "slug": "Steakhouse-USDC",
           "name": "Steakhouse USDC"
+        }
+      ]
+    },
+    {
+      "address": "eth:0xAd430500ECDa11E38C9bCB08a702274b94641112",
+      "name": "Tellor Price Feed",
+      "entity": "Tellor",
+      "totalFundsAtRisk": 0,
+      "protocols": [
+        {
+          "slug": "liquity-v1",
+          "name": "Liquity V1"
+        }
+      ]
+    },
+    {
+      "address": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
+      "name": "GnosisSafe",
+      "entity": "Chainlink",
+      "totalFundsAtRisk": 0,
+      "protocols": [
+        {
+          "slug": "liquity-v1",
+          "name": "Liquity V1"
         }
       ]
     }

--- a/packages/defiscan-frontend/public/data/index.json
+++ b/packages/defiscan-frontend/public/data/index.json
@@ -61,22 +61,10 @@
   },
   "dependencies": [
     {
-      "address": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
-      "name": "Morpho Blue",
-      "entity": "Morpho",
-      "totalFundsAtRisk": 1186633719.4858596,
-      "protocols": [
-        {
-          "slug": "Steakhouse-USDC",
-          "name": "Steakhouse USDC"
-        }
-      ]
-    },
-    {
       "address": "eth:0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
       "name": "Chainlink ETH/USD Price Feed",
       "entity": "Chainlink",
-      "totalFundsAtRisk": 91354642.20883462,
+      "totalFundsAtRisk": 288969848.1950712,
       "protocols": [
         {
           "slug": "liquity-v1",
@@ -89,10 +77,34 @@
       ]
     },
     {
+      "address": "eth:0xAd430500ECDa11E38C9bCB08a702274b94641112",
+      "name": "Tellor Price Feed",
+      "entity": "Tellor",
+      "totalFundsAtRisk": 175609673.29952922,
+      "protocols": [
+        {
+          "slug": "liquity-v1",
+          "name": "Liquity V1"
+        }
+      ]
+    },
+    {
+      "address": "eth:0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb",
+      "name": "Morpho Blue",
+      "entity": "Morpho",
+      "totalFundsAtRisk": 169519102.78369424,
+      "protocols": [
+        {
+          "slug": "Steakhouse-USDC",
+          "name": "Steakhouse USDC"
+        }
+      ]
+    },
+    {
       "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
       "name": "Chainlink rETH/ETH Price Feed",
       "entity": "Chainlink",
-      "totalFundsAtRisk": 91354642.20883462,
+      "totalFundsAtRisk": 113360174.89554201,
       "protocols": [
         {
           "slug": "liquity-v2",
@@ -104,7 +116,7 @@
       "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
       "name": "RocketPool rETH Token",
       "entity": "RocketPool",
-      "totalFundsAtRisk": 91354642.20883462,
+      "totalFundsAtRisk": 113360174.89554201,
       "protocols": [
         {
           "slug": "liquity-v2",
@@ -116,7 +128,7 @@
       "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
       "name": "Chainlink stETH/USD Price Feed",
       "entity": "Chainlink",
-      "totalFundsAtRisk": 91354642.20883462,
+      "totalFundsAtRisk": 110041751.19971398,
       "protocols": [
         {
           "slug": "liquity-v2",
@@ -128,11 +140,27 @@
       "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
       "name": "Lido wstETH Token",
       "entity": "Lido",
-      "totalFundsAtRisk": 91354642.20883462,
+      "totalFundsAtRisk": 110041751.19971398,
       "protocols": [
         {
           "slug": "liquity-v2",
           "name": "Liquity V2"
+        }
+      ]
+    },
+    {
+      "address": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
+      "name": "GnosisSafe",
+      "entity": "Chainlink",
+      "totalFundsAtRisk": 0,
+      "protocols": [
+        {
+          "slug": "Steakhouse-USDC",
+          "name": "Steakhouse USDC"
+        },
+        {
+          "slug": "liquity-v1",
+          "name": "Liquity V1"
         }
       ]
     },
@@ -217,30 +245,6 @@
         {
           "slug": "Steakhouse-USDC",
           "name": "Steakhouse USDC"
-        }
-      ]
-    },
-    {
-      "address": "eth:0xAd430500ECDa11E38C9bCB08a702274b94641112",
-      "name": "Tellor Price Feed",
-      "entity": "Tellor",
-      "totalFundsAtRisk": 0,
-      "protocols": [
-        {
-          "slug": "liquity-v1",
-          "name": "Liquity V1"
-        }
-      ]
-    },
-    {
-      "address": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
-      "name": "GnosisSafe",
-      "entity": "Chainlink",
-      "totalFundsAtRisk": 0,
-      "protocols": [
-        {
-          "slug": "liquity-v1",
-          "name": "Liquity V1"
         }
       ]
     }

--- a/packages/defiscan-frontend/public/data/liquity-v1/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/liquity-v1/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-10T09:03:16.409Z",
+  "compiledAt": "2026-03-10T14:54:06.399Z",
   "project": "liquity-v1",
   "metadata": {
     "protocolName": "Liquity V1",
@@ -15,7 +15,7 @@
     "permissionedFunctionCount": 17,
     "scoredFunctionCount": 0,
     "adminCount": 4,
-    "dependencyCount": 2,
+    "dependencyCount": 3,
     "totalCapitalAtRisk": 175609673.29952922,
     "totalTokenValueAtRisk": 31203451.700806536,
     "totalTokenValue": 60403451.700806536
@@ -287,7 +287,7 @@
       "description": "Primary oracle for ETH/USD pricing, used by PriceFeed.fetchPrice to determine collateral values for borrowing, liquidation, and redemption. Owned by a Chainlink 4/9 multisig. If the Chainlink feed fails or is frozen, the system automatically falls back to Tellor.",
       "entity": "Chainlink",
       "isAutoDetected": true,
-      "viewOnlyPath": true,
+      "viewOnlyPath": false,
       "calledFunctions": [
         "decimals",
         "latestRoundData",
@@ -295,18 +295,645 @@
       ],
       "functions": [
         {
-          "contractAddress": "eth:0x4c517d4e2c851ca76d7ec94b805269df0f2201de",
-          "contractName": "PriceFeed",
-          "functionName": "fetchPrice",
-          "viewOnlyPath": true
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x4c517d4e2c851ca76d7ec94b805269df0f2201de",
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "getETH",
+                "getLUSDDebt",
+                "decreaseLUSDDebt",
+                "increaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "moveETHGainToTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "repayLUSD",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawLUSD",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
+          "contractName": "PriceFeed",
+          "functionName": "fetchPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
           "contractName": "PriceFeed",
           "functionName": "setAddresses",
-          "viewOnlyPath": true
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+          "contractName": "StabilityPool",
+          "functionName": "withdrawETHGainToTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 14016796.67580555,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+              "name": "LQTY Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "transfer"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 29200000,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+          "contractName": "StabilityPool",
+          "functionName": "withdrawFromSP",
+          "viewOnlyPath": false,
+          "directFundsUsd": 14016796.67580555,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "returnFromPool"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+              "name": "LQTY Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "transfer"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 29200000,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "returnFromPool",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalLUSDDeposits",
+                "offset"
+              ],
+              "fundsUsd": 14016796.67580555,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+              "name": "CollSurplusPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "accountSurplus"
+              ],
+              "fundsUsd": 3224878.719068009,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+          "contractName": "TroveManager",
+          "functionName": "liquidate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "returnFromPool",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalLUSDDeposits",
+                "offset"
+              ],
+              "fundsUsd": 14016796.67580555,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+              "name": "CollSurplusPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "accountSurplus"
+              ],
+              "fundsUsd": 3224878.719068009,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+          "contractName": "TroveManager",
+          "functionName": "liquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "returnFromPool",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalLUSDDeposits",
+                "offset"
+              ],
+              "fundsUsd": 14016796.67580555,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+              "name": "CollSurplusPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "accountSurplus"
+              ],
+              "fundsUsd": 3224878.719068009,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "decreaseLUSDDebt",
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+              "name": "LQTY Token",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getDeploymentStartTime"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 29200000,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+              "name": "CollSurplusPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "accountSurplus"
+              ],
+              "fundsUsd": 3224878.719068009,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         }
-      ]
+      ],
+      "totalFundsAtRisk": 175609673.29952922,
+      "totalTokenValueAtRisk": 60403451.700806536
     },
     {
       "address": "eth:0xAd430500ECDa11E38C9bCB08a702274b94641112",
@@ -320,18 +947,678 @@
       ],
       "functions": [
         {
-          "contractAddress": "eth:0x4c517d4e2c851ca76d7ec94b805269df0f2201de",
-          "contractName": "PriceFeed",
-          "functionName": "fetchPrice",
-          "viewOnlyPath": true
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x4c517d4e2c851ca76d7ec94b805269df0f2201de",
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "getETH",
+                "getLUSDDebt",
+                "decreaseLUSDDebt",
+                "increaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "moveETHGainToTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "repayLUSD",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x24179CD81c9e782A4096035f7eC97fB8B783e007",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawLUSD",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
+          "contractName": "PriceFeed",
+          "functionName": "fetchPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
           "contractName": "PriceFeed",
           "functionName": "setAddresses",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+          "contractName": "StabilityPool",
+          "functionName": "withdrawETHGainToTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 14016796.67580555,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getETH",
+                "getLUSDDebt",
+                "sendETH",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+              "name": "LQTY Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "transfer"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 29200000,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+          "contractName": "StabilityPool",
+          "functionName": "withdrawFromSP",
+          "viewOnlyPath": false,
+          "directFundsUsd": 14016796.67580555,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "returnFromPool"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+              "name": "LQTY Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "transfer"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 29200000,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "returnFromPool",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalLUSDDeposits",
+                "offset"
+              ],
+              "fundsUsd": 14016796.67580555,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+              "name": "CollSurplusPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "accountSurplus"
+              ],
+              "fundsUsd": 3224878.719068009,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+          "contractName": "TroveManager",
+          "functionName": "liquidate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "returnFromPool",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalLUSDDeposits",
+                "offset"
+              ],
+              "fundsUsd": 14016796.67580555,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+              "name": "CollSurplusPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "accountSurplus"
+              ],
+              "fundsUsd": 3224878.719068009,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+          "contractName": "TroveManager",
+          "functionName": "liquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt",
+                "decreaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "returnFromPool",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x66017D22b0f8556afDd19FC67041899Eb65a21bb",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalLUSDDeposits",
+                "offset"
+              ],
+              "fundsUsd": 14016796.67580555,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+              "name": "CollSurplusPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "accountSurplus"
+              ],
+              "fundsUsd": 3224878.719068009,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0xDf9Eb223bAFBE5c5271415C75aeCD68C21fE3D7F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "sendETH",
+                "decreaseLUSDDebt",
+                "getETH",
+                "getLUSDDebt",
+                "increaseLUSDDebt"
+              ],
+              "fundsUsd": 158367997.90465567,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
+              "name": "LUSD Stablecoin Token",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31203451.700806536,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6DEA81C8171D0bA574754EF6F8b412F2Ed88c54D",
+              "name": "LQTY Token",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getDeploymentStartTime"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 29200000,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x3D32e8b97Ed5881324241Cf03b2DA5E2EBcE5521",
+              "name": "CollSurplusPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "accountSurplus"
+              ],
+              "fundsUsd": 3224878.719068009,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         }
-      ]
+      ],
+      "totalFundsAtRisk": 175609673.29952922,
+      "totalTokenValueAtRisk": 60403451.700806536
+    },
+    {
+      "address": "eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA",
+      "name": "GnosisSafe",
+      "description": "",
+      "entity": "Chainlink",
+      "isAutoDetected": true,
+      "viewOnlyPath": false,
+      "calledFunctions": [
+        "isValidSignature"
+      ],
+      "functions": [
+        {
+          "contractAddress": "eth:0xb8a9faDA75c6d891fB77a7988Ff9BaD9e485Ca1C",
+          "contractName": "3/8 38% GnosisSafe",
+          "functionName": "execTransaction",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        },
+        {
+          "contractAddress": "eth:0xb8a9faDA75c6d891fB77a7988Ff9BaD9e485Ca1C",
+          "contractName": "3/8 38% GnosisSafe",
+          "functionName": "isValidSignature",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": []
+        }
+      ],
+      "totalFundsAtRisk": 0,
+      "totalTokenValueAtRisk": 0
     }
   ],
   "funds": [
@@ -553,7 +1840,7 @@
       "name": "4/9 Multisig",
       "isExternal": true,
       "isGovernance": false,
-      "entity": null,
+      "entity": "Chainlink",
       "proxyType": "gnosis safe"
     },
     {

--- a/packages/defiscan-frontend/public/data/liquity-v2/compiled-review.json
+++ b/packages/defiscan-frontend/public/data/liquity-v2/compiled-review.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "compiledAt": "2026-03-10T09:03:16.180Z",
+  "compiledAt": "2026-03-10T15:01:09.924Z",
   "project": "liquity-v2",
   "metadata": {
     "protocolName": "Liquity V2",
@@ -3895,186 +3895,9055 @@
       ],
       "functions": [
         {
-          "contractAddress": "eth:0x4c517D4e2C851CA76d7eC94B805269Df0f2201De",
-          "contractName": "Unknown Contract",
+          "contractAddress": "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B",
+          "contractName": "RETHPriceFeed",
           "functionName": "fetchPrice",
-          "viewOnlyPath": false
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractAddress": "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B",
+          "contractName": "RETHPriceFeed",
+          "functionName": "fetchRedemptionPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTroveInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustZombieTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "burn",
+                "balanceOf",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "kickFromBatch",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
           "contractName": "BorrowerOperations",
           "functionName": "openTrove",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "removeFromBatch",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "repayBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "shutdown",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x372ABD1810eAF23Cb9D941BbE7596DFb2c46BC65",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getTotalBoldDeposits"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
+          "functionName": "adjustZombieTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "burn",
+                "balanceOf",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "kickFromBatch",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "removeFromBatch",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "switchBatchManager",
-          "viewOnlyPath": false
+          "functionName": "repayBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "shutdown",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "setShutdownFlag",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTrove",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "removeFromBatch",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "switchBatchManager",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getTotalBoldDeposits"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xCC5F8102eb670c89a4a3c567C13851260303c24F",
+          "contractName": "WETHPriceFeed",
+          "functionName": "fetchPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xCC5F8102eb670c89a4a3c567C13851260303c24F",
+          "contractName": "WETHPriceFeed",
+          "functionName": "fetchRedemptionPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E",
+          "contractName": "WSTETHPriceFeed",
+          "functionName": "fetchPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E",
+          "contractName": "WSTETHPriceFeed",
+          "functionName": "fetchRedemptionPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
-          "functionName": "shutdown",
-          "viewOnlyPath": false
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
-          "functionName": "openTrove",
-          "viewOnlyPath": false
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
           "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
+          "functionName": "adjustZombieTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "burn",
+                "balanceOf",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
           "functionName": "kickFromBatch",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
           "functionName": "removeFromBatch",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
-          "functionName": "switchBatchManager",
-          "viewOnlyPath": false
+          "functionName": "repayBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0x372abd1810eaf23cb9d941bbe7596dfb2c46bc65",
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
           "functionName": "shutdown",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "setShutdownFlag",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xf949982B91C8c61e952B3bA942cbbfaef5386684",
+          "contractName": "CollateralRegistry",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "totalSupply",
+                "burn",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance",
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         }
-      ]
+      ],
+      "totalFundsAtRisk": 113360174.89554201,
+      "totalTokenValueAtRisk": 31325385.25346636
+    },
+    {
+      "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
+      "name": "Chainlink rETH/ETH Price Feed",
+      "description": "Price oracle used by the RETHPriceFeed contract to value rETH collateral. Combined with the ETH/USD price to derive the rETH/USD price used in the rETH borrowing branch for collateral ratio calculations.",
+      "entity": "Chainlink",
+      "isAutoDetected": true,
+      "viewOnlyPath": false,
+      "calledFunctions": [
+        "latestRoundData"
+      ],
+      "functions": [
+        {
+          "contractAddress": "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B",
+          "contractName": "RETHPriceFeed",
+          "functionName": "fetchPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B",
+          "contractName": "RETHPriceFeed",
+          "functionName": "fetchRedemptionPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getTotalBoldDeposits"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getTotalBoldDeposits"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTroveInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustZombieTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "burn",
+                "balanceOf",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "kickFromBatch",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "removeFromBatch",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "repayBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "shutdown",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "setShutdownFlag",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xf949982B91C8c61e952B3bA942cbbfaef5386684",
+          "contractName": "CollateralRegistry",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "totalSupply",
+                "burn",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance",
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        }
+      ],
+      "totalFundsAtRisk": 113360174.89554201,
+      "totalTokenValueAtRisk": 31325385.25346636
+    },
+    {
+      "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
+      "name": "RocketPool rETH Token",
+      "description": "Rocket Pool's liquid staking token used as collateral in the rETH borrowing branch. The RETHPriceFeed contract queries the rETH exchange rate to derive USD pricing. The ActivePool for this branch holds $14.27M in rETH deposits.",
+      "entity": "RocketPool",
+      "isAutoDetected": true,
+      "viewOnlyPath": false,
+      "calledFunctions": [
+        "getExchangeRate"
+      ],
+      "functions": [
+        {
+          "contractAddress": "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B",
+          "contractName": "RETHPriceFeed",
+          "functionName": "fetchPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x34F1E9c7dcc279ec70d3c4488EB2D80FBa8B7b2B",
+          "contractName": "RETHPriceFeed",
+          "functionName": "fetchRedemptionPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0x7bcb64B2c9206a5B699eD43363f6F98D4776Cf5A",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getTotalBoldDeposits"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xA2895d6A3bf110561Dfe4b71cA539d84e1928B22",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "batchLiquidateTroves",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "sendCollToDefaultPool",
+                "getCollBalance",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "offset",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "getUnbackedPortionPriceAndRedeemability",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": true,
+              "calledFunctions": [
+                "getTotalBoldDeposits"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xb2B2ABEb5C357a234363FF5D180912D319e3e19e",
+          "contractName": "TroveManager",
+          "functionName": "urgentRedemption",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustTroveInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "adjustZombieTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "burn",
+                "balanceOf",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "kickFromBatch",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "removeFromBatch",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "repayBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "shutdown",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "setShutdownFlag",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl",
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xd442E41019B7F5C4dD78F50dc03726C446148695",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 3318423.695828019,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xf949982B91C8c61e952B3bA942cbbfaef5386684",
+          "contractName": "CollateralRegistry",
+          "functionName": "redeemCollateral",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "totalSupply",
+                "burn",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getBoldDebt",
+                "getCollBalance",
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "mintBatchManagementFeeAndAccountForChange",
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getTotalBoldDeposits",
+                "getCollBalance",
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        }
+      ],
+      "totalFundsAtRisk": 113360174.89554201,
+      "totalTokenValueAtRisk": 31325385.25346636
     },
     {
       "address": "eth:0xCfE54B5cD566aB89272946F602D76Ea879CAb4a8",
@@ -4090,64 +12959,1437 @@
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "openTrove",
-          "viewOnlyPath": false
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
+          "functionName": "adjustZombieTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "burn",
+                "balanceOf",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "kickFromBatch",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "openTroveAndJoinInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "removeFromBatch",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "switchBatchManager",
-          "viewOnlyPath": false
+          "functionName": "repayBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "shutdown",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "setShutdownFlag",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E",
+          "contractName": "WSTETHPriceFeed",
+          "functionName": "fetchPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E",
+          "contractName": "WSTETHPriceFeed",
+          "functionName": "fetchRedemptionPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         }
-      ]
+      ],
+      "totalFundsAtRisk": 110041751.19971398,
+      "totalTokenValueAtRisk": 31325385.25346636
     },
     {
       "address": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
@@ -4163,198 +14405,1437 @@
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "openTrove",
-          "viewOnlyPath": false
+          "functionName": "addColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
+          "functionName": "adjustTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
+          "functionName": "adjustZombieTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
+          "functionName": "closeTrove",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "sendColl",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "burn",
+                "balanceOf",
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "kickFromBatch",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
           "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
-          "contractName": "BorrowerOperations",
-          "functionName": "removeFromBatch",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
-          "contractName": "BorrowerOperations",
-          "functionName": "switchBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
-          "contractName": "BorrowerOperations",
-          "functionName": "shutdown",
-          "viewOnlyPath": false
-        }
-      ]
-    },
-    {
-      "address": "eth:0x536218f9E9Eb48863970252233c8F271f554C2d0",
-      "name": "Chainlink rETH/ETH Price Feed",
-      "description": "Price oracle used by the RETHPriceFeed contract to value rETH collateral. Combined with the ETH/USD price to derive the rETH/USD price used in the rETH borrowing branch for collateral ratio calculations.",
-      "entity": "Chainlink",
-      "isAutoDetected": true,
-      "viewOnlyPath": false,
-      "calledFunctions": [
-        "latestRoundData"
-      ],
-      "functions": [
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
           "contractName": "BorrowerOperations",
           "functionName": "openTrove",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "removeFromBatch",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
-          "functionName": "switchBatchManager",
-          "viewOnlyPath": false
+          "functionName": "repayBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         },
         {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setBatchManagerAnnualInterestRate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "setInterestIndividualDelegate",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
           "contractName": "BorrowerOperations",
           "functionName": "shutdown",
-          "viewOnlyPath": false
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getCollBalance",
+                "getBoldDebt",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "setShutdownFlag",
+                "mintAggInterest"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "switchBatchManager",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterestAndAccountForTroveChange",
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "getCollBalance",
+                "getBoldDebt"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawBold",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xa741A32f9dcFe6aDBa088fD0f97e90742d7d5DA3",
+          "contractName": "BorrowerOperations",
+          "functionName": "withdrawColl",
+          "viewOnlyPath": false,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x531a8f99c70D6A56A7CEe02d6B4281650d7919a0",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "getNewApproxAvgInterestRateFromTroveChange",
+                "mintAggInterestAndAccountForTroveChange",
+                "getCollBalance",
+                "getBoldDebt",
+                "sendColl",
+                "accountForReceivedColl"
+              ],
+              "fundsUsd": 64143216.414889336,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "balanceOf",
+                "mint",
+                "burn"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9074D72cc82DaD1e13E454755Aa8f144c479532F",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "receiveColl"
+              ],
+              "fundsUsd": 14274796.542198261,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x9502b7c397E9aa22FE9dB7EF7DAF21cD2AEBe56B",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 11136200.135608597,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E",
+          "contractName": "WSTETHPriceFeed",
+          "functionName": "fetchPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
+        },
+        {
+          "contractAddress": "eth:0xe7Aa2Ba9E086A379d3beb224098bC634a46e314E",
+          "contractName": "WSTETHPriceFeed",
+          "functionName": "fetchRedemptionPrice",
+          "viewOnlyPath": true,
+          "directFundsUsd": 0,
+          "directTokenValueUsd": 0,
+          "reachableContracts": [
+            {
+              "address": "eth:0x6440f144b7e50D6a8439336510312d2F54beB01D",
+              "name": "BoldToken",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mint"
+              ],
+              "fundsUsd": 0,
+              "tokenValueUsd": 31325385.25346636,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0xeB5A8C825582965f1d84606E078620a84ab16AfE",
+              "name": "ActivePool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "mintAggInterest",
+                "setShutdownFlag"
+              ],
+              "fundsUsd": 12936629.251747033,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            },
+            {
+              "address": "eth:0x5721cbbd64fc7Ae3Ef44A0A3F9a790A9264Cf9BF",
+              "name": "StabilityPool",
+              "viewOnlyPath": false,
+              "calledFunctions": [
+                "triggerBoldRewards"
+              ],
+              "fundsUsd": 7550908.855270761,
+              "tokenValueUsd": 0,
+              "fundsAtRisk": true
+            }
+          ]
         }
-      ]
-    },
-    {
-      "address": "eth:0xae78736Cd615f374D3085123A210448E74Fc6393",
-      "name": "RocketPool rETH Token",
-      "description": "Rocket Pool's liquid staking token used as collateral in the rETH borrowing branch. The RETHPriceFeed contract queries the rETH exchange rate to derive USD pricing. The ActivePool for this branch holds $14.27M in rETH deposits.",
-      "entity": "RocketPool",
-      "isAutoDetected": true,
-      "viewOnlyPath": false,
-      "calledFunctions": [
-        "getExchangeRate"
       ],
-      "functions": [
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTrove",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "openTroveAndJoinInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "adjustTroveInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestIndividualDelegate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setBatchManagerAnnualInterestRate",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "setInterestBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "removeFromBatch",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "switchBatchManager",
-          "viewOnlyPath": false
-        },
-        {
-          "contractAddress": "eth:0xe8119fC02953B27a1b48D2573855738485A17329",
-          "contractName": "BorrowerOperations",
-          "functionName": "shutdown",
-          "viewOnlyPath": false
-        }
-      ]
+      "totalFundsAtRisk": 110041751.19971398,
+      "totalTokenValueAtRisk": 31325385.25346636
     }
   ],
   "funds": [

--- a/packages/defiscan-frontend/scripts/compile-data.ts
+++ b/packages/defiscan-frontend/scripts/compile-data.ts
@@ -35,6 +35,7 @@ interface CompiledReview {
     address: string
     name: string
     entity: string | null
+    totalFundsAtRisk: number
     functions: { contractAddress: string; contractName: string; functionName: string }[]
   }[]
   funds: {
@@ -197,32 +198,18 @@ function main() {
       totalTokenValueAtRisk += protocolTokenValue
     }
 
-    // Aggregate dependencies across protocols
-    // For each dependency, sum capital of admins whose functions use this dependency
-    // This avoids attributing the entire protocol TVL to every dependency
+    // Aggregate dependencies across protocols using pre-computed funds
     for (const dep of review.dependencies) {
       const key = dep.address
-      // Compute capital controlled by admins that call through this dependency
-      const depContractAddresses = new Set(dep.functions.map((f) => f.contractAddress))
-      let depCapital = 0
-      for (const admin of review.admins) {
-        const usesThisDep = admin.functions.some(
-          (f) => depContractAddresses.has(f.contractAddress),
-        )
-        if (usesThisDep) {
-          depCapital += admin.totalDirectCapital
-        }
-      }
-
       const existing = depMap.get(key)
       if (existing) {
         existing.protocols.push({ slug, name: review.metadata.protocolName })
-        existing.totalFundsAtRisk += depCapital
+        existing.totalFundsAtRisk += dep.totalFundsAtRisk
       } else {
         depMap.set(key, {
           name: dep.name,
           entity: dep.entity,
-          totalFundsAtRisk: depCapital,
+          totalFundsAtRisk: dep.totalFundsAtRisk,
           protocols: [{ slug, name: review.metadata.protocolName }],
         })
       }

--- a/packages/defiscan-frontend/scripts/compile-data.ts
+++ b/packages/defiscan-frontend/scripts/compile-data.ts
@@ -6,6 +6,8 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 
+// Minimal subset of CompiledReview (from src/types.ts) — only fields needed for index aggregation.
+// Keep in sync with the full type when adding new aggregated fields.
 interface CompiledReview {
   metadata: {
     protocolName: string

--- a/packages/defiscan-frontend/src/pages/review/views/explorer/DepsTab.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/explorer/DepsTab.tsx
@@ -4,11 +4,7 @@ import { Badge } from '../../../../components/Badge'
 import { AddressDisplay } from '../../../../components/AddressDisplay'
 import { UsdValue } from '../../../../components/UsdValue'
 import { formatUsdValue } from '../../../../utils/format'
-import {
-  buildFunctionContractFundsMap,
-  computeDepFundsAtRisk,
-  getFunctionFunds,
-} from '../../../../utils/dependencies'
+import { getDepFunctionFunds } from '../../../../utils/dependencies'
 import type { CompiledReview, CompiledDependency } from '../../../../types'
 import { ShareableDiagram } from '../../../../components/ShareableDiagram'
 import { DependencyRiskDiagram } from './svg/DependencyRiskDiagram'
@@ -25,19 +21,14 @@ export function DepsTab({ review }: DepsTabProps) {
   const [sortField, setSortField] = useState<SortField>('fundsAtRisk')
   const [sortDir, setSortDir] = useState<SortDir>('desc')
 
-  const fnContractMap = useMemo(
-    () => buildFunctionContractFundsMap(review),
-    [review],
-  )
-
-  // Pre-compute deduplicated funds at risk for each dependency
+  // Use pre-computed funds from compiled review
   const depsWithFunds = useMemo(
     () =>
       dependencies.map((dep) => ({
         dep,
-        fundsAtRisk: computeDepFundsAtRisk(dep, fnContractMap),
+        fundsAtRisk: dep.totalFundsAtRisk,
       })),
-    [dependencies, fnContractMap],
+    [dependencies],
   )
 
   const sorted = useMemo(() => {
@@ -191,7 +182,6 @@ export function DepsTab({ review }: DepsTabProps) {
                 key={dep.address}
                 dep={dep}
                 fundsAtRisk={fundsAtRisk}
-                fnContractMap={fnContractMap}
               />
             ))}
           </tbody>
@@ -204,11 +194,9 @@ export function DepsTab({ review }: DepsTabProps) {
 function DependencyRow({
   dep,
   fundsAtRisk,
-  fnContractMap,
 }: {
   dep: CompiledDependency
   fundsAtRisk: number
-  fnContractMap: Map<string, Map<string, number>>
 }) {
   const [expanded, setExpanded] = useState(false)
 
@@ -287,10 +275,7 @@ function DependencyRow({
             colSpan={5}
             className="px-0 py-0 bg-bg-muted/50 border-b border-border"
           >
-            <ExpandedDependency
-              dep={dep}
-              fnContractMap={fnContractMap}
-            />
+            <ExpandedDependency dep={dep} />
           </td>
         </tr>
       )}
@@ -298,13 +283,7 @@ function DependencyRow({
   )
 }
 
-function ExpandedDependency({
-  dep,
-  fnContractMap,
-}: {
-  dep: CompiledDependency
-  fnContractMap: Map<string, Map<string, number>>
-}) {
+function ExpandedDependency({ dep }: { dep: CompiledDependency }) {
   // Separate read and write functions
   const readFns = dep.functions.filter((f) => f.viewOnlyPath)
   const writeFns = dep.functions.filter((f) => !f.viewOnlyPath)
@@ -346,7 +325,7 @@ function ExpandedDependency({
               write access
             </span>
           </div>
-          <FunctionList functions={writeFns} fnContractMap={fnContractMap} />
+          <FunctionList functions={writeFns} />
         </div>
       )}
 
@@ -360,7 +339,7 @@ function ExpandedDependency({
               read-only access
             </span>
           </div>
-          <FunctionList functions={readFns} fnContractMap={fnContractMap} />
+          <FunctionList functions={readFns} />
         </div>
       )}
     </div>
@@ -369,10 +348,8 @@ function ExpandedDependency({
 
 function FunctionList({
   functions,
-  fnContractMap,
 }: {
   functions: CompiledDependency['functions']
-  fnContractMap: Map<string, Map<string, number>>
 }) {
   return (
     <table className="w-full text-xs">
@@ -385,11 +362,7 @@ function FunctionList({
       </thead>
       <tbody>
         {functions.map((fn) => {
-          const capital = getFunctionFunds(
-            fn.contractAddress,
-            fn.functionName,
-            fnContractMap,
-          )
+          const capital = getDepFunctionFunds(fn)
           return (
             <tr
               key={`${fn.contractAddress}-${fn.functionName}`}

--- a/packages/defiscan-frontend/src/pages/review/views/report/DependencyCards.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/report/DependencyCards.tsx
@@ -1,13 +1,9 @@
-import { useState, useMemo } from 'react'
+import { useState } from 'react'
 import { Badge } from '../../../../components/Badge'
 import { AddressDisplay } from '../../../../components/AddressDisplay'
 import { GlossaryTooltip } from '../../../../components/GlossaryTooltip'
 import { formatUsdValue } from '../../../../utils/format'
-import {
-  buildFunctionContractFundsMap,
-  computeDepFundsAtRisk,
-  getFunctionFunds,
-} from '../../../../utils/dependencies'
+import { getDepFunctionFunds } from '../../../../utils/dependencies'
 import type { CompiledReview, CompiledDependency } from '../../../../types'
 
 interface DependencyCardsProps {
@@ -26,10 +22,6 @@ const DEP_BAR_COLORS = [
 export function DependencyCards({ review }: DependencyCardsProps) {
   const { dependencies } = review
   const [expandedDeps, setExpandedDeps] = useState<Set<string>>(new Set())
-  const fnContractMap = useMemo(
-    () => buildFunctionContractFundsMap(review),
-    [review],
-  )
 
   if (dependencies.length === 0) {
     return (
@@ -129,7 +121,7 @@ export function DependencyCards({ review }: DependencyCardsProps) {
           // Sort deps by funds at risk descending within each group
           const depsWithFunds = deps.map((dep) => ({
             dep,
-            fundsAtRisk: computeDepFundsAtRisk(dep, fnContractMap),
+            fundsAtRisk: dep.totalFundsAtRisk,
           }))
           depsWithFunds.sort((a, b) => b.fundsAtRisk - a.fundsAtRisk)
           const groupTotal = depsWithFunds.reduce(
@@ -149,7 +141,6 @@ export function DependencyCards({ review }: DependencyCardsProps) {
               groupTotal={groupTotal}
               expandedSet={expandedDeps}
               onToggle={toggleDep}
-              fnContractMap={fnContractMap}
             />
           )
         })}
@@ -164,14 +155,12 @@ function DepDistributionChart({
   groupTotal,
   expandedSet,
   onToggle,
-  fnContractMap,
 }: {
   title: string | undefined
   deps: { dep: CompiledDependency; fundsAtRisk: number }[]
   groupTotal: number
   expandedSet: Set<string>
   onToggle: (key: string) => void
-  fnContractMap: Map<string, Map<string, number>>
 }) {
   const maxFunds = Math.max(...deps.map((d) => d.fundsAtRisk), 0)
 
@@ -239,12 +228,7 @@ function DepDistributionChart({
                 )}
               </button>
 
-              {isExpanded && (
-                <DepExpandedContent
-                  dep={dep}
-                  fnContractMap={fnContractMap}
-                />
-              )}
+              {isExpanded && <DepExpandedContent dep={dep} />}
             </div>
           )
         })}
@@ -253,13 +237,7 @@ function DepDistributionChart({
   )
 }
 
-function DepExpandedContent({
-  dep,
-  fnContractMap,
-}: {
-  dep: CompiledDependency
-  fnContractMap: Map<string, Map<string, number>>
-}) {
+function DepExpandedContent({ dep }: { dep: CompiledDependency }) {
   const readFns = dep.functions.filter((f) => f.viewOnlyPath)
   const writeFns = dep.functions.filter((f) => !f.viewOnlyPath)
 
@@ -310,11 +288,7 @@ function DepExpandedContent({
           </p>
           <div className="space-y-1">
             {dep.functions.map((fn) => {
-              const fnFunds = getFunctionFunds(
-                fn.contractAddress,
-                fn.functionName,
-                fnContractMap,
-              )
+              const fnFunds = getDepFunctionFunds(fn)
               return (
                 <div
                   key={`${fn.contractAddress}-${fn.functionName}`}

--- a/packages/defiscan-frontend/src/types.ts
+++ b/packages/defiscan-frontend/src/types.ts
@@ -98,6 +98,16 @@ export interface CompiledReachableContract {
   fundsAtRisk: boolean
 }
 
+export interface CompiledDependencyFunction {
+  contractAddress: string
+  contractName: string
+  functionName: string
+  viewOnlyPath: boolean
+  directFundsUsd: number
+  directTokenValueUsd: number
+  reachableContracts: CompiledReachableContract[]
+}
+
 export interface CompiledDependency {
   address: string
   name: string
@@ -106,12 +116,9 @@ export interface CompiledDependency {
   isAutoDetected: boolean
   viewOnlyPath: boolean
   calledFunctions: string[]
-  functions: {
-    contractAddress: string
-    contractName: string
-    functionName: string
-    viewOnlyPath: boolean
-  }[]
+  functions: CompiledDependencyFunction[]
+  totalFundsAtRisk: number
+  totalTokenValueAtRisk: number
 }
 
 export interface CompiledFundHolder {

--- a/packages/defiscan-frontend/src/utils/dependencies.ts
+++ b/packages/defiscan-frontend/src/utils/dependencies.ts
@@ -1,86 +1,13 @@
-import type { CompiledReview, CompiledDependency } from '../types'
+import type { CompiledDependencyFunction } from '../types'
 
 /**
- * Build a per-function map of contract → funds from admin data.
- *
- * Key: "contractAddress:functionName" (lowercase)
- * Value: Map<contractAddress, fundsUsd> — the unique contracts whose funds
- * are exposed through this function (its own contract + reachable contracts).
+ * Compute per-function funds from the compiled dependency function data.
+ * Sums direct funds + reachable contract funds.
  */
-export function buildFunctionContractFundsMap(
-  review: CompiledReview,
-): Map<string, Map<string, number>> {
-  const map = new Map<string, Map<string, number>>()
-  for (const admin of review.admins) {
-    for (const fn of admin.functions) {
-      const key = `${fn.contractAddress.toLowerCase()}:${fn.functionName}`
-      const existing = map.get(key)
-      const contracts = existing ?? new Map<string, number>()
-
-      // Direct funds (the contract the function lives on)
-      if (fn.directFundsUsd > 0) {
-        const addr = fn.contractAddress.toLowerCase()
-        contracts.set(addr, Math.max(contracts.get(addr) ?? 0, fn.directFundsUsd))
-      }
-
-      // Reachable contracts with funds at risk
-      for (const rc of fn.reachableContracts) {
-        if (!rc.fundsAtRisk || rc.fundsUsd <= 0) continue
-        const addr = rc.address.toLowerCase()
-        contracts.set(addr, Math.max(contracts.get(addr) ?? 0, rc.fundsUsd))
-      }
-
-      map.set(key, contracts)
-    }
-  }
-  return map
-}
-
-/**
- * Compute deduplicated funds at risk through a dependency.
- *
- * Collects all unique contracts-with-funds across every caller function,
- * deduplicating by contract address so the same contract isn't counted twice
- * when multiple functions share it.
- */
-export function computeDepFundsAtRisk(
-  dep: CompiledDependency,
-  fnContractMap: Map<string, Map<string, number>>,
-): number {
-  // Merge all contract → funds across caller functions
-  const merged = new Map<string, number>()
-  for (const fn of dep.functions) {
-    const key = `${fn.contractAddress.toLowerCase()}:${fn.functionName}`
-    const contracts = fnContractMap.get(key)
-    if (!contracts) continue
-    for (const [addr, funds] of contracts) {
-      merged.set(addr, Math.max(merged.get(addr) ?? 0, funds))
-    }
-  }
-
-  let total = 0
-  for (const funds of merged.values()) {
-    total += funds
-  }
-  return total
-}
-
-/**
- * Compute per-function funds (still useful for the function breakdown table).
- * This DOES double-count across functions on purpose — it shows each
- * function's individual exposure.
- */
-export function getFunctionFunds(
-  contractAddress: string,
-  functionName: string,
-  fnContractMap: Map<string, Map<string, number>>,
-): number {
-  const key = `${contractAddress.toLowerCase()}:${functionName}`
-  const contracts = fnContractMap.get(key)
-  if (!contracts) return 0
-  let total = 0
-  for (const funds of contracts.values()) {
-    total += funds
+export function getDepFunctionFunds(fn: CompiledDependencyFunction): number {
+  let total = fn.directFundsUsd
+  for (const rc of fn.reachableContracts) {
+    total += rc.fundsUsd
   }
   return total
 }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/functionAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/functionAnalysis.ts
@@ -1,4 +1,6 @@
 import type { DiscoveryPaths } from '@l2beat/discovery'
+import * as fs from 'fs'
+import * as path from 'path'
 import { addressesEqual, normalizeChainAddress } from './addressUtils'
 import {
   buildExternalAddressSet,
@@ -20,11 +22,112 @@ import type {
   ContractTag,
   FunctionAnalysis,
   FunctionDependencyEntry,
+  FunctionEntry,
   FunctionImpactEntry,
 } from './types'
 
+// ============================================================================
+// ABI Write Function Extraction
+// ============================================================================
+
+const READ_MARKERS = [' view ', ' pure ']
+const FUNCTION_NAME_REGEX = /^function\s+(\w+)\s*\(/
+
+/**
+ * Extract all write function names from an ABI entry list.
+ * Mirrors the frontend logic in PermissionsDisplay.tsx: filters out
+ * events, errors, and functions containing ' view ' or ' pure '.
+ */
+function extractWriteFunctionNames(abiEntries: string[]): string[] {
+  const names: string[] = []
+  for (const entry of abiEntries) {
+    // Skip non-function entries (events, errors, constructors)
+    if (
+      entry.startsWith('event') ||
+      entry.startsWith('error') ||
+      entry.startsWith('constructor')
+    ) {
+      continue
+    }
+    // Skip view/pure functions
+    if (READ_MARKERS.some((marker) => entry.includes(marker))) continue
+    // Extract function name
+    const match = entry.match(FUNCTION_NAME_REGEX)
+    if (match?.[1]) {
+      names.push(match[1])
+    }
+  }
+  return names
+}
+
+/**
+ * Build the set of all write functions per contract from discovered.json ABIs.
+ * For each contract entry, finds the corresponding ABI (using the contract's
+ * own address, plus implementation addresses for proxies) and extracts write functions.
+ *
+ * Returns Record<contractAddress, Set<functionName>>.
+ */
+function buildWriteFunctionsFromAbis(
+  discoveredPath: string,
+): Record<string, Set<string>> {
+  if (!fs.existsSync(discoveredPath)) {
+    return {}
+  }
+
+  try {
+    const fileContent = fs.readFileSync(discoveredPath, 'utf8')
+    const discovered = JSON.parse(fileContent)
+
+    const abis: Record<string, string[]> = discovered.abis ?? {}
+    const entries: any[] = discovered.entries ?? []
+    const result: Record<string, Set<string>> = {}
+
+    for (const entry of entries) {
+      if (entry.type !== 'Contract') continue
+
+      const contractAddress: string = entry.address
+      const functionNames = new Set<string>()
+
+      // Collect ABI addresses: the contract itself + any implementations
+      const abiAddresses: string[] = [contractAddress]
+      const implValue = entry.values?.$implementation
+      if (typeof implValue === 'string') {
+        abiAddresses.push(implValue)
+      } else if (Array.isArray(implValue)) {
+        abiAddresses.push(...implValue.filter((v: any) => typeof v === 'string'))
+      }
+
+      // Extract write functions from each ABI
+      for (const abiAddr of abiAddresses) {
+        const abiEntries = abis[abiAddr]
+        if (!abiEntries) continue
+        for (const name of extractWriteFunctionNames(abiEntries)) {
+          functionNames.add(name)
+        }
+      }
+
+      if (functionNames.size > 0) {
+        result[contractAddress] = functionNames
+      }
+    }
+
+    return result
+  } catch (error) {
+    console.error('Error reading discovered.json for ABI extraction:', error)
+    return {}
+  }
+}
+
+// ============================================================================
+// Main Analysis
+// ============================================================================
+
 /**
  * Compute per-function impact and dependency analysis for a project.
+ *
+ * Iterates over ALL write functions from discovered.json ABIs (same set shown
+ * in the UI's permissions section). functions.json provides metadata overlay
+ * (isPermissioned, manual dependencies, scores, etc.).
  *
  * - Impact (permissioned functions only): reachable contracts with funds
  * - Dependencies (all functions): auto-detected external + manual
@@ -44,28 +147,45 @@ export function computeFunctionAnalysis(
 
   const contracts: Record<string, Record<string, FunctionAnalysis>> = {}
 
-  if (!functionsData.contracts) {
-    return {
-      version: '1.0',
-      lastModified: new Date().toISOString(),
-      contracts: {},
-    }
-  }
+  // Build the canonical set of write functions from ABIs
+  const discoveredPath = path.join(paths.discovery, projectName, 'discovered.json')
+  const writeFunctionsByContract = buildWriteFunctionsFromAbis(discoveredPath)
 
-  for (const [contractAddress, contractData] of Object.entries(
-    functionsData.contracts,
+  // Build a normalized lookup for functions.json metadata
+  const functionsMetadata = buildFunctionsMetadataLookup(functionsData)
+
+  // Iterate over all write functions from ABIs
+  for (const [contractAddress, functionNames] of Object.entries(
+    writeFunctionsByContract,
   )) {
-    for (const func of contractData.functions) {
+    for (const functionName of functionNames) {
+      // Look up metadata from functions.json (if any)
+      const metadata = lookupFunctionMetadata(
+        functionsMetadata,
+        contractAddress,
+        functionName,
+      )
+
       // Run call graph traversal with path tracking
       const traversalResult = traverseWithPaths(
         callGraphData,
         contractAddress,
-        func.functionName,
+        functionName,
       )
 
-      // --- Impact (permissioned functions only) ---
+      // --- Dependencies (all functions) ---
+      const dependencies = computeDependencies(
+        metadata?.dependencies,
+        contractAddress,
+        traversalResult,
+        externalAddresses,
+        tagsByAddress,
+        callGraphData,
+      )
+
+      // --- Impact (permissioned functions OR functions with dependencies) ---
       let impact: FunctionAnalysis['impact'] = null
-      if (func.isPermissioned) {
+      if (metadata?.isPermissioned || dependencies.entries.length > 0) {
         impact = computeImpact(
           contractAddress,
           traversalResult,
@@ -74,22 +194,12 @@ export function computeFunctionAnalysis(
         )
       }
 
-      // --- Dependencies (all functions) ---
-      const dependencies = computeDependencies(
-        func.dependencies,
-        contractAddress,
-        traversalResult,
-        externalAddresses,
-        tagsByAddress,
-        callGraphData,
-      )
-
       // Only include functions that have impact data or dependencies
       if (impact !== null || dependencies.entries.length > 0) {
         if (!contracts[contractAddress]) {
           contracts[contractAddress] = {}
         }
-        contracts[contractAddress][func.functionName] = {
+        contracts[contractAddress][functionName] = {
           impact,
           dependencies,
         }
@@ -102,6 +212,49 @@ export function computeFunctionAnalysis(
     lastModified: new Date().toISOString(),
     contracts,
   }
+}
+
+// ============================================================================
+// Functions.json Metadata Lookup
+// ============================================================================
+
+type FunctionsMetadataMap = Map<string, Map<string, FunctionEntry>>
+
+/**
+ * Build a normalized lookup: contractAddress -> functionName -> FunctionEntry
+ */
+function buildFunctionsMetadataLookup(
+  functionsData: ApiFunctionsResponse,
+): FunctionsMetadataMap {
+  const lookup: FunctionsMetadataMap = new Map()
+  if (!functionsData.contracts) return lookup
+
+  for (const [contractAddress, contractData] of Object.entries(
+    functionsData.contracts,
+  )) {
+    const normalized = normalizeChainAddress(contractAddress)
+    let funcMap = lookup.get(normalized)
+    if (!funcMap) {
+      funcMap = new Map()
+      lookup.set(normalized, funcMap)
+    }
+    for (const func of contractData.functions) {
+      funcMap.set(func.functionName, func)
+    }
+  }
+  return lookup
+}
+
+/**
+ * Look up function metadata from functions.json by contract address and function name.
+ */
+function lookupFunctionMetadata(
+  metadata: FunctionsMetadataMap,
+  contractAddress: string,
+  functionName: string,
+): FunctionEntry | undefined {
+  const normalized = normalizeChainAddress(contractAddress)
+  return metadata.get(normalized)?.get(functionName)
 }
 
 // ============================================================================

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/functionAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/functionAnalysis.ts
@@ -16,9 +16,11 @@ import { getFunctions } from './functions'
 import { getFundsData } from './fundsData'
 import type {
   ApiCallGraphResponse,
+  ApiContractTagsResponse,
   ApiFunctionAnalysisResponse,
   ApiFunctionsResponse,
   ApiFundsDataResponse,
+  ContractFundsData,
   ContractTag,
   FunctionAnalysis,
   FunctionDependencyEntry,
@@ -94,7 +96,9 @@ function buildWriteFunctionsFromAbis(
       if (typeof implValue === 'string') {
         abiAddresses.push(implValue)
       } else if (Array.isArray(implValue)) {
-        abiAddresses.push(...implValue.filter((v: any) => typeof v === 'string'))
+        abiAddresses.push(
+          ...implValue.filter((v: any) => typeof v === 'string'),
+        )
       }
 
       // Extract write functions from each ABI
@@ -123,36 +127,58 @@ function buildWriteFunctionsFromAbis(
 // ============================================================================
 
 /**
+ * Pre-loaded data that can be passed to avoid redundant file I/O.
+ * When provided, `computeFunctionAnalysis` skips loading these from disk.
+ */
+export interface FunctionAnalysisPreloadedData {
+  functionsData?: ApiFunctionsResponse
+  callGraphData?: ApiCallGraphResponse
+  fundsData?: ApiFundsDataResponse
+  contractTagsData?: ApiContractTagsResponse
+}
+
+/**
  * Compute per-function impact and dependency analysis for a project.
  *
  * Iterates over ALL write functions from discovered.json ABIs (same set shown
  * in the UI's permissions section). functions.json provides metadata overlay
  * (isPermissioned, manual dependencies, scores, etc.).
  *
- * - Impact (permissioned functions only): reachable contracts with funds
+ * - Impact (permissioned functions or functions with dependencies): reachable contracts with funds
  * - Dependencies (all functions): auto-detected external + manual
  */
 export function computeFunctionAnalysis(
   paths: DiscoveryPaths,
   projectName: string,
+  preloaded?: FunctionAnalysisPreloadedData,
 ): ApiFunctionAnalysisResponse {
-  const functionsData = getFunctions(paths, projectName)
-  const callGraphData = getCallGraphData(paths, projectName)
-  const fundsData = getFundsData(paths, projectName)
-  const contractTagsData = getContractTags(paths, projectName)
+  const functionsData =
+    preloaded?.functionsData ?? getFunctions(paths, projectName)
+  const callGraphData =
+    preloaded?.callGraphData ?? getCallGraphData(paths, projectName)
+  const fundsData = preloaded?.fundsData ?? getFundsData(paths, projectName)
+  const contractTagsData =
+    preloaded?.contractTagsData ?? getContractTags(paths, projectName)
 
   // Build lookup maps
   const externalAddresses = buildExternalAddressSet(contractTagsData.tags)
   const tagsByAddress = buildTagsByAddress(contractTagsData.tags)
 
-  const contracts: Record<string, Record<string, FunctionAnalysis>> = {}
-
-  // Build the canonical set of write functions from ABIs
-  const discoveredPath = path.join(paths.discovery, projectName, 'discovered.json')
-  const writeFunctionsByContract = buildWriteFunctionsFromAbis(discoveredPath)
+  // Build normalized funds lookup for O(1) access
+  const fundsLookup = buildFundsLookup(fundsData)
 
   // Build a normalized lookup for functions.json metadata
   const functionsMetadata = buildFunctionsMetadataLookup(functionsData)
+
+  const contracts: Record<string, Record<string, FunctionAnalysis>> = {}
+
+  // Build the canonical set of write functions from ABIs
+  const discoveredPath = path.join(
+    paths.discovery,
+    projectName,
+    'discovered.json',
+  )
+  const writeFunctionsByContract = buildWriteFunctionsFromAbis(discoveredPath)
 
   // Iterate over all write functions from ABIs
   for (const [contractAddress, functionNames] of Object.entries(
@@ -189,8 +215,8 @@ export function computeFunctionAnalysis(
         impact = computeImpact(
           contractAddress,
           traversalResult,
-          fundsData,
-          functionsData,
+          fundsLookup,
+          functionsMetadata,
         )
       }
 
@@ -261,11 +287,13 @@ function lookupFunctionMetadata(
 // Impact Computation
 // ============================================================================
 
+type FundsLookup = Map<string, ContractFundsData>
+
 function computeImpact(
   startContractAddress: string,
   traversalResult: ReturnType<typeof traverseWithPaths>,
-  fundsData: ApiFundsDataResponse,
-  functionsData: ApiFunctionsResponse,
+  fundsLookup: FundsLookup,
+  functionsMetadata: FunctionsMetadataMap,
 ): FunctionAnalysis['impact'] {
   const reachableContracts: FunctionImpactEntry[] = []
 
@@ -273,16 +301,17 @@ function computeImpact(
     // Skip self-reference
     if (addressesEqual(addr, startContractAddress)) continue
 
-    const fundsUsd = getContractFunds(fundsData, addr)
-    const tokenValueUsd = getContractTokenValue(fundsData, addr)
+    const fundsUsd = getFundsFromLookup(fundsLookup, addr)
+    const tokenValueUsd = getTokenValueFromLookup(fundsLookup, addr)
 
     // Only include contracts with funds or token value
     if (fundsUsd <= 0 && tokenValueUsd <= 0) continue
 
     const calledFunctions = Array.from(data.calledFunctions)
-    const permissionedFunctions = calledFunctions.filter((fn) =>
-      isFunctionPermissioned(functionsData, addr, fn),
-    )
+    const permissionedFunctions = calledFunctions.filter((fn) => {
+      const meta = lookupFunctionMetadata(functionsMetadata, addr, fn)
+      return meta?.isPermissioned === true
+    })
 
     reachableContracts.push({
       contractAddress: addr,
@@ -297,9 +326,9 @@ function computeImpact(
   }
 
   // Also check direct contract funds
-  const directFunds = getContractFunds(fundsData, startContractAddress)
-  const directTokenValue = getContractTokenValue(
-    fundsData,
+  const directFunds = getFundsFromLookup(fundsLookup, startContractAddress)
+  const directTokenValue = getTokenValueFromLookup(
+    fundsLookup,
     startContractAddress,
   )
 
@@ -395,51 +424,33 @@ function computeDependencies(
 }
 
 // ============================================================================
-// Helpers (specific to function analysis)
+// Funds Lookup Helpers (O(1) access via pre-built normalized map)
 // ============================================================================
 
-function getContractFunds(
-  fundsData: ApiFundsDataResponse,
+function buildFundsLookup(fundsData: ApiFundsDataResponse): FundsLookup {
+  const lookup: FundsLookup = new Map()
+  for (const [addr, data] of Object.entries(fundsData.contracts ?? {})) {
+    lookup.set(normalizeChainAddress(addr), data)
+  }
+  return lookup
+}
+
+function getFundsFromLookup(
+  fundsLookup: FundsLookup,
   contractAddress: string,
 ): number {
-  if (!fundsData?.contracts) return 0
-  const normalizedAddress = normalizeChainAddress(contractAddress)
-  const fundsEntry = Object.entries(fundsData.contracts).find(
-    ([key]) => normalizeChainAddress(key) === normalizedAddress,
-  )
-  if (!fundsEntry) return 0
-  const funds = fundsEntry[1]
+  const data = fundsLookup.get(normalizeChainAddress(contractAddress))
+  if (!data) return 0
   return (
-    (funds.balances?.totalUsdValue ?? 0) + (funds.positions?.totalUsdValue ?? 0)
+    (data.balances?.totalUsdValue ?? 0) + (data.positions?.totalUsdValue ?? 0)
   )
 }
 
-function getContractTokenValue(
-  fundsData: ApiFundsDataResponse,
+function getTokenValueFromLookup(
+  fundsLookup: FundsLookup,
   contractAddress: string,
 ): number {
-  if (!fundsData?.contracts) return 0
-  const normalizedAddress = normalizeChainAddress(contractAddress)
-  const fundsEntry = Object.entries(fundsData.contracts).find(
-    ([key]) => normalizeChainAddress(key) === normalizedAddress,
-  )
-  if (!fundsEntry) return 0
-  return fundsEntry[1].tokenInfo?.tokenValue ?? 0
-}
-
-function isFunctionPermissioned(
-  functionsData: ApiFunctionsResponse,
-  contractAddress: string,
-  functionName: string,
-): boolean {
-  if (!functionsData.contracts) return false
-  const normalizedAddress = normalizeChainAddress(contractAddress)
-  const contractEntry = Object.entries(functionsData.contracts).find(
-    ([key]) => normalizeChainAddress(key) === normalizedAddress,
-  )
-  if (!contractEntry) return false
-  const func = contractEntry[1].functions.find(
-    (f) => f.functionName === functionName,
-  )
-  return func?.isPermissioned === true
+  const data = fundsLookup.get(normalizeChainAddress(contractAddress))
+  if (!data) return 0
+  return data.tokenInfo?.tokenValue ?? 0
 }

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -101,6 +101,18 @@ export interface CompiledReachableContract {
   fundsAtRisk: boolean
 }
 
+export interface CompiledDependencyFunction {
+  contractAddress: string
+  contractName: string
+  functionName: string
+  viewOnlyPath: boolean
+  /** Funds on the function's own contract */
+  directFundsUsd: number
+  directTokenValueUsd: number
+  /** Contracts reachable via call graph from this function that hold funds */
+  reachableContracts: CompiledReachableContract[]
+}
+
 export interface CompiledDependency {
   address: string
   name: string
@@ -109,12 +121,11 @@ export interface CompiledDependency {
   isAutoDetected: boolean
   viewOnlyPath: boolean
   calledFunctions: string[]
-  functions: {
-    contractAddress: string
-    contractName: string
-    functionName: string
-    viewOnlyPath: boolean
-  }[]
+  functions: CompiledDependencyFunction[]
+  /** Aggregated funds at risk across all functions that use this dependency (deduplicated by contract) */
+  totalFundsAtRisk: number
+  /** Aggregated token value at risk across all functions that use this dependency (deduplicated by contract) */
+  totalTokenValueAtRisk: number
 }
 
 export interface CompiledFundHolder {
@@ -463,16 +474,11 @@ export class ReviewCompiler {
       }
     }
 
-    // Build contract name lookup from v2Score admin functions
+    // Build contract name lookup from discovery entries (covers all contracts)
     const contractNameMap = new Map<string, string>()
-    if (v2Score.inventory.admins.breakdown) {
-      for (const admin of v2Score.inventory.admins.breakdown) {
-        for (const fn of admin.functions) {
-          contractNameMap.set(
-            normalizeChainAddress(fn.contractAddress),
-            fn.contractName,
-          )
-        }
+    for (const entry of discoveryEntries) {
+      if (entry.name) {
+        contractNameMap.set(normalizeChainAddress(entry.address), entry.name)
       }
     }
 
@@ -485,12 +491,7 @@ export class ReviewCompiler {
         entity: string | undefined
         isAutoDetected: boolean
         calledFunctions: Set<string>
-        functions: {
-          contractAddress: string
-          contractName: string
-          functionName: string
-          viewOnlyPath: boolean
-        }[]
+        functions: CompiledDependencyFunction[]
       }
     >()
 
@@ -524,6 +525,15 @@ export class ReviewCompiler {
               f.functionName === funcName,
           )
           if (!alreadyAdded) {
+            // Build per-function impact data from functionAnalysis
+            const impact = analysis.impact
+            const directFunds = impact
+              ? getContractFundsFromLookup(fundsLookup, contractAddr)
+              : 0
+            const directTokenValue = impact
+              ? getContractTokenValueFromLookup(fundsLookup, contractAddr)
+              : 0
+
             existing.functions.push({
               contractAddress: contractAddr,
               contractName:
@@ -531,6 +541,19 @@ export class ReviewCompiler {
                 'Unknown Contract',
               functionName: funcName,
               viewOnlyPath: dep.viewOnlyPath,
+              directFundsUsd: directFunds,
+              directTokenValueUsd: directTokenValue,
+              reachableContracts: (impact?.reachableContracts ?? []).map(
+                (r) => ({
+                  address: r.contractAddress,
+                  name: r.contractName,
+                  viewOnlyPath: r.viewOnlyPath,
+                  calledFunctions: r.calledFunctions,
+                  fundsUsd: r.fundsUsd,
+                  tokenValueUsd: r.tokenValueUsd,
+                  fundsAtRisk: r.fundsUsd > 0 || r.tokenValueUsd > 0,
+                }),
+              ),
             })
           }
         }
@@ -541,6 +564,42 @@ export class ReviewCompiler {
     const dependencies: CompiledDependency[] = []
     for (const dep of depMap.values()) {
       const desc = getFromAddressRecord(reviewConfig.dependencies, dep.address)
+
+      // Compute aggregated funds at risk (deduplicated by reachable contract)
+      const mergedContracts = new Map<
+        string,
+        { funds: number; tokenValue: number }
+      >()
+      for (const fn of dep.functions) {
+        // Direct funds on the function's contract
+        if (fn.directFundsUsd > 0 || fn.directTokenValueUsd > 0) {
+          const addr = normalizeChainAddress(fn.contractAddress)
+          const existing = mergedContracts.get(addr)
+          mergedContracts.set(addr, {
+            funds: Math.max(existing?.funds ?? 0, fn.directFundsUsd),
+            tokenValue: Math.max(
+              existing?.tokenValue ?? 0,
+              fn.directTokenValueUsd,
+            ),
+          })
+        }
+        // Reachable contracts
+        for (const rc of fn.reachableContracts) {
+          if (rc.fundsUsd <= 0 && rc.tokenValueUsd <= 0) continue
+          const addr = normalizeChainAddress(rc.address)
+          const existing = mergedContracts.get(addr)
+          mergedContracts.set(addr, {
+            funds: Math.max(existing?.funds ?? 0, rc.fundsUsd),
+            tokenValue: Math.max(existing?.tokenValue ?? 0, rc.tokenValueUsd),
+          })
+        }
+      }
+      let totalFundsAtRisk = 0
+      let totalTokenValueAtRisk = 0
+      for (const { funds, tokenValue } of mergedContracts.values()) {
+        totalFundsAtRisk += funds
+        totalTokenValueAtRisk += tokenValue
+      }
 
       dependencies.push({
         address: dep.address,
@@ -553,6 +612,8 @@ export class ReviewCompiler {
           dep.functions.every((f) => f.viewOnlyPath),
         calledFunctions: Array.from(dep.calledFunctions),
         functions: dep.functions,
+        totalFundsAtRisk,
+        totalTokenValueAtRisk,
       })
     }
 
@@ -837,6 +898,28 @@ export class ReviewCompiler {
 
     return typeof value === 'number' ? value : null
   }
+}
+
+// ============================================================================
+// Funds Lookup Helpers
+// ============================================================================
+
+function getContractFundsFromLookup(
+  fundsLookup: Map<string, ContractFundsData>,
+  contractAddress: string,
+): number {
+  const data = fundsLookup.get(normalizeChainAddress(contractAddress))
+  if (!data) return 0
+  return (data.balances?.totalUsdValue ?? 0) + (data.positions?.totalUsdValue ?? 0)
+}
+
+function getContractTokenValueFromLookup(
+  fundsLookup: Map<string, ContractFundsData>,
+  contractAddress: string,
+): number {
+  const data = fundsLookup.get(normalizeChainAddress(contractAddress))
+  if (!data) return 0
+  return data.tokenInfo?.tokenValue ?? 0
 }
 
 // ============================================================================

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/reviewCompiler.ts
@@ -247,11 +247,16 @@ export class ReviewCompiler {
       // 4. Read contract tags
       const contractTags = getContractTags(this.paths, project)
 
-      // 5. Compute function analysis (rich dependency data with viewOnlyPath)
-      const functionAnalysis = computeFunctionAnalysis(this.paths, project)
-
-      // 5b. Read functions data (for mitigations)
+      // 5. Read functions data (for mitigations + passed to function analysis)
       const functionsData = getFunctions(this.paths, project)
+
+      // 6. Compute function analysis (rich dependency data with viewOnlyPath)
+      // Pass pre-loaded data to avoid redundant file I/O
+      const functionAnalysis = computeFunctionAnalysis(this.paths, project, {
+        functionsData,
+        fundsData,
+        contractTagsData: contractTags,
+      })
 
       // 6. Load project data for contract names (applies config name overrides + multisig formatting)
       const projectData = getProject(configReader, templateService, project)
@@ -910,7 +915,9 @@ function getContractFundsFromLookup(
 ): number {
   const data = fundsLookup.get(normalizeChainAddress(contractAddress))
   if (!data) return 0
-  return (data.balances?.totalUsdValue ?? 0) + (data.positions?.totalUsdValue ?? 0)
+  return (
+    (data.balances?.totalUsdValue ?? 0) + (data.positions?.totalUsdValue ?? 0)
+  )
 }
 
 function getContractTokenValueFromLookup(

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
@@ -10,13 +10,7 @@ import {
   stripChainPrefix,
 } from './addressUtils'
 import {
-  buildExternalAddressSet,
-  buildTagsByAddress,
-  findTag,
-  getCallGraphContractName,
   getCallGraphData,
-  isExternalAddress,
-  traverseWithPaths,
 } from './callGraph'
 import { CapitalAnalysisCalculator } from './capitalAnalysis'
 import { getContractTags } from './contractTags'
@@ -26,11 +20,13 @@ import {
   resolveDelayFromDiscovered,
   resolveOwnersFromDiscovered,
 } from './functions'
+import { computeFunctionAnalysis } from './functionAnalysis'
 import { getFundsData } from './fundsData'
 import type {
   AdminDetail,
   AdminDetailWithCapital,
   ApiAddressType,
+  ApiFunctionAnalysisResponse,
   ApiCallGraphResponse,
   DependencyDetail,
   FunctionDetail,
@@ -79,6 +75,7 @@ interface ScoringData {
   paths: DiscoveryPaths
   projectName: string
   callGraphData: ApiCallGraphResponse
+  functionAnalysis: ApiFunctionAnalysisResponse
 }
 
 // ============================================================================
@@ -224,8 +221,7 @@ class FunctionInventoryModule {
 
 /**
  * Dependency Inventory Module
- * Analyzes functions that depend on external contracts using call graph BFS
- * and manual dependencies from functions.json.
+ * Consumes pre-computed function analysis to group dependencies by external contract.
  */
 class DependencyInventoryModule {
   name = 'dependencies'
@@ -246,64 +242,47 @@ class DependencyInventoryModule {
       })
     })
 
-    // Build external address set and tag lookup from contract tags
-    const tags = data.contractTags?.tags ?? []
-    const externalAddresses = buildExternalAddressSet(tags)
-    const tagsByAddress = buildTagsByAddress(tags)
-
-    // Process dependencies: group by external contract
+    // Group dependencies from pre-computed function analysis by external contract
     const dependenciesMap = new Map<string, DependencyDetail>()
 
-    if (data.functions?.contracts) {
-      Object.entries(data.functions.contracts).forEach(
-        ([contractAddress, contractData]: [string, any]) => {
-          contractData.functions.forEach((func: any) => {
-            // Process all functions for dependency detection (not just scored ones)
-            // Dependencies are structural — they exist regardless of score status
+    for (const [contractAddress, functions] of Object.entries(
+      data.functionAnalysis.contracts,
+    )) {
+      for (const [functionName, analysis] of Object.entries(functions)) {
+        if (!analysis.dependencies?.entries) continue
 
-            // Run BFS traversal from this function through the call graph
-            const traversalResult = traverseWithPaths(
-              data.callGraphData,
+        for (const dep of analysis.dependencies.entries) {
+          const normalizedDep = normalizeChainAddress(dep.contractAddress)
+
+          // Get or create dependency entry
+          if (!dependenciesMap.has(normalizedDep)) {
+            dependenciesMap.set(normalizedDep, {
+              dependencyAddress: dep.contractAddress,
+              dependencyName: dep.contractName || 'Unknown Contract',
+              entity: dep.entity,
+              functions: [],
+            })
+          }
+
+          // Add function to dependency (avoid duplicates)
+          const depData = dependenciesMap.get(normalizedDep)!
+          const alreadyAdded = depData.functions.some(
+            (f) =>
+              addressesEqual(f.contractAddress, contractAddress) &&
+              f.functionName === functionName,
+          )
+          if (!alreadyAdded) {
+            depData.functions.push({
               contractAddress,
-              func.functionName,
-            )
-
-            // 1. Auto-detected: external contracts reachable via call graph
-            for (const [addr] of traversalResult.reachableContracts) {
-              if (addressesEqual(addr, contractAddress)) continue
-              if (!isExternalAddress(addr, externalAddresses)) continue
-
-              this.addDependency(
-                dependenciesMap,
-                addr,
-                contractNameMap,
-                tagsByAddress,
-                data.callGraphData,
-                contractAddress,
-                func.functionName,
-              )
-            }
-
-            // 2. Manual dependencies from functions.json
-            if (func.dependencies && func.dependencies.length > 0) {
-              for (const dep of func.dependencies) {
-                const depAddress = dep.contractAddress
-                if (!isExternalAddress(depAddress, externalAddresses)) continue
-
-                this.addDependency(
-                  dependenciesMap,
-                  depAddress,
-                  contractNameMap,
-                  tagsByAddress,
-                  data.callGraphData,
-                  contractAddress,
-                  func.functionName,
-                )
-              }
-            }
-          })
-        },
-      )
+              contractName:
+                contractNameMap.get(normalizeChainAddress(contractAddress)) ||
+                'Unknown Contract',
+              functionName,
+              impact: 'critical' as Impact,
+            })
+          }
+        }
+      }
     }
 
     const breakdown = Array.from(dependenciesMap.values())
@@ -311,50 +290,6 @@ class DependencyInventoryModule {
     return {
       inventory: breakdown.length,
       breakdown,
-    }
-  }
-
-  private addDependency(
-    dependenciesMap: Map<string, DependencyDetail>,
-    depAddress: string,
-    contractNameMap: Map<string, string>,
-    tagsByAddress: Map<string, import('./types').ContractTag>,
-    callGraphData: ApiCallGraphResponse,
-    callerContractAddress: string,
-    callerFunctionName: string,
-  ) {
-    const normalizedDep = normalizeChainAddress(depAddress)
-
-    // Get or create dependency entry
-    if (!dependenciesMap.has(normalizedDep)) {
-      const tag = findTag(tagsByAddress, depAddress)
-      dependenciesMap.set(normalizedDep, {
-        dependencyAddress: depAddress,
-        dependencyName:
-          contractNameMap.get(normalizedDep) ||
-          getCallGraphContractName(callGraphData, depAddress) ||
-          'Unknown Contract',
-        entity: tag?.entity,
-        functions: [],
-      })
-    }
-
-    // Add function to dependency (avoid duplicates)
-    const depData = dependenciesMap.get(normalizedDep)!
-    const alreadyAdded = depData.functions.some(
-      (f) =>
-        f.contractAddress === callerContractAddress &&
-        f.functionName === callerFunctionName,
-    )
-    if (!alreadyAdded) {
-      depData.functions.push({
-        contractAddress: callerContractAddress,
-        contractName:
-          contractNameMap.get(normalizeChainAddress(callerContractAddress)) ||
-          'Unknown Contract',
-        functionName: callerFunctionName,
-        impact: 'critical' as Impact,
-      })
     }
   }
 }
@@ -633,6 +568,7 @@ export class ScoreCalculator {
     const contractTags = getContractTags(this.paths, projectName)
     const functions = getFunctions(this.paths, projectName)
     const callGraphData = getCallGraphData(this.paths, projectName)
+    const functionAnalysis = computeFunctionAnalysis(this.paths, projectName)
 
     const data: ScoringData = {
       projectData,
@@ -642,6 +578,7 @@ export class ScoreCalculator {
       paths: this.paths,
       projectName,
       callGraphData,
+      functionAnalysis,
     }
 
     // Calculate each module score

--- a/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/v2Scoring.ts
@@ -9,9 +9,7 @@ import {
   normalizeChainAddress,
   stripChainPrefix,
 } from './addressUtils'
-import {
-  getCallGraphData,
-} from './callGraph'
+import { getCallGraphData } from './callGraph'
 import { CapitalAnalysisCalculator } from './capitalAnalysis'
 import { getContractTags } from './contractTags'
 import {
@@ -69,7 +67,6 @@ export interface V2ScoreResult {
 
 interface ScoringData {
   projectData: any
-  permissionOverrides: any
   contractTags: any
   functions: any
   paths: DiscoveryPaths
@@ -150,8 +147,8 @@ class FunctionInventoryModule {
     const breakdown: FunctionDetail[] = []
     let functionCount = 0
 
-    if (data.permissionOverrides?.contracts) {
-      Object.entries(data.permissionOverrides.contracts).forEach(
+    if (data.functions?.contracts) {
+      Object.entries(data.functions.contracts).forEach(
         ([contractAddress, contractData]: [string, any]) => {
           contractData.functions?.forEach((func: any) => {
             if (func.isPermissioned === true) {
@@ -564,15 +561,17 @@ export class ScoreCalculator {
       this.templateService,
       projectName,
     )
-    const permissionOverrides = getFunctions(this.paths, projectName)
-    const contractTags = getContractTags(this.paths, projectName)
     const functions = getFunctions(this.paths, projectName)
+    const contractTags = getContractTags(this.paths, projectName)
     const callGraphData = getCallGraphData(this.paths, projectName)
-    const functionAnalysis = computeFunctionAnalysis(this.paths, projectName)
+    const functionAnalysis = computeFunctionAnalysis(this.paths, projectName, {
+      functionsData: functions,
+      callGraphData,
+      contractTagsData: contractTags,
+    })
 
     const data: ScoringData = {
       projectData,
-      permissionOverrides,
       contractTags,
       functions,
       paths: this.paths,


### PR DESCRIPTION
Fixing an issue in order to show the funds impacted by a dependency.

 - Scan the dependencies for all functions, not only functions we have an entry for
 - Scan funds imacted for functions both if they're permissioned OR have a dependency
 - Compile the functions and funds impacted by a dependency for the frontend at the compilation step directly