### PR TITLE
Fix reachable capital: treat unscored functions as potentially impactful

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
+++ b/packages/l2b/src/implementations/discovery-ui/defidisco/capitalAnalysis.ts
@@ -54,9 +54,10 @@ export class CapitalAnalysisCalculator {
   }
 
   /**
-   * Check if a function on a contract has an impact score (not unscored).
-   * Returns true if the function has a real impact score, regardless of permissioned status.
-   * A non-permissioned function with high impact still represents funds at risk when called.
+   * Check if a function on a contract has potential impact on funds.
+   * Returns true unless the function is explicitly marked as 'no-impact' by a researcher.
+   * Unscored functions are treated as potentially impactful (safe default),
+   * matching how direct capital already counts unscored functions.
    */
   private functionHasImpact(
     contractAddress: string,
@@ -78,14 +79,10 @@ export class CapitalAnalysisCalculator {
 
     if (!func) return false
 
-    // Check if it has a real impact score (not unscored or undefined)
-    // Note: We don't check isPermissioned here - a function with high impact
-    // is still risky regardless of whether it's permissioned
-    return (
-      func.score !== undefined &&
-      func.score !== 'unscored' &&
-      func.score !== 'no-impact'
-    )
+    // Only exclude functions explicitly marked as no-impact by a researcher.
+    // Unscored/undefined functions default to "potentially impactful" so that
+    // unreviewed projects surface maximum risk rather than hiding it.
+    return func.score !== 'no-impact'
   }
 
   /**


### PR DESCRIPTION
Unscored functions were excluded from reachable capital calculations (functionHasImpact returned false), while direct capital already counted them. This caused admins like the 4/7 multisig controlling EtherFi's timelock to show $0 reachable capital despite reaching $1.58B+ in upgradeable contracts. Now only explicitly 'no-impact' functions are excluded, matching the safe-default principle.

