### PR TITLE
Polish report & gallery: modal chrome, column trims, gallery restyle

### DIFF
--- a/docs/developers/features/infrastructure.md
+++ b/docs/developers/features/infrastructure.md
@@ -262,6 +262,9 @@ The report view received a full visual redesign:
   - Section label row at top with icon + uppercase label + ShowMore button (top-right, opens a modal with the full explorer tab content)
   - Inner white card: `bg-white border border-border rounded-lg` for detailed content
   - Sidebar stats card: same `bg-bg-card` as outer frame, no border (visually blends in)
+- **ShowMore modals** (`ReportView.tsx` + `Modal.tsx`):
+  - Modal chrome matches the outer-frame branding: `bg-bg-card` background, `rounded-lg border border-border`, uppercase bold `[11px]` label header (same style as `SectionHeader`), round bordered close button (matches `CarouselNav` style)
+  - Tabs render inside with `variant="modal"` — hides heavy visualizations (`FundsTab` stacked bar chart, `DepsTab` `DependencyRiskDiagram`) so the modal shows the table content only. `AdminsTab` / `GovernanceTab` accept the `variant` prop for parity even though they don't currently branch on it
 - **Admins section (`AdminsSection.tsx`)**:
   - "ADMINISTRATIVE CONTROL" label, ShowMore button in outer frame header
   - Inner white card: top 3 admins sorted by `totalReachableCapital` descending

--- a/packages/defiscan-frontend/src/components/Modal.tsx
+++ b/packages/defiscan-frontend/src/components/Modal.tsx
@@ -22,37 +22,52 @@ export function Modal({ title, children, onClose }: ModalProps) {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-text-primary/40 backdrop-blur-sm p-4 sm:p-6"
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      <div className="relative mx-4 flex max-h-[85vh] w-full max-w-[1100px] flex-col rounded-2xl bg-white shadow-2xl">
-        {/* Header */}
-        <div className="flex items-center justify-between border-b border-border px-6 py-4">
-          <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
-          <button
-            onClick={onClose}
-            className="rounded-lg p-1.5 text-text-muted hover:bg-bg-muted hover:text-text-primary transition-colors"
-            aria-label="Close"
-          >
+      <div className="relative flex max-h-[90vh] w-full max-w-[1180px] flex-col rounded-lg border border-border bg-bg-card shadow-2xl">
+        {/* Header — matches SectionHeader branding */}
+        <div className="flex items-center justify-between gap-4 border-b border-border px-5 sm:px-[33px] py-5">
+          <div className="flex items-center gap-2 min-w-0">
             <svg
-              className="h-5 w-5"
-              fill="none"
+              className="size-3.5 text-text-muted shrink-0"
               viewBox="0 0 24 24"
+              fill="none"
               stroke="currentColor"
               strokeWidth={2}
             >
               <path
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                d="M6 18L18 6M6 6l12 12"
+                d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"
               />
+            </svg>
+            <span className="font-bold text-[11px] uppercase text-text-muted tracking-[1.2px] truncate">
+              {title}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="border border-border rounded-full p-[7px] text-text-muted hover:bg-hover hover:text-text-primary transition-colors shrink-0"
+            aria-label="Close"
+          >
+            <svg
+              className="h-[10px] w-[10px]"
+              viewBox="0 0 10 10"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.5}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M1 1l8 8M9 1l-8 8" />
             </svg>
           </button>
         </div>
         {/* Body */}
-        <div className="overflow-y-auto p-6">{children}</div>
+        <div className="overflow-y-auto p-5 sm:p-[33px]">{children}</div>
       </div>
     </div>,
     document.body,

--- a/packages/defiscan-frontend/src/pages/gallery/GalleryPage.tsx
+++ b/packages/defiscan-frontend/src/pages/gallery/GalleryPage.tsx
@@ -165,12 +165,12 @@ function ProtocolCard({
   const radarData = review ? deriveRadarData(review) : null
 
   return (
-    <div className="flex flex-col rounded-lg border border-border bg-white overflow-hidden">
+    <div className="flex flex-col rounded-xl border border-border bg-bg-card overflow-hidden">
       {/* Card header */}
-      <div className="flex items-start justify-between p-5 pb-3">
-        <div className="flex items-center gap-3 min-w-0">
-          <div className="size-9 rounded bg-accent-tint-light flex items-center justify-center shrink-0">
-            <img src="/defiscan-mark-blue.svg" alt="" className="h-5 w-5" />
+      <div className="flex items-start justify-between p-6 pb-3">
+        <div className="flex items-center gap-4 min-w-0">
+          <div className="size-12 rounded bg-white border border-hover flex items-center justify-center shrink-0 shadow-[0_1px_2px_0_rgba(0,0,0,0.05)] p-[9px]">
+            <img src="/defiscan-mark-blue.svg" alt="" className="h-full w-full" />
           </div>
           <div className="min-w-0">
             <h3 className="font-semibold text-sm text-text-primary truncate">
@@ -401,22 +401,27 @@ export function GalleryPage() {
 
   if (indexLoading) {
     return (
-      <div className="mx-auto max-w-[1280px] px-6 py-12">
-        <p className="text-text-muted">Loading protocols...</p>
+      <div className="bg-white min-h-screen">
+        <div className="mx-auto max-w-[1280px] px-6 py-12">
+          <p className="text-text-muted">Loading protocols...</p>
+        </div>
       </div>
     )
   }
 
   if (!indexData) {
     return (
-      <div className="mx-auto max-w-[1280px] px-6 py-12">
-        <p className="text-status-red">Failed to load data.</p>
+      <div className="bg-white min-h-screen">
+        <div className="mx-auto max-w-[1280px] px-6 py-12">
+          <p className="text-status-red">Failed to load data.</p>
+        </div>
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-[1280px] px-4 sm:px-6 py-8 sm:py-10">
+    <div className="bg-white min-h-screen">
+      <div className="mx-auto max-w-[1280px] px-4 sm:px-6 py-8 sm:py-10">
       {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-text-primary tracking-tight">
@@ -548,6 +553,7 @@ export function GalleryPage() {
           </div>
         </div>
       )}
+      </div>
     </div>
   )
 }

--- a/packages/defiscan-frontend/src/pages/review/ReviewPage.tsx
+++ b/packages/defiscan-frontend/src/pages/review/ReviewPage.tsx
@@ -80,35 +80,37 @@ export function ReviewPage() {
 
   return (
     <div className="w-full bg-white">
-      {/* Back nav + View toggle bar */}
-      <div className="mx-auto max-w-[1280px] px-4 sm:px-6 py-4 print:hidden">
-        <div className="flex items-center justify-between gap-3 flex-wrap">
-          <Link
-            to="/gallery"
-            className="inline-flex items-center gap-1.5 text-sm text-text-secondary transition-colors hover:text-accent"
-          >
-            <svg
-              className="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
+      {/* Back nav + View toggle bar (hidden on report view) */}
+      {view !== 'report' && (
+        <div className="mx-auto max-w-[1280px] px-4 sm:px-6 py-4 print:hidden">
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <Link
+              to="/gallery"
+              className="inline-flex items-center gap-1.5 text-sm text-text-secondary transition-colors hover:text-accent"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M15 19l-7-7 7-7"
-              />
-            </svg>
-            Back to gallery
-          </Link>
-          <div className="print:hidden">
-            <ViewModeToggle current={view} onChange={handleViewChange}>
-              <ShareButton review={review} onExportPdf={handleExportPdf} />
-            </ViewModeToggle>
+              <svg
+                className="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M15 19l-7-7 7-7"
+                />
+              </svg>
+              Back to gallery
+            </Link>
+            <div className="print:hidden">
+              <ViewModeToggle current={view} onChange={handleViewChange}>
+                <ShareButton review={review} onExportPdf={handleExportPdf} />
+              </ViewModeToggle>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {/* View content */}
       <Suspense

--- a/packages/defiscan-frontend/src/pages/review/views/explorer/AdminsTab.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/explorer/AdminsTab.tsx
@@ -13,14 +13,10 @@ import {
 
 interface AdminsTabProps {
   review: CompiledReview
+  variant?: 'page' | 'modal'
 }
 
-type SortField =
-  | 'name'
-  | 'type'
-  | 'reachableCapital'
-  | 'tokenValue'
-  | 'functions'
+type SortField = 'name' | 'type' | 'tvs' | 'functions'
 type SortDir = 'asc' | 'desc'
 
 export function AdminsTab({ review }: AdminsTabProps) {
@@ -29,7 +25,7 @@ export function AdminsTab({ review }: AdminsTabProps) {
     () => getHumanAdmins(admins).filter((a) => !a.isGovernance),
     [admins],
   )
-  const [sortField, setSortField] = useState<SortField>('reachableCapital')
+  const [sortField, setSortField] = useState<SortField>('tvs')
   const [sortDir, setSortDir] = useState<SortDir>('desc')
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
@@ -44,11 +40,11 @@ export function AdminsTab({ review }: AdminsTabProps) {
         case 'type':
           cmp = a.adminType.localeCompare(b.adminType)
           break
-        case 'reachableCapital':
-          cmp = a.totalReachableCapital - b.totalReachableCapital
-          break
-        case 'tokenValue':
-          cmp = a.totalReachableTokenValue - b.totalReachableTokenValue
+        case 'tvs':
+          cmp =
+            a.totalReachableCapital +
+            a.totalReachableTokenValue -
+            (b.totalReachableCapital + b.totalReachableTokenValue)
           break
         case 'functions':
           cmp = a.functions.length - b.functions.length
@@ -99,23 +95,13 @@ export function AdminsTab({ review }: AdminsTabProps) {
       <div className="flex items-center gap-6 mb-4 text-sm">
         <AdminsSummaryLabel admins={humanAdmins} />
         <span className="text-text-secondary">
-          TVL:{' '}
+          TVS:{' '}
           <UsdValue
-            value={totals.totalCapitalAtRisk}
+            value={totals.totalCapitalAtRisk + totals.totalTokenValueAtRisk}
             variant="capital"
             className="text-sm"
           />
         </span>
-        {totals.totalTokenValueAtRisk > 0 && (
-          <span className="text-text-secondary">
-            Market Cap:{' '}
-            <UsdValue
-              value={totals.totalTokenValueAtRisk}
-              variant="token"
-              className="text-sm"
-            />
-          </span>
-        )}
       </div>
 
       {/* Sortable table */}
@@ -138,16 +124,8 @@ export function AdminsTab({ review }: AdminsTabProps) {
                 onClick={handleSort}
               />
               <SortHeader
-                field="reachableCapital"
-                label="TVL"
-                current={sortField}
-                dir={sortDir}
-                onClick={handleSort}
-                className="text-right"
-              />
-              <SortHeader
-                field="tokenValue"
-                label="Market Cap"
+                field="tvs"
+                label="TVS"
                 current={sortField}
                 dir={sortDir}
                 onClick={handleSort}
@@ -229,21 +207,12 @@ function AdminRow({
           </Badge>
         </td>
         <td className="px-4 py-2.5 text-right tabular-nums">
-          {admin.totalReachableCapital > 0 ? (
+          {admin.totalReachableCapital + admin.totalReachableTokenValue > 0 ? (
             <UsdValue
-              value={admin.totalReachableCapital}
+              value={
+                admin.totalReachableCapital + admin.totalReachableTokenValue
+              }
               variant="capital"
-              className="text-sm"
-            />
-          ) : (
-            <span className="text-text-muted">-</span>
-          )}
-        </td>
-        <td className="px-4 py-2.5 text-right tabular-nums">
-          {admin.totalReachableTokenValue > 0 ? (
-            <UsdValue
-              value={admin.totalReachableTokenValue}
-              variant="token"
               className="text-sm"
             />
           ) : (
@@ -259,7 +228,7 @@ function AdminRow({
       </tr>
       {isExpanded && (
         <tr>
-          <td colSpan={6} className="px-0 py-0">
+          <td colSpan={5} className="px-0 py-0">
             <ExpandedAdminFunctions admin={admin} />
           </td>
         </tr>

--- a/packages/defiscan-frontend/src/pages/review/views/explorer/DepsTab.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/explorer/DepsTab.tsx
@@ -12,12 +12,14 @@ import { SortHeader, MitigationsSummary } from './shared'
 
 interface DepsTabProps {
   review: CompiledReview
+  variant?: 'page' | 'modal'
 }
 
 type SortField = 'name' | 'entity' | 'fundsAtRisk' | 'functions'
 type SortDir = 'asc' | 'desc'
 
-export function DepsTab({ review }: DepsTabProps) {
+export function DepsTab({ review, variant = 'page' }: DepsTabProps) {
+  const isModal = variant === 'modal'
   const { dependencies } = review
   const [sortField, setSortField] = useState<SortField>('fundsAtRisk')
   const [sortDir, setSortDir] = useState<SortDir>('desc')
@@ -110,7 +112,7 @@ export function DepsTab({ review }: DepsTabProps) {
         )}
         {totalFundsAtRisk > 0 && (
           <span className="text-text-secondary">
-            TVL{' '}
+            TVS{' '}
             <UsdValue
               value={totalFundsAtRisk}
               variant="capital"
@@ -127,15 +129,17 @@ export function DepsTab({ review }: DepsTabProps) {
       </div>
 
       {/* Dependency risk diagram */}
-      <ShareableDiagram
-        id="dependency-diagram"
-        title="Dependency Entity Concentration"
-        linkQuery="?view=explorer&tab=dependencies"
-        downloadName="dependency-concentration.png"
-        className="mb-4"
-      >
-        <DependencyRiskDiagram dependencies={dependencies} />
-      </ShareableDiagram>
+      {!isModal && (
+        <ShareableDiagram
+          id="dependency-diagram"
+          title="Dependency Entity Concentration"
+          linkQuery="?view=explorer&tab=dependencies"
+          downloadName="dependency-concentration.png"
+          className="mb-4"
+        >
+          <DependencyRiskDiagram dependencies={dependencies} />
+        </ShareableDiagram>
+      )}
 
       {/* Table */}
       <div className="rounded-lg border border-border bg-white shadow-sm overflow-hidden">
@@ -151,14 +155,11 @@ export function DepsTab({ review }: DepsTabProps) {
               />
               <SortHeader
                 field="entity"
-                label="Entity"
+                label="Vendor"
                 current={sortField}
                 dir={sortDir}
                 onClick={handleSort}
               />
-              <th className="px-4 py-2 font-medium text-text-secondary text-left">
-                Access
-              </th>
               <SortHeader
                 field="functions"
                 label="Used By"
@@ -172,7 +173,7 @@ export function DepsTab({ review }: DepsTabProps) {
               </th>
               <SortHeader
                 field="fundsAtRisk"
-                label="TVL"
+                label="TVS"
                 current={sortField}
                 dir={sortDir}
                 onClick={handleSort}
@@ -246,11 +247,6 @@ function DependencyRow({
             <span className="text-text-muted">-</span>
           )}
         </td>
-        <td className="px-4 py-2.5">
-          <div className="flex items-center gap-1.5">
-            {dep.viewOnlyPath ? <ReadBadge /> : <WriteBadge />}
-          </div>
-        </td>
         <td className="px-4 py-2.5 text-right">
           <span className="font-medium text-text-primary">
             {dep.functions.length}
@@ -279,7 +275,7 @@ function DependencyRow({
       {expanded && (
         <tr>
           <td
-            colSpan={6}
+            colSpan={5}
             className="px-0 py-0 bg-bg-muted/50 border-b border-border"
           >
             <ExpandedDependency dep={dep} />
@@ -365,7 +361,7 @@ function FunctionList({
           <th className="text-left pb-1 font-medium">Contract</th>
           <th className="text-left pb-1 font-medium">Function</th>
           <th className="text-left pb-1 font-medium">Mitigations</th>
-          <th className="text-right pb-1 font-medium">TVL</th>
+          <th className="text-right pb-1 font-medium">TVS</th>
         </tr>
       </thead>
       <tbody>

--- a/packages/defiscan-frontend/src/pages/review/views/explorer/FundsTab.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/explorer/FundsTab.tsx
@@ -15,12 +15,14 @@ import type { CompiledReview, CompiledFundHolder } from '../../../../types'
 
 interface FundsTabProps {
   review: CompiledReview
+  variant?: 'page' | 'modal'
 }
 
 type SortField = 'name' | 'total'
 type SortDir = 'asc' | 'desc'
 
-export function FundsTab({ review }: FundsTabProps) {
+export function FundsTab({ review, variant = 'page' }: FundsTabProps) {
+  const isModal = variant === 'modal'
   const { funds } = review
   const [sortField, setSortField] = useState<SortField>('total')
   const [sortDir, setSortDir] = useState<SortDir>('desc')
@@ -98,27 +100,17 @@ export function FundsTab({ review }: FundsTabProps) {
       <div className="flex items-center gap-6 mb-4 text-sm flex-wrap">
         <FundsSummaryLabel funds={funds} />
         <span className="text-text-secondary">
-          TVL:{' '}
+          TVS:{' '}
           <UsdValue
-            value={totalCapital}
+            value={totalCapital + totalTokenValue}
             variant="capital"
             className="text-sm"
           />
         </span>
-        {totalTokenValue > 0 && (
-          <span className="text-text-secondary">
-            Token:{' '}
-            <UsdValue
-              value={totalTokenValue}
-              variant="token"
-              className="text-sm"
-            />
-          </span>
-        )}
       </div>
 
       {/* Stacked bar chart */}
-      {chartData.length > 0 && (
+      {!isModal && chartData.length > 0 && (
         <div className="rounded-lg border border-border bg-white p-4 mb-4">
           <h3 className="text-sm font-semibold text-text-primary mb-3">
             TVS Distribution

--- a/packages/defiscan-frontend/src/pages/review/views/explorer/GovernanceTab.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/explorer/GovernanceTab.tsx
@@ -10,6 +10,7 @@ import {
 
 interface GovernanceTabProps {
   review: CompiledReview
+  variant?: 'page' | 'modal'
 }
 
 type SortField = 'name' | 'reachableCapital' | 'tokenValue' | 'functions'

--- a/packages/defiscan-frontend/src/pages/review/views/explorer/shared.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/explorer/shared.tsx
@@ -213,8 +213,7 @@ export function AdminFunctionTable({
           <th className="text-left pb-1 font-medium">Contract</th>
           <th className="text-left pb-1 font-medium">Function</th>
           <th className="text-left pb-1 font-medium">Mitigations</th>
-          <th className="text-right pb-1 font-medium">TVL</th>
-          <th className="text-right pb-1 font-medium">Reachable Contracts</th>
+          <th className="text-right pb-1 font-medium">TVS</th>
         </tr>
       </thead>
       <tbody>
@@ -249,26 +248,6 @@ export function AdminFunctionTable({
               {fn.directFundsUsd > 0 ? (
                 <span className="text-capital font-medium">
                   {formatUsdValue(fn.directFundsUsd)}
-                </span>
-              ) : (
-                <span className="text-text-muted">-</span>
-              )}
-            </td>
-            <td className="py-1.5 text-right">
-              {fn.reachableContracts.length > 0 ? (
-                <span className="text-text-primary">
-                  {fn.reachableContracts.length}
-                  {fn.reachableContracts.some((rc) => rc.fundsAtRisk) && (
-                    <span className="ml-1 text-capital">
-                      (
-                      {formatUsdValue(
-                        fn.reachableContracts
-                          .filter((rc) => rc.fundsAtRisk)
-                          .reduce((s, rc) => s + rc.fundsUsd, 0),
-                      )}
-                      )
-                    </span>
-                  )}
                 </span>
               ) : (
                 <span className="text-text-muted">-</span>

--- a/packages/defiscan-frontend/src/pages/review/views/report/ReportView.tsx
+++ b/packages/defiscan-frontend/src/pages/review/views/report/ReportView.tsx
@@ -40,7 +40,7 @@ export function ReportView({ review, onExportPdf }: ReportViewProps) {
   }
 
   return (
-    <div className="flex flex-col gap-10 sm:gap-16 md:gap-[80px] pb-12 md:pb-24">
+    <div className="flex flex-col gap-10 sm:gap-16 md:gap-[80px] pt-8 sm:pt-12 md:pt-16 pb-12 md:pb-24">
       {/* Hero */}
       <section className="w-full">
         <div className="mx-auto w-full max-w-[1280px] px-4 sm:px-6">
@@ -94,10 +94,10 @@ export function ReportView({ review, onExportPdf }: ReportViewProps) {
           title={MODAL_TITLES[activeModal]}
           onClose={() => setActiveModal(null)}
         >
-          {activeModal === 'funds' && <FundsTab review={review} />}
-          {activeModal === 'admins' && <AdminsTab review={review} />}
-          {activeModal === 'governance' && <GovernanceTab review={review} />}
-          {activeModal === 'dependencies' && <DepsTab review={review} />}
+          {activeModal === 'funds' && <FundsTab review={review} variant="modal" />}
+          {activeModal === 'admins' && <AdminsTab review={review} variant="modal" />}
+          {activeModal === 'governance' && <GovernanceTab review={review} variant="modal" />}
+          {activeModal === 'dependencies' && <DepsTab review={review} variant="modal" />}
         </Modal>
       )}
     </div>


### PR DESCRIPTION
- Redesign ShowMore modal chrome to match Figma branding; hide heavy visualizations in modal variant of explorer tabs.
- Admins popup: collapse TVL + Market Cap into a single TVS column.
- Expanded admin/function table: drop Reachable Contracts column, rename TVL -> TVS.
- TVS popup: drop separate Token stat, show unified TVS.
- Dependencies popup: rename Entity -> Vendor, remove Access column, rename TVL -> TVS.
- Hide top nav/menu bar on report view; add top padding so the report hero breathes below the site header.
- Gallery: white page background and slate-50 cards matching Figma, 48x48 white logo frame with border + shadow.